### PR TITLE
Add --download_only flag to pipeline and check if files are already downloaded

### DIFF
--- a/probedesign.py
+++ b/probedesign.py
@@ -7,6 +7,7 @@ import time
 import argparse
 import logging
 from datetime import datetime
+from pathlib import Path
 
 timestamp = datetime.now()
 logging.basicConfig(filename='log_probe_design_{}-{}-{}-{}-{}.txt'.format(timestamp.year, timestamp.month, timestamp.day, timestamp.hour, timestamp.minute), level=logging.NOTSET)
@@ -29,9 +30,11 @@ def args():
     args_parser = argparse.ArgumentParser(description=__doc__,formatter_class=argparse.RawDescriptionHelpFormatter)
     args_parser.add_argument('-c','--config',help='path to config yaml file',type=str,required=True)
     args_parser.add_argument('-o','--output',help='path of output folder',type=str,required=True)
+    args_parser.add_argument('-d','--download_only',help='dry run that only downloads the necessary files',
+                             action='store_true', required=False)
     return args_parser.parse_args()
 
-def probe_pipeline(config, dir_output):
+def probe_pipeline(config, dir_output, download_only=False):
     '''Pipeline of probe designer. Sets up all required directories; loads annotations, genes and probes; 
     and filters probes based on sequence properties and blast aligment search results.
 
@@ -39,14 +42,20 @@ def probe_pipeline(config, dir_output):
     :type config: dict
     :param dir_output: User-defined output directory.
     :type dir_output: string
+    :param download_only: Whether to interupt the pipeline after download of the necessary files.
+    :type download_only: bool
     '''
     dir_output = os.path.join(dir_output, "")
+    Path(dir_output).mkdir(parents=True, exist_ok=True)
     logging.info('Results will be saved to: {}'.format(dir_output))
 
     datamodule = DataModule(config, logging, dir_output)
     
     t = time.time()
     datamodule.load_annotations()
+    if download_only:
+        logging.info("Download finished. Pipeline interrupted. Set download_only to False to run the full pipeline.")
+        return
     datamodule.load_genes()
     datamodule.load_transcriptome()
     datamodule.load_probes()
@@ -94,13 +103,14 @@ if __name__ == '__main__':
 
     dir_output = parameters.output
     config = get_config(parameters.config)
+    download_only = parameters.download_only
     print_config(config, logging)
 
     logging.info('#########Start Pipeline#########')
     print('#########Start Pipeline#########')
 
     t_pipeline = time.time()
-    probe_pipeline(config, dir_output)
+    probe_pipeline(config, dir_output, download_only=download_only)
     t_pipeline = (time.time() - t_pipeline)/60
 
     logging.info('Time Pipeline: {} min'.format(t_pipeline))

--- a/src/datamodule.py
+++ b/src/datamodule.py
@@ -208,20 +208,39 @@ class DataModule:
             
             os.replace(file_tmp, file_genome_fasta)            
         
-        if self.source == 'ncbi':
-            # if source ncbi we need a chromosome mapping
-            mapping = _download_chr_mapping()
-        elif self.source == 'ensemble':
-            # if source ensemble we don't need a chromosome mapping
-            mapping = None
-
+        # Check if files are already present
         if self.file_gene_gtf is None:
-            self.file_gene_gtf = _download_gene_gtf(mapping)
-            self.logging.info('Downloaded gene annotation from {} and save as gene gtf: {}'.format(self.source, self.file_gene_gtf))
-            
+            file = os.path.join(self.dir_output_annotations,self.ftp_gene["file_name"])
+            if os.path.exists(file):
+                self.file_gene_gtf = file
+                self.logging.info('Found gene annotation from {} as gene gtf at: {}'.format(self.source, self.file_gene_gtf))
         if self.file_genome_fasta is None:
-            self.file_genome_fasta = _download_genome_fasta(mapping)
-            self.logging.info('Downloaded genome annotation from {} and save as genome fasta: {}'.format(self.source, self.file_genome_fasta))
+            file = os.path.join(self.dir_output_annotations,self.ftp_genome["file_name"])
+            if os.path.exists(file):
+                self.file_genome_fasta = file
+                self.logging.info('Found genome annotation from {} as genome fasta at: {}'.format(self.source, self.file_genome_fasta))
+        
+        # Download if files are not present
+        if (self.file_gene_gtf is None) or (self.file_genome_fasta is None):
+            if self.source == 'ncbi':
+                # if source ncbi we need a chromosome mapping
+                self.logging.info('Download chromosome mapping')
+                mapping = _download_chr_mapping()
+                self.logging.info('\tDone')
+            elif self.source == 'ensemble':
+                # if source ensemble we don't need a chromosome mapping
+                mapping = None
+    
+            if self.file_gene_gtf is None:
+                self.logging.info('Download gtf file')
+                self.file_gene_gtf = _download_gene_gtf(mapping)
+                self.logging.info('Downloaded gene annotation from {} and save as gene gtf: {}'.format(self.source, self.file_gene_gtf))
+                
+            if self.file_genome_fasta is None:
+                self.logging.info('Download fasta file')
+                self.file_genome_fasta = _download_genome_fasta(mapping)
+                self.logging.info('Downloaded genome annotation from {} and save as genome fasta: {}'.format(self.source, self.file_genome_fasta))
+
             
         print('Annotations downloaded.')
 


### PR DESCRIPTION
This PR would add two things:

1. A `--download_only` argument for the pipeline. I.e. interrupts pipeline after download. I found this handy when I wrote the cli in the spapros package, not sure if you want to include it
2.  A check the tests if the files it would download are already at the expected location and eventually doesn't download them again; don't know if this download check design fits well to the flag system that you mentioned, and also if it's fitting in the "pipeline philosophy".

Think it's handy, but fine for me if you say it doesn't fit in well.