### PR TITLE
Add overlap matrix calculation to pipeline and generalise overlap to genes with multiple genomic sites

### DIFF
--- a/probedesign.py
+++ b/probedesign.py
@@ -14,6 +14,7 @@ logging.basicConfig(filename='log_probe_design_{}-{}-{}-{}-{}.txt'.format(timest
 from src.utils import get_config, print_config, rm_intermediate_files
 from src.datamodule import DataModule
 from src.probefilter import ProbeFilter
+from src.get_overlap_matrix import get_overlap_matrix
 
 
 ############################################
@@ -80,6 +81,16 @@ def probe_pipeline(config, dir_output):
     print('Time to filter with Blast results: {} min \n'.format(t))
 
     probefilter.log_statistics()
+    
+    t = time.time()
+    get_overlap_matrix(os.path.join(dir_output,"probes"),os.path.join(dir_output,"overlap"))
+    t = (time.time() - t)/60    
+    
+    logging.info('Time to compute overlap matrices: {} min'.format(t))
+    print('Time to compute overlap matrices: {} min \n'.format(t))
+    
+    
+    
 
 
 ############################################


### PR DESCRIPTION
In this PR the overlap matrix calculation
- is generalised to genes with multiple genomic sites (see #1)
- is added to the pipeline

Imo we need to put the overlap matrix into the pipeline, without that one we won't get to the real number of possible probes per gene since the genes in the final set of genes can't overlap. However I haven't adjusted the filter according `config["min_probes_per_gene"]`, that one could be applied after the overlap matrix. I created an issue that we keep it in mind (#3).