### PR TITLE
Db class

### DIFF
--- a/oligo_designer_toolsuite/IO/_database.py
+++ b/oligo_designer_toolsuite/IO/_database.py
@@ -1,25 +1,32 @@
-import pandas as pd
 import os
-import warnings
 import random
 import shutil
+import warnings
 from pathlib import Path
 
-import pyfaidx
+import _data_parser as data_parser
+import _ftp_loader as ftp_loader
 import gtfparse
+import pandas as pd
+import pyfaidx
 from Bio import SeqIO
 
-import _ftp_loader as ftp_loader
-import _data_parser as data_parser
-#import the filters class
 
-
-class BaseDB():
-    '''This class generates all possible guides that can be designed for a given list of genes, 
+class BaseDB:
+    """This class generates all possible guides that can be designed for a given list of genes,
     based on the transcriptome annotation or of those genes and the reference fasta file.
-    '''
-    def __init__(self, probe_length_min, probe_length_max, species = None, genome_assembly = None, annotation_release = None, filters = None):
-        '''Initializes the class.
+    """
+
+    def __init__(
+        self,
+        probe_length_min,
+        probe_length_max,
+        species=None,
+        genome_assembly=None,
+        annotation_release=None,
+        filters=None,
+    ):
+        """Initializes the class.
 
         :param probe_length_min: minimum length of the probes created
         :type probe_length_min: int
@@ -33,8 +40,8 @@ class BaseDB():
         :type annotation_release: str, optional
         :param filters: list of filters classes already initialized, defaults to None
         :type filters: list of classes, optional
-        '''
-       
+        """
+
         self.species = species
         self.genome_assembly = genome_assembly
         self.annotation_release = annotation_release
@@ -42,7 +49,7 @@ class BaseDB():
         self.probe_length_max = probe_length_max
         self.probe_length_min = probe_length_min
 
-        self.annotation = None # dataframe containing the gene annotation
+        self.annotation = None  # dataframe containing the gene annotation
         self.file_reference_DB = None
         self.file_oligos_DB = None
         self.oligos_DB = None
@@ -50,66 +57,66 @@ class BaseDB():
         self.file_sequence = None
 
     def read_reference_DB(self, file_reference_DB):
-        '''Saves the path of a previously generated reference DB in the <self.file_reference_DB> attribute.
+        """Saves the path of a previously generated reference DB in the <self.file_reference_DB> attribute.
 
         :param file_reference_DB: path of the reference_DB file
         :type file_reference_DB: str
-        '''
+        """
         if os.path.exists(file_reference_DB):
             if data_parser.check_fasta_format(file_reference_DB):
                 self.file_reference_DB = file_reference_DB
             else:
-                raise ValueError('Database has incorrect format!')
+                raise ValueError("Database has incorrect format!")
         else:
-            raise ValueError('Database file does not exist!')
+            raise ValueError("Database file does not exist!")
 
     def read_oligos_DB(self, file_oligos_DB):
-        '''Reads a previously generated oligos DB and saves it in the <self.oligos_DB> attribute as a dictionary.
+        """Reads a previously generated oligos DB and saves it in the <self.oligos_DB> attribute as a dictionary.
         The order of columns is : gene_id, probe_sequence, 'transcript_id', 'exon_id', 'chromosome', 'start', 'end', 'strand', all the additional info computed by the filtersing class.
 
         :param file_oligos_DB: path of the oligos_DB file
         :type file_oligos_DB: str
-        '''
+        """
         if os.path.exists(file_oligos_DB):
             if data_parser.check_tsv_format(file_oligos_DB):
                 self.file_oligos_DB = file_oligos_DB
             else:
-                raise ValueError('Database has incorrect format!')
+                raise ValueError("Database has incorrect format!")
         else:
-            raise ValueError('Database file does not exist!')
+            raise ValueError("Database file does not exist!")
         if os.path.exists(file_oligos_DB):
             self.file_oligos_DB = file_oligos_DB
         else:
-            raise ValueError('Database file does not exist!')
-            
+            raise ValueError("Database file does not exist!")
+
         self.oligos_DB = {}
-        handle_probe = open(self.file_oligos_DB, 'r')
+        handle_probe = open(self.file_oligos_DB, "r")
         # read the header
         line = handle_probe.readline()
-        columns = line.split('\t')
-        columns[-1] = columns[-1][0:-1] #delete \n in the last word
+        columns = line.split("\t")
+        columns[-1] = columns[-1][0:-1]  # delete \n in the last word
         add_features = len(columns) > 8
         # read the first line
         line = handle_probe.readline()
-        line = line.split('\t')
-        line[-1] = line[-1][0:-1] #delete \n of the last word
+        line = line.split("\t")
+        line[-1] = line[-1][0:-1]  # delete \n of the last word
         current_gene = line[0]
         sequence = line[1]
         self.oligos_DB[current_gene] = {}
         self.oligos_DB[current_gene][sequence] = {}
-        self.oligos_DB[current_gene][sequence]['transcript_id'] = line[2].split(';')
-        self.oligos_DB[current_gene][sequence]['exon_id'] = line[3].split(';')
-        self.oligos_DB[current_gene][sequence]['chromosome'] = line[4]
-        self.oligos_DB[current_gene][sequence]['start'] = line[5].split(';')
-        self.oligos_DB[current_gene][sequence]['end'] = line[6].split(';')
-        self.oligos_DB[current_gene][sequence]['strand'] = line[7]
-        #retrive the remaining features if they were computed
+        self.oligos_DB[current_gene][sequence]["transcript_id"] = line[2].split(";")
+        self.oligos_DB[current_gene][sequence]["exon_id"] = line[3].split(";")
+        self.oligos_DB[current_gene][sequence]["chromosome"] = line[4]
+        self.oligos_DB[current_gene][sequence]["start"] = line[5].split(";")
+        self.oligos_DB[current_gene][sequence]["end"] = line[6].split(";")
+        self.oligos_DB[current_gene][sequence]["strand"] = line[7]
+        # retrive the remaining features if they were computed
         if add_features:
-                for i, column in enumerate(columns[8:]):
-                    self.oligos_DB[current_gene][sequence][column] = line[i+8]
+            for i, column in enumerate(columns[8:]):
+                self.oligos_DB[current_gene][sequence][column] = line[i + 8]
         # read the rest of the file
         for line in handle_probe:
-            line = line.split('\t')
+            line = line.split("\t")
             line[-1] = line[-1][0:-1]
             if line[0] != current_gene:
                 current_gene = line[0]
@@ -117,49 +124,63 @@ class BaseDB():
             sequence = line[1]
             # what if we have duplicated sequences?
             self.oligos_DB[current_gene][sequence] = {}
-            self.oligos_DB[current_gene][sequence]['transcript_id'] = line[2].split(';')
-            self.oligos_DB[current_gene][sequence]['exon_id'] = line[3].split(';')
-            self.oligos_DB[current_gene][sequence]['chromosome'] = line[4]
-            self.oligos_DB[current_gene][sequence]['start'] = line[5].split(';')
-            self.oligos_DB[current_gene][sequence]['end'] = line[6].split(';')
-            self.oligos_DB[current_gene][sequence]['strand'] = line[7]
-            #retrive the remaining features if they were computed
+            self.oligos_DB[current_gene][sequence]["transcript_id"] = line[2].split(";")
+            self.oligos_DB[current_gene][sequence]["exon_id"] = line[3].split(";")
+            self.oligos_DB[current_gene][sequence]["chromosome"] = line[4]
+            self.oligos_DB[current_gene][sequence]["start"] = line[5].split(";")
+            self.oligos_DB[current_gene][sequence]["end"] = line[6].split(";")
+            self.oligos_DB[current_gene][sequence]["strand"] = line[7]
+            # retrive the remaining features if they were computed
             if add_features:
-                    for i, column in enumerate(columns[8:]):
-                        self.oligos_DB[current_gene][sequence][column] = line[i+8]
-                    
-        handle_probe.close() 
+                for i, column in enumerate(columns[8:]):
+                    self.oligos_DB[current_gene][sequence][column] = line[i + 8]
+
+        handle_probe.close()
 
     def write_oligos_DB(self):
-        '''Writes the data structure self.oligos_DB in a tsv file in the <self.file_oligos_DB> path. 
+        """Writes the data structure self.oligos_DB in a tsv file in the <self.file_oligos_DB> path.
         The order of columns is : gene_id, probe_sequence, 'transcript_id', 'exon_id', 'chromosome', 'start', 'end', 'strand', all the additional info computed by the filtersing class.
-        '''
-        
-        with open(self.file_oligos_DB, 'w') as handle_probe:
-            columns =['gene_id', 'probe_sequence']
-            #find all the other names of the columns (depend on the filterss applied)
+        """
+
+        with open(self.file_oligos_DB, "w") as handle_probe:
+            columns = ["gene_id", "probe_sequence"]
+            # find all the other names of the columns (depend on the filterss applied)
             tmp = list(self.oligos_DB.values())[0]
             tmp = list(list(tmp.values())[0].keys())
             columns.extend(tmp)
             print(columns)
-            handle_probe.write("\t".join(columns)+"\n")
+            handle_probe.write("\t".join(columns) + "\n")
 
             for gene_id, probe in self.oligos_DB.items():
                 for probe_sequence, probe_attributes in probe.items():
                     # write the basic information information we compute for each probe
-                    output = '{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}'.format(gene_id, probe_sequence, ';'.join(probe_attributes['transcript_id']), 
-                        ';'.join(probe_attributes['exon_id']), probe_attributes['chromosome'], ';'.join(str(s) for s in probe_attributes['start']), 
-                        ';'.join(str(e) for e in probe_attributes['end']), probe_attributes['strand'])
+                    output = "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}".format(
+                        gene_id,
+                        probe_sequence,
+                        ";".join(probe_attributes["transcript_id"]),
+                        ";".join(probe_attributes["exon_id"]),
+                        probe_attributes["chromosome"],
+                        ";".join(str(s) for s in probe_attributes["start"]),
+                        ";".join(str(e) for e in probe_attributes["end"]),
+                        probe_attributes["strand"],
+                    )
                     # if we computed additional features we write also those
                     if len(columns) > 8:
                         for column in columns[8:]:
-                            output += '\t{}'.format(probe_attributes[column])
+                            output += "\t{}".format(probe_attributes[column])
                         # \n at the end f the string
-                    output += '\n'
+                    output += "\n"
                     handle_probe.write(output)
 
-    def _create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
-        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
+    def _create_reference_DB(
+        self,
+        genome=False,
+        gene_transcript=True,
+        gene_CDS=False,
+        dir_output="./output/annotation",
+        block_size=None,
+    ):
+        """Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements.
         If not specified the exon juctions size is set to <probe_length_max> + 5.
 
         :param genome: create the reference file for the whole genome, defaults to False
@@ -172,36 +193,44 @@ class BaseDB():
         :type dir_output: str, optional
         :param block_size: size of the exon junctions, defaults to None
         :type block_size: int, optional
-        '''
+        """
+
         def get_files_fasta():
-            '''generates the fasta files that will compose the reference_DB
+            """generates the fasta files that will compose the reference_DB
 
             :return: list of the fasta files
             :rtype: list of str
-            '''
+            """
             files_fasta = []
             if genome:
-                file_genome = os.path.join(dir_output,'genome.fna')
+                file_genome = os.path.join(dir_output, "genome.fna")
                 shutil.copyfile(self.file_sequence, file_genome)
                 files_fasta.append(file_genome)
             if gene_transcript:
-                file_gene_transcript_annotation, file_gene_transcript_fasta = self.__generate_gene_transcript(block_size, False, dir_output)
-                os.remove(file_gene_transcript_annotation) #not required anymore in this case
+                (
+                    file_gene_transcript_annotation,
+                    file_gene_transcript_fasta,
+                ) = self.__generate_gene_transcript(block_size, False, dir_output)
+                os.remove(
+                    file_gene_transcript_annotation
+                )  # not required anymore in this case
                 files_fasta.append(file_gene_transcript_fasta)
             if gene_CDS:
-                #generate gene cds
-                warnings.warn('Gene CDS not implemented yet')
+                # generate gene cds
+                warnings.warn("Gene CDS not implemented yet")
             return files_fasta
 
-        if block_size is None: #when not specified define it automatically
-                block_size = self.probe_length_max + 5
+        if block_size is None:  # when not specified define it automatically
+            block_size = self.probe_length_max + 5
 
         files_fasta = get_files_fasta()
         data_parser.merge_fasta(files_fasta, self.file_reference_DB)
 
-    def __generate_gene_transcript(self, block_size, oligos, dir_output = './output/annotation'):
-        '''Creates a fasta file containing the whole transcriptome. The file contains also the exon junctions, which are the union of two consecuteive exons and 
-        for each exon we consider only the last/ first <block_size> base pairs. The required compoutations are different between for the transcriptome for the reference and 
+    def __generate_gene_transcript(
+        self, block_size, oligos, dir_output="./output/annotation"
+    ):
+        """Creates a fasta file containing the whole transcriptome. The file contains also the exon junctions, which are the union of two consecuteive exons and
+        for each exon we consider only the last/ first <block_size> base pairs. The required compoutations are different between for the transcriptome for the reference and
         the oligos sequences, the variable <oligos> defines which computations should be made.
 
         :param block_size: size of the exon juctions
@@ -210,143 +239,289 @@ class BaseDB():
         :type oligos: bool
         :param dir_output: folder where the fasta file will be saved, defaults to './output/annotation'
         :type dir_output: str, optional
-        '''
+        """
 
         def _load_exon_annotation():
-            '''Retrive exon annotation from loaded gene annotation.
+            """Retrive exon annotation from loaded gene annotation.
 
             :return: Exon annotation
             :rtype: pandas.DataFrame
-            '''
-            exon_annotation = self.annotation.loc[self.annotation['feature'] == 'exon']
-            exon_annotation = exon_annotation.assign(source='unknown')
+            """
+            exon_annotation = self.annotation.loc[self.annotation["feature"] == "exon"]
+            exon_annotation = exon_annotation.assign(source="unknown")
 
-            if not 'exon_id' in exon_annotation.columns:
-                exon_annotation['exon_id'] = exon_annotation['transcript_id'] + '_exon' + exon_annotation['exon_number']
-            
-            #there are some exon annotations which have the same start and end coordinates and can't be saved as fasta from bedtools
-            exon_annotation = exon_annotation[(exon_annotation.end - exon_annotation.start) > 0] 
+            if not "exon_id" in exon_annotation.columns:
+                exon_annotation["exon_id"] = (
+                    exon_annotation["transcript_id"]
+                    + "_exon"
+                    + exon_annotation["exon_number"]
+                )
+
+            # there are some exon annotations which have the same start and end coordinates and can't be saved as fasta from bedtools
+            exon_annotation = exon_annotation[
+                (exon_annotation.end - exon_annotation.start) > 0
+            ]
             exon_annotation.reset_index(inplace=True, drop=True)
-            exon_annotation['start'] -= 1
+            exon_annotation["start"] -= 1
 
             return exon_annotation
-    
+
         def _load_unique_exons(exon_annotation):
-            '''Merge overlapping exons, which have the same start and end coordinates. 
+            """Merge overlapping exons, which have the same start and end coordinates.
             Save transcript information for those exons.
 
             :param exon_annotation: Exon annotation
             :type exon_annotation: pandas.DataFrame
             :return: Merged exon annotation
             :rtype: pandas.DataFrame
-            '''
+            """
 
-            exon_annotation['region'] = (exon_annotation['seqname'] + '_' + exon_annotation['start'].astype('str') + '_' + 
-                                         exon_annotation['end'].astype('str') + '_' + exon_annotation['strand'])
-            
-            aggregate_function = {'gene_id': 'first', 'transcript_id': ':'.join, 'exon_id': ':'.join, 
-                                  'seqname': 'first', 'start': 'first', 'end': 'first', 'score': 'first', 'strand': 'first'}
-            merged_exons = exon_annotation.groupby(exon_annotation['region']).aggregate(aggregate_function)
-            
-            merged_exons['score'] = 0
-            merged_exons['thickStart'] = merged_exons['start']
-            merged_exons['thickEnd'] = merged_exons['end']
-            merged_exons['itemRgb'] = 0
-            merged_exons['blockCount'] = 1
-            merged_exons['block_sizes'] = merged_exons['end'] - merged_exons['start']
-            merged_exons['blockStarts'] = 0
-            merged_exons['gene_transcript_exon_id'] = (merged_exons['gene_id'] + '_tid' + 
-                                                       merged_exons['transcript_id'] + '_eid' + 
-                                                       merged_exons['exon_id'])
-            merged_exons = merged_exons[['gene_id','gene_transcript_exon_id','seqname','start','end','score','strand',
-                                         'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes','blockStarts']]
+            exon_annotation["region"] = (
+                exon_annotation["seqname"]
+                + "_"
+                + exon_annotation["start"].astype("str")
+                + "_"
+                + exon_annotation["end"].astype("str")
+                + "_"
+                + exon_annotation["strand"]
+            )
+
+            aggregate_function = {
+                "gene_id": "first",
+                "transcript_id": ":".join,
+                "exon_id": ":".join,
+                "seqname": "first",
+                "start": "first",
+                "end": "first",
+                "score": "first",
+                "strand": "first",
+            }
+            merged_exons = exon_annotation.groupby(exon_annotation["region"]).aggregate(
+                aggregate_function
+            )
+
+            merged_exons["score"] = 0
+            merged_exons["thickStart"] = merged_exons["start"]
+            merged_exons["thickEnd"] = merged_exons["end"]
+            merged_exons["itemRgb"] = 0
+            merged_exons["blockCount"] = 1
+            merged_exons["block_sizes"] = merged_exons["end"] - merged_exons["start"]
+            merged_exons["blockStarts"] = 0
+            merged_exons["gene_transcript_exon_id"] = (
+                merged_exons["gene_id"]
+                + "_tid"
+                + merged_exons["transcript_id"]
+                + "_eid"
+                + merged_exons["exon_id"]
+            )
+            merged_exons = merged_exons[
+                [
+                    "gene_id",
+                    "gene_transcript_exon_id",
+                    "seqname",
+                    "start",
+                    "end",
+                    "score",
+                    "strand",
+                    "thickStart",
+                    "thickEnd",
+                    "itemRgb",
+                    "blockCount",
+                    "block_sizes",
+                    "blockStarts",
+                ]
+            ]
 
             return merged_exons
 
         def _merge_containing_exons(unique_exons):
-            '''Merge exons that are contained in a larger exon, e.g. have the same start coordinates but different end coordinates, into one entry.
+            """Merge exons that are contained in a larger exon, e.g. have the same start coordinates but different end coordinates, into one entry.
 
             :param unique_exons: Dataframe with annotation of unique exons, where overlapping exons are merged.
             :type unique_exons: pandas.DataFrame
             :return: Dataframe with annotation of merged exons, where containing exons are merged.
             :rtype: pandas.DataFrame
-            '''
+            """
 
-            aggregate_function = {'gene_id': 'first', 'gene_transcript_exon_id': ':'.join, 
-                                  'seqname': 'first', 'start': 'min', 'end': 'max', 'score': 'first', 'strand': 'first',
-                                  'thickStart': 'min','thickEnd': 'max', 'itemRgb': 'first',
-                                  'blockCount': 'first','block_sizes': 'max','blockStarts': 'first'}
-            
-            unique_exons['region_start'] = (unique_exons['seqname'] + '_' + unique_exons['start'].astype('str') + '_' + unique_exons['strand'])
-            merged_unique_exons = unique_exons.groupby(unique_exons['region_start']).aggregate(aggregate_function)
-            
-            merged_unique_exons['region_end'] = (merged_unique_exons['seqname'] + '_' + merged_unique_exons['end'].astype('str') + '_' + merged_unique_exons['strand'])
-            merged_unique_exons = merged_unique_exons.groupby(merged_unique_exons['region_end']).aggregate(aggregate_function)
-            
+            aggregate_function = {
+                "gene_id": "first",
+                "gene_transcript_exon_id": ":".join,
+                "seqname": "first",
+                "start": "min",
+                "end": "max",
+                "score": "first",
+                "strand": "first",
+                "thickStart": "min",
+                "thickEnd": "max",
+                "itemRgb": "first",
+                "blockCount": "first",
+                "block_sizes": "max",
+                "blockStarts": "first",
+            }
+
+            unique_exons["region_start"] = (
+                unique_exons["seqname"]
+                + "_"
+                + unique_exons["start"].astype("str")
+                + "_"
+                + unique_exons["strand"]
+            )
+            merged_unique_exons = unique_exons.groupby(
+                unique_exons["region_start"]
+            ).aggregate(aggregate_function)
+
+            merged_unique_exons["region_end"] = (
+                merged_unique_exons["seqname"]
+                + "_"
+                + merged_unique_exons["end"].astype("str")
+                + "_"
+                + merged_unique_exons["strand"]
+            )
+            merged_unique_exons = merged_unique_exons.groupby(
+                merged_unique_exons["region_end"]
+            ).aggregate(aggregate_function)
+
             return merged_unique_exons
 
         def _load_exon_junctions(block_size, exon_annotation):
-            '''Get all possible exon junctions from the transcript annotation.
+            """Get all possible exon junctions from the transcript annotation.
             Merge overlapping exons jucntions, which have the same satrt and end coordinates.
             Save transcript information for those exons.
 
-            :param block_size: Size of the exon junction regions, i.e. <block_size> bp upstream of first exon 
+            :param block_size: Size of the exon junction regions, i.e. <block_size> bp upstream of first exon
                 and <block_size> bp downstream of second exon.
             :type block_size: int
             :return: Dataframe with annotation of exons junctions, where overlapping exons junctions are merged.
             :rtype: pandas.DataFrame
-            '''
-            transcript_exons, transcript_info = _get_transcript_exons_and_info(exon_annotation)
-            exon_junction_list = _get_exon_junction_list(block_size, transcript_exons, transcript_info)
-            
-            exon_junctions = pd.DataFrame(exon_junction_list, 
-                                          columns=['region', 'gene_id', 'transcript_id', 'exon_id', 'seqname', 'start', 'end', 'score', 'strand', 
-                                                   'thickStart', 'thickEnd', 'itemRgb', 'blockCount', 'block_sizes', 'blockStarts'])
-            aggregate_function = {'gene_id': 'first', 'transcript_id': ':'.join, 'exon_id': ':'.join, 
-                                  'seqname': 'first', 'start': 'first', 'end': 'first', 'score': 'first', 'strand': 'first', 
-                                  'thickStart': 'first', 'thickEnd': 'first', 'itemRgb': 'first', 'blockCount': 'first', 'block_sizes': 'first', 'blockStarts': 'first'}     
-            merged_exon_junctions = exon_junctions.groupby(exon_junctions['region']).aggregate(aggregate_function)
-            
-            merged_exon_junctions['gene_transcript_exon_id'] = (merged_exon_junctions['gene_id'] + '_tid' + 
-                                                                merged_exon_junctions['transcript_id'] + '_eid' + 
-                                                                merged_exon_junctions['exon_id'])
-            merged_exon_junctions = merged_exon_junctions[['gene_id','gene_transcript_exon_id','seqname','start','end','score','strand',
-                                                           'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes','blockStarts']]
+            """
+            transcript_exons, transcript_info = _get_transcript_exons_and_info(
+                exon_annotation
+            )
+            exon_junction_list = _get_exon_junction_list(
+                block_size, transcript_exons, transcript_info
+            )
+
+            exon_junctions = pd.DataFrame(
+                exon_junction_list,
+                columns=[
+                    "region",
+                    "gene_id",
+                    "transcript_id",
+                    "exon_id",
+                    "seqname",
+                    "start",
+                    "end",
+                    "score",
+                    "strand",
+                    "thickStart",
+                    "thickEnd",
+                    "itemRgb",
+                    "blockCount",
+                    "block_sizes",
+                    "blockStarts",
+                ],
+            )
+            aggregate_function = {
+                "gene_id": "first",
+                "transcript_id": ":".join,
+                "exon_id": ":".join,
+                "seqname": "first",
+                "start": "first",
+                "end": "first",
+                "score": "first",
+                "strand": "first",
+                "thickStart": "first",
+                "thickEnd": "first",
+                "itemRgb": "first",
+                "blockCount": "first",
+                "block_sizes": "first",
+                "blockStarts": "first",
+            }
+            merged_exon_junctions = exon_junctions.groupby(
+                exon_junctions["region"]
+            ).aggregate(aggregate_function)
+
+            merged_exon_junctions["gene_transcript_exon_id"] = (
+                merged_exon_junctions["gene_id"]
+                + "_tid"
+                + merged_exon_junctions["transcript_id"]
+                + "_eid"
+                + merged_exon_junctions["exon_id"]
+            )
+            merged_exon_junctions = merged_exon_junctions[
+                [
+                    "gene_id",
+                    "gene_transcript_exon_id",
+                    "seqname",
+                    "start",
+                    "end",
+                    "score",
+                    "strand",
+                    "thickStart",
+                    "thickEnd",
+                    "itemRgb",
+                    "blockCount",
+                    "block_sizes",
+                    "blockStarts",
+                ]
+            ]
 
             return merged_exon_junctions
 
         def _get_transcript_exons_and_info(exon_annotation):
-            '''Get list of exons that belong to a transcript. 
+            """Get list of exons that belong to a transcript.
             Save information about each transcript, i.e. gene ID, chromosome and strand.
-            
+
             :param exon_annotation: Exon annotation.
             :type exon_annotation: pandas.DataFrame
             :return: Two dictionaries: transcript - exon mapping and transcript information.
             :rtype: dict
-            '''
-            transcripts = self.annotation.loc[self.annotation["transcript_id"] != '']
-            transcripts = sorted(list(transcripts['transcript_id'].unique()))
+            """
+            transcripts = self.annotation.loc[self.annotation["transcript_id"] != ""]
+            transcripts = sorted(list(transcripts["transcript_id"].unique()))
             transcript_exons = {key: {} for key in transcripts}
             transcript_info = dict()
-            
-            for (transcript_id, exon_number, exon_id, start, end, gene_id, seqname, strand) in zip(exon_annotation['transcript_id'], exon_annotation['exon_number'], exon_annotation['exon_id'], exon_annotation['start'], exon_annotation['end'], exon_annotation['gene_id'], exon_annotation['seqname'], exon_annotation['strand']):
-                transcript_exons[transcript_id][int(exon_number)] = [exon_id, start, end]
+
+            for (
+                transcript_id,
+                exon_number,
+                exon_id,
+                start,
+                end,
+                gene_id,
+                seqname,
+                strand,
+            ) in zip(
+                exon_annotation["transcript_id"],
+                exon_annotation["exon_number"],
+                exon_annotation["exon_id"],
+                exon_annotation["start"],
+                exon_annotation["end"],
+                exon_annotation["gene_id"],
+                exon_annotation["seqname"],
+                exon_annotation["strand"],
+            ):
+                transcript_exons[transcript_id][int(exon_number)] = [
+                    exon_id,
+                    start,
+                    end,
+                ]
                 transcript_info[transcript_id] = [gene_id, seqname, strand]
-                
-            if not ('transcript' in self.annotation['feature'].values):
+
+            if not ("transcript" in self.annotation["feature"].values):
                 delete_ids = []
                 for transcript_id in transcript_exons:
                     if transcript_id not in transcript_info:
                         delete_ids.append(transcript_id)
                 for transcript_id in delete_ids:
                     del transcript_exons[transcript_id]
-                
+
             return transcript_exons, transcript_info
 
         def _get_exon_junction_list(block_size, transcript_exons, transcript_info):
-            '''Get list of all possible exon junctions and save all required information for bed12 file.
+            """Get list of all possible exon junctions and save all required information for bed12 file.
 
-            :param block_size: Size of the exon junction regions, i.e. <block_size> bp upstream of first exon 
+            :param block_size: Size of the exon junction regions, i.e. <block_size> bp upstream of first exon
                 and <block_size> bp downstream of second exon.
             :type block_size: int
             :param transcript_exons: Transcript - exon mapping.
@@ -355,7 +530,7 @@ class BaseDB():
             :type transcript_info: dict
             :return: List of exon junctions.
             :rtype: list
-            '''
+            """
             exon_junction_list = []
 
             for transcript, exons in transcript_exons.items():
@@ -363,76 +538,180 @@ class BaseDB():
                 seqname = transcript_info[transcript][1]
                 strand = transcript_info[transcript][2]
 
-                if strand == '+':
-                    exons = [entry[1] for entry in sorted(exons.items())] #return only exon attributes sorted by exon number
-                elif strand == '-':
-                    exons = [entry[1] for entry in sorted(exons.items(), reverse=True)] #return only exon attributes sorted by exon number -> reverse sort on minus strand
-                
+                if strand == "+":
+                    exons = [
+                        entry[1] for entry in sorted(exons.items())
+                    ]  # return only exon attributes sorted by exon number
+                elif strand == "-":
+                    exons = [
+                        entry[1] for entry in sorted(exons.items(), reverse=True)
+                    ]  # return only exon attributes sorted by exon number -> reverse sort on minus strand
+
                 for idx, attributes in enumerate(exons):
-                    if idx == 0: #first exon of transcript
+                    if idx == 0:  # first exon of transcript
                         exon_upstream = attributes
                         exons_small = []
-                    elif ((idx+1) < len(exons)) & ((attributes[2] - attributes[1]) < block_size): #if exon is not the last exon of transcript and shorter than probe block_size but not the last exon -> create sequence with neighboring exons
+                    elif ((idx + 1) < len(exons)) & (
+                        (attributes[2] - attributes[1]) < block_size
+                    ):  # if exon is not the last exon of transcript and shorter than probe block_size but not the last exon -> create sequence with neighboring exons
                         exons_small.append(attributes)
                     else:
                         exon_downstream = attributes
-                        block_size_up = min(block_size, (exon_upstream[2] - exon_upstream[1])) #catch case that first or last exon < block_size
-                        block_size_down = min(block_size, (exon_downstream[2] - exon_downstream[1])) #catch case that first or last exon < block_size
+                        block_size_up = min(
+                            block_size, (exon_upstream[2] - exon_upstream[1])
+                        )  # catch case that first or last exon < block_size
+                        block_size_down = min(
+                            block_size, (exon_downstream[2] - exon_downstream[1])
+                        )  # catch case that first or last exon < block_size
                         start_up = exon_upstream[2] - block_size_up
                         end_down = exon_downstream[1] + block_size_down
-                        
+
                         if exons_small == []:
                             blockCount = 2
-                            block_size_length_entry = '{},{}'.format(block_size_up, block_size_down)
-                            block_size_start_entry = '{},{}'.format(0, exon_downstream[1] - start_up)
+                            block_size_length_entry = "{},{}".format(
+                                block_size_up, block_size_down
+                            )
+                            block_size_start_entry = "{},{}".format(
+                                0, exon_downstream[1] - start_up
+                            )
                         else:
                             blockCount = len(exons_small) + 2
-                            block_size_length_entry = str(block_size_up) + ',' + ','.join([str(attributes[2] - attributes[1]) for attributes in exons_small]) + ',' + str(block_size_down) 
-                            block_size_start_entry = '0,' + ','.join([str(attributes[1] - start_up,) for attributes in exons_small]) + ',' + str(exon_downstream[1] - start_up) 
+                            block_size_length_entry = (
+                                str(block_size_up)
+                                + ","
+                                + ",".join(
+                                    [
+                                        str(attributes[2] - attributes[1])
+                                        for attributes in exons_small
+                                    ]
+                                )
+                                + ","
+                                + str(block_size_down)
+                            )
+                            block_size_start_entry = (
+                                "0,"
+                                + ",".join(
+                                    [
+                                        str(
+                                            attributes[1] - start_up,
+                                        )
+                                        for attributes in exons_small
+                                    ]
+                                )
+                                + ","
+                                + str(exon_downstream[1] - start_up)
+                            )
                             exons_small = []
 
-                        exon_junction_list.append(['{}_{}_{}_{}'.format(seqname, start_up, end_down, strand), gene_id, transcript, '{}_{}'.format(exon_upstream[0], exon_downstream[0]),
-                                                    seqname, start_up, end_down, 0, strand, start_up, end_down, 0, blockCount, block_size_length_entry, block_size_start_entry])
+                        exon_junction_list.append(
+                            [
+                                "{}_{}_{}_{}".format(
+                                    seqname, start_up, end_down, strand
+                                ),
+                                gene_id,
+                                transcript,
+                                "{}_{}".format(exon_upstream[0], exon_downstream[0]),
+                                seqname,
+                                start_up,
+                                end_down,
+                                0,
+                                strand,
+                                start_up,
+                                end_down,
+                                0,
+                                blockCount,
+                                block_size_length_entry,
+                                block_size_start_entry,
+                            ]
+                        )
                         exon_upstream = attributes
-            
+
             return exon_junction_list
-        
-        # get annotation of exons and  
+
+        # get annotation of exons and
         exons_annotation = _load_exon_annotation()
         # merge exon annotations for the same region
         unique_exons = _load_unique_exons(exons_annotation)
-        if not oligos: # only for the reference class
+        if not oligos:  # only for the reference class
             unique_exons = _merge_containing_exons(unique_exons)
         # get exon junction annotation
         exon_junctions_probes = _load_exon_junctions(block_size, exons_annotation)
         # concatenate the two annotations
         gene_transcript_annotation = pd.concat([unique_exons, exon_junctions_probes])
-        gene_transcript_annotation = gene_transcript_annotation.sort_values(by=['gene_id'])
+        gene_transcript_annotation = gene_transcript_annotation.sort_values(
+            by=["gene_id"]
+        )
         gene_transcript_annotation.reset_index(inplace=True, drop=True)
         # save the gene transcript annotation
-        file_gene_transcript_annotation = os.path.join(dir_output, 'gene_transcript.bed')
+        file_gene_transcript_annotation = os.path.join(
+            dir_output, "gene_transcript.bed"
+        )
         # for the oligos we don't need the fasta file and we need the gene, transcript, exon informations
         if oligos:
             file_gene_transcript_fasta = None
-            gene_transcript_annotation[['seqname','start','end', 'gene_id', 'gene_transcript_exon_id','score','strand',
-                                    'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes',
-                                    'blockStarts']].to_csv(file_gene_transcript_annotation, sep='\t', header=False, index = False)
+            gene_transcript_annotation[
+                [
+                    "seqname",
+                    "start",
+                    "end",
+                    "gene_id",
+                    "gene_transcript_exon_id",
+                    "score",
+                    "strand",
+                    "thickStart",
+                    "thickEnd",
+                    "itemRgb",
+                    "blockCount",
+                    "block_sizes",
+                    "blockStarts",
+                ]
+            ].to_csv(
+                file_gene_transcript_annotation, sep="\t", header=False, index=False
+            )
         else:
-            gene_transcript_annotation[['seqname','start','end', 'gene_id','score','strand',
-                                    'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes',
-                                    'blockStarts']].to_csv(file_gene_transcript_annotation, sep='\t', header=False, index = False)
-            # create the fasta file 
-            file_gene_transcript_fasta = os.path.join(dir_output, 'gene_transcript.fasta')
-            data_parser.get_sequence_from_annotation(file_gene_transcript_annotation, self.file_sequence, file_gene_transcript_fasta, split=True)
+            gene_transcript_annotation[
+                [
+                    "seqname",
+                    "start",
+                    "end",
+                    "gene_id",
+                    "score",
+                    "strand",
+                    "thickStart",
+                    "thickEnd",
+                    "itemRgb",
+                    "blockCount",
+                    "block_sizes",
+                    "blockStarts",
+                ]
+            ].to_csv(
+                file_gene_transcript_annotation, sep="\t", header=False, index=False
+            )
+            # create the fasta file
+            file_gene_transcript_fasta = os.path.join(
+                dir_output, "gene_transcript.fasta"
+            )
+            data_parser.get_sequence_from_annotation(
+                file_gene_transcript_annotation,
+                self.file_sequence,
+                file_gene_transcript_fasta,
+                split=True,
+            )
 
         return file_gene_transcript_annotation, file_gene_transcript_fasta
 
     def __generate_gene_CDS():
-        ''''Creates a fasta file containing the whole transcriptome.'''
-        pass
+        """'Creates a fasta file containing the whole transcriptome."""
 
-    def _create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
-        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+    def _create_oligos_DB(
+        self,
+        genes=None,
+        region="gene_transcript",
+        number_batchs=1,
+        dir_output="./output/annotation",
+        write=True,
+    ):
+        """creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then
         will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
 
         :param genes: genes for which compute the probes, defaults to None
@@ -445,48 +724,58 @@ class BaseDB():
         :type dir_output: str, optional
         :param write: write the file, defaults to True
         :type write: bool, optional
-        '''
+        """
 
         def create_target_region():
-            '''cretares the annotation file for the specified region.
-            '''
+            """cretares the annotation file for the specified region."""
 
-            if region == 'genome':
+            if region == "genome":
                 file_region_annotation = None
-                #TODO
-            elif region == 'gene_transcript':
-                file_region_annotation, _ = self.__generate_gene_transcript(self.probe_length_max - 1, True, dir_output)
-            elif region == 'gene_CDS':
+                # TODO
+            elif region == "gene_transcript":
+                file_region_annotation, _ = self.__generate_gene_transcript(
+                    self.probe_length_max - 1, True, dir_output
+                )
+            elif region == "gene_CDS":
                 file_region_annotation = None
-                #TODO
+                # TODO
             else:
-                raise ValueError(f'The given region does not exists. You selected {region}')
+                raise ValueError(
+                    f"The given region does not exists. You selected {region}"
+                )
             return file_region_annotation
 
         def get_gene_list_from_annotation():
-            '''generates all the different genes in the annotation file of the specified region.
-            '''
+            """generates all the different genes in the annotation file of the specified region."""
 
-            genes = self.annotation.loc[self.annotation['feature'] == 'gene']
-            genes = list(genes['gene_id'].unique())
+            genes = self.annotation.loc[self.annotation["feature"] == "gene"]
+            genes = list(genes["gene_id"].unique())
             random.shuffle(genes)
             return genes
 
         file_region_annotation = create_target_region()
         if genes is None:
-           genes = get_gene_list_from_annotation()
-        self.oligos_DB = self.__generate_oligos(file_region_annotation, genes, number_batchs, dir_output) 
+            genes = get_gene_list_from_annotation()
+        self.oligos_DB = self.__generate_oligos(
+            file_region_annotation, genes, number_batchs, dir_output
+        )
         if write:
             self.write_oligos_DB()
 
-        #clean folder
+        # clean folder
         os.remove(file_region_annotation)
 
-    def __generate_oligos(self,file_region_annotation, genes, number_batchs, dir_output = './output/annotation'):
-        '''Get the fasta sequence of all possible probes with user-defined length for all input genes and store the in a dictionary. 
+    def __generate_oligos(
+        self,
+        file_region_annotation,
+        genes,
+        number_batchs,
+        dir_output="./output/annotation",
+    ):
+        """Get the fasta sequence of all possible probes with user-defined length for all input genes and store the in a dictionary.
         Generated probes are filtered by the filters give in input and the features computed for the  filters are added to the dictionary.
 
-        :param file_region_annotation: path to the gtf annotaiton file of the region 
+        :param file_region_annotation: path to the gtf annotaiton file of the region
         :type file_region_annotation: str
         :param genes: genes for which the probes are computed
         :type genes: list of str
@@ -494,21 +783,27 @@ class BaseDB():
         :type number_batchs: int
         :param dir_output: directory where temporary diles are written, defaults to './output/annotation'
         :type dir_output: str, optional
-        '''
+        """
 
         def _get_probes(batch_id, genes_batch):
-            '''Get the fasta sequence of all possible probes for all genes in the batch.
+            """Get the fasta sequence of all possible probes for all genes in the batch.
 
             :param batch_id: Batch ID.
             :type batch_id: int
             :param genes_batch: List of genes for which probes should be designed.
             :type genes_batch: list
-            '''
-            
-            file_region_bed_batch = os.path.join(dir_output, 'region_batch{}.bed'.format(batch_id))
-            file_region_fasta_batch = os.path.join(dir_output, 'region_batch{}.fna'.format(batch_id))
-            
-            _get_region_fasta(genes_batch, file_region_bed_batch, file_region_fasta_batch)
+            """
+
+            file_region_bed_batch = os.path.join(
+                dir_output, "region_batch{}.bed".format(batch_id)
+            )
+            file_region_fasta_batch = os.path.join(
+                dir_output, "region_batch{}.fna".format(batch_id)
+            )
+
+            _get_region_fasta(
+                genes_batch, file_region_bed_batch, file_region_fasta_batch
+            )
             gene_probes_batch = _get_probes_info(genes_batch, file_region_fasta_batch)
 
             os.remove(file_region_bed_batch)
@@ -516,8 +811,10 @@ class BaseDB():
 
             return gene_probes_batch
 
-        def _get_region_fasta(genes_batch, file_region_bed_batch, file_region_fasta_batch):
-            '''Extract transcripts for the current batch and write transcript regions to bed file. 
+        def _get_region_fasta(
+            genes_batch, file_region_bed_batch, file_region_fasta_batch
+        ):
+            """Extract transcripts for the current batch and write transcript regions to bed file.
             Get sequence for annotated transcript regions (bed file) from genome sequence (fasta file) and write transcriptome sequences to fasta file.
 
             :param genes_batch: List of genes for which probes should be designed.
@@ -526,42 +823,64 @@ class BaseDB():
             :type file_region_bed_batch: string
             :param file_region_fasta_batch: Path to fasta transcriptome sequence output file.
             :type file_region_fasta_batch: string
-            '''
+            """
 
-            region_annotation_batch = region_annotation.loc[region_annotation['gene_id'].isin(genes_batch)].copy()
-            region_annotation_batch = region_annotation_batch.sort_values(by=['gene_id'])
-            region_annotation_batch[['seqname','start','end', 'gene_transcript_exon_id','score','strand',
-                                            'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes',
-                                            'blockStarts']].to_csv(file_region_bed_batch, sep='\t', header=False, index = False)
-            
+            region_annotation_batch = region_annotation.loc[
+                region_annotation["gene_id"].isin(genes_batch)
+            ].copy()
+            region_annotation_batch = region_annotation_batch.sort_values(
+                by=["gene_id"]
+            )
+            region_annotation_batch[
+                [
+                    "seqname",
+                    "start",
+                    "end",
+                    "gene_transcript_exon_id",
+                    "score",
+                    "strand",
+                    "thickStart",
+                    "thickEnd",
+                    "itemRgb",
+                    "blockCount",
+                    "block_sizes",
+                    "blockStarts",
+                ]
+            ].to_csv(file_region_bed_batch, sep="\t", header=False, index=False)
+
             # get sequence for exons
-            data_parser.get_sequence_from_annotation(file_region_bed_batch, self.file_sequence, file_region_fasta_batch, split=True)
+            data_parser.get_sequence_from_annotation(
+                file_region_bed_batch,
+                self.file_sequence,
+                file_region_fasta_batch,
+                split=True,
+            )
 
         def _parse_header(header):
-            '''Helper function to parse the header of each exon fasta entry.
+            """Helper function to parse the header of each exon fasta entry.
 
             :param header: Header of fasta entry.
             :type header: string
             :return: Parsed header information, i.e.
                 gene_id, transcript_id, exon_id and position (chromosome, start, strand)
             :rtype: string
-            '''
+            """
 
-            identifier = header.split('::')[0]
-            gene_id = identifier.split('_tid')[0]
-            transcript_id = identifier.split('_tid')[1].split('_eid')[0]
-            exon_id = identifier.split('_eid')[1]
+            identifier = header.split("::")[0]
+            gene_id = identifier.split("_tid")[0]
+            transcript_id = identifier.split("_tid")[1].split("_eid")[0]
+            exon_id = identifier.split("_eid")[1]
 
-            coordinates = header.split('::')[1]
-            chrom = coordinates.split(':')[0]
-            start = int(coordinates.split(':')[1].split('-')[0])
-            strand = coordinates.split('(')[1].split(')')[0]
+            coordinates = header.split("::")[1]
+            chrom = coordinates.split(":")[0]
+            start = int(coordinates.split(":")[1].split("-")[0])
+            strand = coordinates.split("(")[1].split(")")[0]
 
             return gene_id, transcript_id, exon_id, chrom, start, strand
-        
+
         def _get_probes_info(genes_batch, file_region_fasta_batch):
-            '''Merge all probes with identical sequence that come from the same gene into one fasta entry.
-            Filter all probes based on user-defined filters and collect the additional information about each probe. 
+            """Merge all probes with identical sequence that come from the same gene into one fasta entry.
+            Filter all probes based on user-defined filters and collect the additional information about each probe.
 
             :param genes_batch: List of genes for which probes should be designed.
             :type genes_batch: list
@@ -570,7 +889,7 @@ class BaseDB():
             :return: Mapping of probes to corresponding genes with additional information about each probe, i.e.
                 position (chromosome, start, end, strand), gene_id, transcript_id, exon_id
             :rtype: dict
-            '''
+            """
 
             gene_probes = {key: {} for key in genes_batch}
             total_probes = 0
@@ -580,16 +899,27 @@ class BaseDB():
             for exon in SeqIO.parse(file_region_fasta_batch, "fasta"):
                 sequence = exon.seq
 
-                for probe_length in range(self.probe_length_min, self.probe_length_max + 1):
+                for probe_length in range(
+                    self.probe_length_min, self.probe_length_max + 1
+                ):
                     if len(sequence) > probe_length:
-                        number_probes = len(sequence)-(probe_length-1)
-                        probes_sequence = [sequence[i:i+probe_length] for i in range(number_probes)]
+                        number_probes = len(sequence) - (probe_length - 1)
+                        probes_sequence = [
+                            sequence[i : i + probe_length] for i in range(number_probes)
+                        ]
 
                         for i in range(number_probes):
-                            total_probes +=1
+                            total_probes += 1
                             probe_sequence = probes_sequence[i]
-     
-                            gene_id, transcript_id, exon_id, chrom, start, strand = _parse_header(exon.id)
+
+                            (
+                                gene_id,
+                                transcript_id,
+                                exon_id,
+                                chrom,
+                                start,
+                                strand,
+                            ) = _parse_header(exon.id)
                             probe_start = start + i
                             probe_end = start + i + probe_length
 
@@ -597,46 +927,88 @@ class BaseDB():
                             # fulfills, info = filter
                             # if fulfills:  add the probe to the list of probes for this gene
                             if probe_sequence in gene_probes[gene_id]:
-                                gene_probes[gene_id][probe_sequence]['transcript_id'].append(transcript_id)
-                                gene_probes[gene_id][probe_sequence]['exon_id'].append(exon_id)
-                                gene_probes[gene_id][probe_sequence]['start'].append(probe_start)
-                                gene_probes[gene_id][probe_sequence]['end'].append(probe_end)
+                                gene_probes[gene_id][probe_sequence][
+                                    "transcript_id"
+                                ].append(transcript_id)
+                                gene_probes[gene_id][probe_sequence]["exon_id"].append(
+                                    exon_id
+                                )
+                                gene_probes[gene_id][probe_sequence]["start"].append(
+                                    probe_start
+                                )
+                                gene_probes[gene_id][probe_sequence]["end"].append(
+                                    probe_end
+                                )
                             else:
                                 loaded_probes += 1
-                                gene_probes[gene_id][probe_sequence] = {'transcript_id': [transcript_id], 'exon_id': [exon_id], 'chromosome': chrom, 'start': [probe_start], 
-                                            'end': [probe_end], 'strand': strand}
-        
+                                gene_probes[gene_id][probe_sequence] = {
+                                    "transcript_id": [transcript_id],
+                                    "exon_id": [exon_id],
+                                    "chromosome": chrom,
+                                    "start": [probe_start],
+                                    "end": [probe_end],
+                                    "strand": strand,
+                                }
+
             return gene_probes
 
         # create index file
         pyfaidx.Fasta(self.file_sequence)
 
-        region_annotation = pd.read_csv(file_region_annotation, sep='\t', names=['seqname','start','end', 'gene_id', 'gene_transcript_exon_id','score','strand',
-                                    'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes', 'blockStarts'])
+        region_annotation = pd.read_csv(
+            file_region_annotation,
+            sep="\t",
+            names=[
+                "seqname",
+                "start",
+                "end",
+                "gene_id",
+                "gene_transcript_exon_id",
+                "score",
+                "strand",
+                "thickStart",
+                "thickEnd",
+                "itemRgb",
+                "blockCount",
+                "block_sizes",
+                "blockStarts",
+            ],
+        )
 
-        #keep the batch structure for parellalization
+        # keep the batch structure for parellalization
         batch_size = int(len(genes) / number_batchs) + (len(genes) % number_batchs > 0)
         probes = {}
-        for batch_id in range(number_batchs): 
-            genes_batch = genes[(batch_size * batch_id):(min(batch_size * (batch_id+1), len(genes)+1))]
+        for batch_id in range(number_batchs):
+            genes_batch = genes[
+                (batch_size * batch_id) : (
+                    min(batch_size * (batch_id + 1), len(genes) + 1)
+                )
+            ]
             probes.update(_get_probes(batch_id, genes_batch))
 
         # remove index file
-        os.remove('{}.fai'.format(self.file_sequence))
+        os.remove("{}.fai".format(self.file_sequence))
 
         return probes
 
     def filter_oligos(self):
-        '''applies the used-defined filters.
-        '''
-        pass
+        """applies the used-defined filters."""
 
 
 class NcbiDB(BaseDB):
-    '''Class to create reference and oligos DB using gtf and fasta files taken from the NCBI server'''
+    """Class to create reference and oligos DB using gtf and fasta files taken from the NCBI server"""
 
-    def __init__(self, probe_length_min, probe_length_max, species = None, genome_assembly = None, annotation_release = None, dir_output='./output/annotation', filters = None):
-        '''Sets species, genome_assembly, annotation_release to a predefined value if thay are not given in input
+    def __init__(
+        self,
+        probe_length_min,
+        probe_length_max,
+        species=None,
+        genome_assembly=None,
+        annotation_release=None,
+        dir_output="./output/annotation",
+        filters=None,
+    ):
+        """Sets species, genome_assembly, annotation_release to a predefined value if thay are not given in input
             Dowloads the fasta and annotation files from the NCBI server and stores them in the dir_output folder
 
         :param probe_length_min: minimum length of the probes created
@@ -653,29 +1025,48 @@ class NcbiDB(BaseDB):
         :type dir_output: str, optional
         :param filters: list of filters classes already initialized, defaults to None
         :type filters: list of classes, optional
-        '''
+        """
         if species is None:
-            species = 'human'
-            warnings.warn(f'No species defined. Using default species {species}!')
+            species = "human"
+            warnings.warn(f"No species defined. Using default species {species}!")
 
         if genome_assembly is None:
-            genome_assembly = 'hg38'
-            warnings.warn(f'No genome assembly defined. Using default assembly {genome_assembly}!')
+            genome_assembly = "hg38"
+            warnings.warn(
+                f"No genome assembly defined. Using default assembly {genome_assembly}!"
+            )
 
         if annotation_release is None:
-            annotation_release = 'current'
-            warnings.warn(f'No annotation release defined. Using default release {annotation_release}!')
+            annotation_release = "current"
+            warnings.warn(
+                f"No annotation release defined. Using default release {annotation_release}!"
+            )
 
-        super().__init__(probe_length_min, probe_length_max, species, genome_assembly, annotation_release)
-        
+        super().__init__(
+            probe_length_min,
+            probe_length_max,
+            species,
+            genome_assembly,
+            annotation_release,
+        )
+
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        ftp = ftp_loader.FTPLoaderNCBI(dir_output, species, genome_assembly, annotation_release)
-        self.file_annotation = ftp.download_files('gtf')
-        self.file_sequence = ftp.download_files('fasta')
+        ftp = ftp_loader.FTPLoaderNCBI(
+            dir_output, species, genome_assembly, annotation_release
+        )
+        self.file_annotation = ftp.download_files("gtf")
+        self.file_sequence = ftp.download_files("fasta")
         self.annotation = gtfparse.read_gtf(self.file_annotation)
-    
-    def create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
-        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
+
+    def create_reference_DB(
+        self,
+        genome=False,
+        gene_transcript=True,
+        gene_CDS=False,
+        dir_output="./output/annotation",
+        block_size=None,
+    ):
+        """Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements.
 
         :param genome: create the reference file for the whole genome, defaults to False
         :type genome: bool, optional
@@ -687,14 +1078,26 @@ class NcbiDB(BaseDB):
         :type dir_output: str, optional
         :param block_size: size of the exon junctions, defaults to None
         :type block_size: int, optional
-        '''
+        """
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_reference_DB = os.path.join(dir_output, f'reference_DB_{self.species}_{self.genome_assembly}_NCBI_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}')
-        self._create_reference_DB(genome, gene_transcript, gene_CDS, dir_output, block_size)
+        self.file_reference_DB = os.path.join(
+            dir_output,
+            f"reference_DB_{self.species}_{self.genome_assembly}_NCBI_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}",
+        )
+        self._create_reference_DB(
+            genome, gene_transcript, gene_CDS, dir_output, block_size
+        )
 
-    def create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
-        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+    def create_oligos_DB(
+        self,
+        genes=None,
+        region="gene_transcript",
+        number_batchs=1,
+        dir_output="./output/annotation",
+        write=True,
+    ):
+        """creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then
         will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
 
         :param genes: genes for which compute the probes, defaults to None
@@ -707,18 +1110,30 @@ class NcbiDB(BaseDB):
         :type dir_output: str, optional
         :param write: write the file, defaults to True
         :type write: bool, optional
-        '''
+        """
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_oligos_DB = os.path.join(dir_output, f'oligo_DB_{self.species}_{self.genome_assembly}_NCBI_release_{self.annotation_release}_{region}')
+        self.file_oligos_DB = os.path.join(
+            dir_output,
+            f"oligo_DB_{self.species}_{self.genome_assembly}_NCBI_release_{self.annotation_release}_{region}",
+        )
         self._create_oligos_DB(genes, region, number_batchs, dir_output, write)
 
 
 class EnsemblDB(BaseDB):
-    '''Class to create reference and oligos DB using gtf and fasta files taken from the Ensembl server'''
+    """Class to create reference and oligos DB using gtf and fasta files taken from the Ensembl server"""
 
-    def __init__(self, probe_length_min, probe_length_max, species = None, genome_assembly = None, annotation_release = None,  dir_output='./output/annotation', filters = None):
-        '''Sets species, genome_assembly, annotation_release to a predefined value if thay are not given in input
+    def __init__(
+        self,
+        probe_length_min,
+        probe_length_max,
+        species=None,
+        genome_assembly=None,
+        annotation_release=None,
+        dir_output="./output/annotation",
+        filters=None,
+    ):
+        """Sets species, genome_assembly, annotation_release to a predefined value if thay are not given in input
             Dowloads the fasta and annotation files from the Ensemble server and stores them in the dir_output folder
 
         :param probe_length_min: minimum length of the probes created
@@ -735,29 +1150,48 @@ class EnsemblDB(BaseDB):
         :type dir_output: str, optional
         :param filters: list of filters classes already initialized, defaults to None
         :type filters: list of classes, optional
-        '''
-        if species is None: #change to some standard values for Ensemble
-            species = 'human'
-            warnings.warn(f'No species defined. Using default species {species}!')
+        """
+        if species is None:  # change to some standard values for Ensemble
+            species = "human"
+            warnings.warn(f"No species defined. Using default species {species}!")
 
         if genome_assembly is None:
-            genome_assembly = 'hg38'
-            warnings.warn(f'No genome assembly defined. Using default assembly {genome_assembly}!')
+            genome_assembly = "hg38"
+            warnings.warn(
+                f"No genome assembly defined. Using default assembly {genome_assembly}!"
+            )
 
         if annotation_release is None:
-            annotation_release = 'current'
-            warnings.warn(f'No annotation release defined. Using default release {annotation_release}!')
-        
-        super().__init__(probe_length_min, probe_length_max, species, genome_assembly, annotation_release)
+            annotation_release = "current"
+            warnings.warn(
+                f"No annotation release defined. Using default release {annotation_release}!"
+            )
+
+        super().__init__(
+            probe_length_min,
+            probe_length_max,
+            species,
+            genome_assembly,
+            annotation_release,
+        )
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        ftp = ftp_loader.FtpLoaderEnsembl(species, dir_output, genome_assembly, annotation_release)
-        self.file_annotation = ftp.download_files('gtf')
-        self.file_sequence = ftp.download_files('fasta')
+        ftp = ftp_loader.FtpLoaderEnsembl(
+            species, dir_output, genome_assembly, annotation_release
+        )
+        self.file_annotation = ftp.download_files("gtf")
+        self.file_sequence = ftp.download_files("fasta")
         self.annotation = gtfparse.read_gtf(self.file_annotation)
 
-    def create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
-        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
+    def create_reference_DB(
+        self,
+        genome=False,
+        gene_transcript=True,
+        gene_CDS=False,
+        dir_output="./output/annotation",
+        block_size=None,
+    ):
+        """Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements.
 
         :param genome: create the reference file for the whole genome, defaults to False
         :type genome: bool, optional
@@ -769,14 +1203,26 @@ class EnsemblDB(BaseDB):
         :type dir_output: str, optional
         :param block_size: size of the exon junctions, defaults to None
         :type block_size: int, optional
-        '''
+        """
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_reference_DB = os.path.join(dir_output, f'reference_DB_{self.species}_{self.genome_assembly}_Ensembl_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}')
-        self._create_reference_DB(genome, gene_transcript, gene_CDS, dir_output, block_size)
+        self.file_reference_DB = os.path.join(
+            dir_output,
+            f"reference_DB_{self.species}_{self.genome_assembly}_Ensembl_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}",
+        )
+        self._create_reference_DB(
+            genome, gene_transcript, gene_CDS, dir_output, block_size
+        )
 
-    def create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
-        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+    def create_oligos_DB(
+        self,
+        genes=None,
+        region="gene_transcript",
+        number_batchs=1,
+        dir_output="./output/annotation",
+        write=True,
+    ):
+        """creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then
         will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
 
         :param genes: genes for which compute the probes, defaults to None
@@ -789,18 +1235,31 @@ class EnsemblDB(BaseDB):
         :type dir_output: str, optional
         :param write: write the file, defaults to True
         :type write: bool, optional
-        '''
+        """
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_oligos_DB = os.path.join(dir_output, f'oligo_DB_{self.species}_{self.genome_assembly}_Ensembl_release_{self.annotation_release}_{region}')
+        self.file_oligos_DB = os.path.join(
+            dir_output,
+            f"oligo_DB_{self.species}_{self.genome_assembly}_Ensembl_release_{self.annotation_release}_{region}",
+        )
         self._create_oligos_DB(genes, region, number_batchs, dir_output, write)
 
 
 class CustomDB(BaseDB):
-    '''Class to create reference and oligos DB where gtf and fasta files are given by the user'''
+    """Class to create reference and oligos DB where gtf and fasta files are given by the user"""
 
-    def __init__(self, probe_length_min, probe_length_max, species=None, genome_assembly=None, annotation_release=None, file_annotation = None, file_sequence = None, filters = None):
-        '''Sets species, genome_assembly, annotation_release to 'unknown' if thay are not given in input
+    def __init__(
+        self,
+        probe_length_min,
+        probe_length_max,
+        species=None,
+        genome_assembly=None,
+        annotation_release=None,
+        file_annotation=None,
+        file_sequence=None,
+        filters=None,
+    ):
+        """Sets species, genome_assembly, annotation_release to 'unknown' if thay are not given in input
             Saves the path of the user defined annoation and fasta file
 
         :param probe_length_min: minimum length of the probes created
@@ -819,40 +1278,54 @@ class CustomDB(BaseDB):
         :type file_sequence: str, optional
         :param filters: list of filters classes already initialized, defaults to None
         :type filters: list of classes, optional
-        '''
+        """
         if species is None:
-            species = 'unknown'
-            warnings.warn(f'Species not specified.')
+            species = "unknown"
+            warnings.warn(f"Species not specified.")
 
         if genome_assembly is None:
-            genome_assembly = 'unknown'
-            warnings.warn(f'Genome assembly not specified.')
+            genome_assembly = "unknown"
+            warnings.warn(f"Genome assembly not specified.")
 
         if annotation_release is None:
-            annotation_release = 'unknown'
-            warnings.warn(f'Annotation release not specified.')
+            annotation_release = "unknown"
+            warnings.warn(f"Annotation release not specified.")
 
-        super().__init__(probe_length_min, probe_length_max, species, genome_assembly, annotation_release, filters)
+        super().__init__(
+            probe_length_min,
+            probe_length_max,
+            species,
+            genome_assembly,
+            annotation_release,
+            filters,
+        )
 
         # check the filles format
         if file_annotation == None:
-            raise ValueError('Annotation File not defined!')
-        
+            raise ValueError("Annotation File not defined!")
+
         if file_sequence == None:
-            raise ValueError('Sequence File not defined!')
+            raise ValueError("Sequence File not defined!")
 
         if not data_parser.check_gtf_format(file_annotation):
-            raise ValueError('Annotation File has incorrect format!')
-                
+            raise ValueError("Annotation File has incorrect format!")
+
         if not data_parser.check_fasta_format(file_sequence):
-            raise ValueError('Sequence File has incorrect format!')
-        
+            raise ValueError("Sequence File has incorrect format!")
+
         self.file_annotation = file_annotation
         self.file_sequence = file_sequence
         self.annotation = gtfparse.read_gtf(self.file_annotation)
 
-    def create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
-        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
+    def create_reference_DB(
+        self,
+        genome=False,
+        gene_transcript=True,
+        gene_CDS=False,
+        dir_output="./output/annotation",
+        block_size=None,
+    ):
+        """Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements.
 
         :param genome: create the reference file for the whole genome, defaults to False
         :type genome: bool, optional
@@ -864,14 +1337,26 @@ class CustomDB(BaseDB):
         :type dir_output: str, optional
         :param block_size: size of the exon junctions, defaults to None
         :type block_size: int, optional
-        '''
+        """
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_reference_DB = self.file_reference_DB = os.path.join(dir_output, f'reference_DB_{self.species}_{self.genome_assembly}_Custom_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}')
-        self._create_reference_DB(genome, gene_transcript, gene_CDS, dir_output, block_size)
+        self.file_reference_DB = self.file_reference_DB = os.path.join(
+            dir_output,
+            f"reference_DB_{self.species}_{self.genome_assembly}_Custom_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}",
+        )
+        self._create_reference_DB(
+            genome, gene_transcript, gene_CDS, dir_output, block_size
+        )
 
-    def create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
-        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+    def create_oligos_DB(
+        self,
+        genes=None,
+        region="gene_transcript",
+        number_batchs=1,
+        dir_output="./output/annotation",
+        write=True,
+    ):
+        """creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then
         will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
 
         :param genes: genes for which compute the probes, defaults to None
@@ -884,8 +1369,11 @@ class CustomDB(BaseDB):
         :type dir_output: str, optional
         :param write: write the file, defaults to True
         :type write: bool, optional
-        '''
+        """
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_oligos_DB = os.path.join(dir_output, f'oligo_DB_{self.species}_{self.genome_assembly}_Custom_release_{self.annotation_release}_{region}')
+        self.file_oligos_DB = os.path.join(
+            dir_output,
+            f"oligo_DB_{self.species}_{self.genome_assembly}_Custom_release_{self.annotation_release}_{region}",
+        )
         self._create_oligos_DB(genes, region, number_batchs, dir_output, write)

--- a/oligo_designer_toolsuite/IO/_database.py
+++ b/oligo_designer_toolsuite/IO/_database.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import _data_parser as data_parser
 import _ftp_loader as ftp_loader
-import gtfparse
 import pandas as pd
 import pyfaidx
 from Bio import SeqIO
@@ -1056,7 +1055,7 @@ class NcbiDB(BaseDB):
         )
         self.file_annotation = ftp.download_files("gtf")
         self.file_sequence = ftp.download_files("fasta")
-        self.annotation = gtfparse.read_gtf(self.file_annotation)
+        self.annotation = data_parser.read_gtf(self.file_annotation)
 
     def create_reference_DB(
         self,
@@ -1181,7 +1180,7 @@ class EnsemblDB(BaseDB):
         )
         self.file_annotation = ftp.download_files("gtf")
         self.file_sequence = ftp.download_files("fasta")
-        self.annotation = gtfparse.read_gtf(self.file_annotation)
+        self.annotation = data_parser.read_gtf(self.file_annotation)
 
     def create_reference_DB(
         self,
@@ -1315,7 +1314,7 @@ class CustomDB(BaseDB):
 
         self.file_annotation = file_annotation
         self.file_sequence = file_sequence
-        self.annotation = gtfparse.read_gtf(self.file_annotation)
+        self.annotation = data_parser.read_gtf(self.file_annotation)
 
     def create_reference_DB(
         self,

--- a/oligo_designer_toolsuite/IO/_database.py
+++ b/oligo_designer_toolsuite/IO/_database.py
@@ -1,332 +1,891 @@
+import pandas as pd
 import os
+import warnings
 import random
 import shutil
-import warnings
 from pathlib import Path
 
-import oligo_designer_toolsuite.IO._data_parser as data_parser
-import oligo_designer_toolsuite.IO._ftp_loader as ftp_loader
+import pyfaidx
+import gtfparse
+from Bio import SeqIO
+
+import _ftp_loader as ftp_loader
+import _data_parser as data_parser
+#import the filters class
 
 
-class BaseDB:
-    """_summary_"""
+class BaseDB():
+    '''This class generates all possible guides that can be designed for a given list of genes, 
+    based on the transcriptome annotation or of those genes and the reference fasta file.
+    '''
+    def __init__(self, probe_length_min, probe_length_max, species = None, genome_assembly = None, annotation_release = None, filters = None):
+        '''Initializes the class.
 
-    def __init__(self) -> None:
+        :param probe_length_min: minimum length of the probes created
+        :type probe_length_min: int
+        :param probe_length_max: maximum length of the probes created
+        :type probe_length_max: int
+        :param species: species of the files to dowload, defaults to None
+        :type species: str, optional
+        :param genome_assembly: genome_assembly of the files to dowload, defaults to None
+        :type genome_assembly: str, optional
+        :param annotation_release: annotation_release of the files to dowload, defaults to None
+        :type annotation_release: str, optional
+        :param filters: list of filters classes already initialized, defaults to None
+        :type filters: list of classes, optional
+        '''
+       
+        self.species = species
+        self.genome_assembly = genome_assembly
+        self.annotation_release = annotation_release
+        self.filters = filters
+        self.probe_length_max = probe_length_max
+        self.probe_length_min = probe_length_min
 
-        self.species = "human"
-        self.genome_assembly = "GRCh38"
-        self.annotation_release = "current"
+        self.annotation = None # dataframe containing the gene annotation
+        self.file_reference_DB = None
+        self.file_oligos_DB = None
+        self.oligos_DB = None
+        self.file_annotation = None
+        self.file_sequence = None
 
-    def read_DB(self, file_DB):
-        if os.path.exists(file_DB):
-            if data_parser.check_fasta_format(file_DB):
-                self.file_DB = file_DB
+    def read_reference_DB(self, file_reference_DB):
+        '''Saves the path of a previously generated reference DB in the <self.file_reference_DB> attribute.
+
+        :param file_reference_DB: path of the reference_DB file
+        :type file_reference_DB: str
+        '''
+        if os.path.exists(file_reference_DB):
+            if data_parser.check_fasta_format(file_reference_DB):
+                self.file_reference_DB = file_reference_DB
             else:
-                raise ValueError("Database has incorrect format!")
+                raise ValueError('Database has incorrect format!')
         else:
-            raise ValueError("Database file does not exist!")
+            raise ValueError('Database file does not exist!')
 
-    def download_annotation(
-        self,
-        species,
-        genome_assembly,
-        annotation_source,
-        annotation_release,
-        dir_output,
-    ):
+    def read_oligos_DB(self, file_oligos_DB):
+        '''Reads a previously generated oligos DB and saves it in the <self.oligos_DB> attribute as a dictionary.
+        The order of columns is : gene_id, probe_sequence, 'transcript_id', 'exon_id', 'chromosome', 'start', 'end', 'strand', all the additional info computed by the filtersing class.
+
+        :param file_oligos_DB: path of the oligos_DB file
+        :type file_oligos_DB: str
+        '''
+        if os.path.exists(file_oligos_DB):
+            if data_parser.check_tsv_format(file_oligos_DB):
+                self.file_oligos_DB = file_oligos_DB
+            else:
+                raise ValueError('Database has incorrect format!')
+        else:
+            raise ValueError('Database file does not exist!')
+        if os.path.exists(file_oligos_DB):
+            self.file_oligos_DB = file_oligos_DB
+        else:
+            raise ValueError('Database file does not exist!')
+            
+        self.oligos_DB = {}
+        handle_probe = open(self.file_oligos_DB, 'r')
+        # read the header
+        line = handle_probe.readline()
+        columns = line.split('\t')
+        columns[-1] = columns[-1][0:-1] #delete \n in the last word
+        add_features = len(columns) > 8
+        # read the first line
+        line = handle_probe.readline()
+        line = line.split('\t')
+        line[-1] = line[-1][0:-1] #delete \n of the last word
+        current_gene = line[0]
+        sequence = line[1]
+        self.oligos_DB[current_gene] = {}
+        self.oligos_DB[current_gene][sequence] = {}
+        self.oligos_DB[current_gene][sequence]['transcript_id'] = line[2].split(';')
+        self.oligos_DB[current_gene][sequence]['exon_id'] = line[3].split(';')
+        self.oligos_DB[current_gene][sequence]['chromosome'] = line[4]
+        self.oligos_DB[current_gene][sequence]['start'] = line[5].split(';')
+        self.oligos_DB[current_gene][sequence]['end'] = line[6].split(';')
+        self.oligos_DB[current_gene][sequence]['strand'] = line[7]
+        #retrive the remaining features if they were computed
+        if add_features:
+                for i, column in enumerate(columns[8:]):
+                    self.oligos_DB[current_gene][sequence][column] = line[i+8]
+        # read the rest of the file
+        for line in handle_probe:
+            line = line.split('\t')
+            line[-1] = line[-1][0:-1]
+            if line[0] != current_gene:
+                current_gene = line[0]
+                self.oligos_DB[current_gene] = {}
+            sequence = line[1]
+            # what if we have duplicated sequences?
+            self.oligos_DB[current_gene][sequence] = {}
+            self.oligos_DB[current_gene][sequence]['transcript_id'] = line[2].split(';')
+            self.oligos_DB[current_gene][sequence]['exon_id'] = line[3].split(';')
+            self.oligos_DB[current_gene][sequence]['chromosome'] = line[4]
+            self.oligos_DB[current_gene][sequence]['start'] = line[5].split(';')
+            self.oligos_DB[current_gene][sequence]['end'] = line[6].split(';')
+            self.oligos_DB[current_gene][sequence]['strand'] = line[7]
+            #retrive the remaining features if they were computed
+            if add_features:
+                    for i, column in enumerate(columns[8:]):
+                        self.oligos_DB[current_gene][sequence][column] = line[i+8]
+                    
+        handle_probe.close() 
+
+    def write_oligos_DB(self):
+        '''Writes the data structure self.oligos_DB in a tsv file in the <self.file_oligos_DB> path. 
+        The order of columns is : gene_id, probe_sequence, 'transcript_id', 'exon_id', 'chromosome', 'start', 'end', 'strand', all the additional info computed by the filtersing class.
+        '''
+        
+        with open(self.file_oligos_DB, 'w') as handle_probe:
+            columns =['gene_id', 'probe_sequence']
+            #find all the other names of the columns (depend on the filterss applied)
+            tmp = list(self.oligos_DB.values())[0]
+            tmp = list(list(tmp.values())[0].keys())
+            columns.extend(tmp)
+            print(columns)
+            handle_probe.write("\t".join(columns)+"\n")
+
+            for gene_id, probe in self.oligos_DB.items():
+                for probe_sequence, probe_attributes in probe.items():
+                    # write the basic information information we compute for each probe
+                    output = '{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}'.format(gene_id, probe_sequence, ';'.join(probe_attributes['transcript_id']), 
+                        ';'.join(probe_attributes['exon_id']), probe_attributes['chromosome'], ';'.join(str(s) for s in probe_attributes['start']), 
+                        ';'.join(str(e) for e in probe_attributes['end']), probe_attributes['strand'])
+                    # if we computed additional features we write also those
+                    if len(columns) > 8:
+                        for column in columns[8:]:
+                            output += '\t{}'.format(probe_attributes[column])
+                        # \n at the end f the string
+                    output += '\n'
+                    handle_probe.write(output)
+
+    def _create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
+        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
+        If not specified the exon juctions size is set to <probe_length_max> + 5.
+
+        :param genome: create the reference file for the whole genome, defaults to False
+        :type genome: bool, optional
+        :param gene_transcript: create the reference file for the gene transcript, defaults to True
+        :type gene_transcript: bool, optional
+        :param gene_CDS: create the reference file for the coding region, defaults to False
+        :type gene_CDS: bool, optional
+        :param dir_output: folder where the fasta file will be saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param block_size: size of the exon junctions, defaults to None
+        :type block_size: int, optional
+        '''
+        def get_files_fasta():
+            '''generates the fasta files that will compose the reference_DB
+
+            :return: list of the fasta files
+            :rtype: list of str
+            '''
+            files_fasta = []
+            if genome:
+                file_genome = os.path.join(dir_output,'genome.fna')
+                shutil.copyfile(self.file_sequence, file_genome)
+                files_fasta.append(file_genome)
+            if gene_transcript:
+                file_gene_transcript_annotation, file_gene_transcript_fasta = self.__generate_gene_transcript(block_size, False, dir_output)
+                os.remove(file_gene_transcript_annotation) #not required anymore in this case
+                files_fasta.append(file_gene_transcript_fasta)
+            if gene_CDS:
+                #generate gene cds
+                warnings.warn('Gene CDS not implemented yet')
+            return files_fasta
+
+        if block_size is None: #when not specified define it automatically
+                block_size = self.probe_length_max + 5
+
+        files_fasta = get_files_fasta()
+        data_parser.merge_fasta(files_fasta, self.file_reference_DB)
+
+    def __generate_gene_transcript(self, block_size, oligos, dir_output = './output/annotation'):
+        '''Creates a fasta file containing the whole transcriptome. The file contains also the exon junctions, which are the union of two consecuteive exons and 
+        for each exon we consider only the last/ first <block_size> base pairs. The required compoutations are different between for the transcriptome for the reference and 
+        the oligos sequences, the variable <oligos> defines which computations should be made.
+
+        :param block_size: size of the exon juctions
+        :type block_size: int
+        :param oligos: coputations for oligos or reference
+        :type oligos: bool
+        :param dir_output: folder where the fasta file will be saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        '''
+
+        def _load_exon_annotation():
+            '''Retrive exon annotation from loaded gene annotation.
+
+            :return: Exon annotation
+            :rtype: pandas.DataFrame
+            '''
+            exon_annotation = self.annotation.loc[self.annotation['feature'] == 'exon']
+            exon_annotation = exon_annotation.assign(source='unknown')
+
+            if not 'exon_id' in exon_annotation.columns:
+                exon_annotation['exon_id'] = exon_annotation['transcript_id'] + '_exon' + exon_annotation['exon_number']
+            
+            #there are some exon annotations which have the same start and end coordinates and can't be saved as fasta from bedtools
+            exon_annotation = exon_annotation[(exon_annotation.end - exon_annotation.start) > 0] 
+            exon_annotation.reset_index(inplace=True, drop=True)
+            exon_annotation['start'] -= 1
+
+            return exon_annotation
+    
+        def _load_unique_exons(exon_annotation):
+            '''Merge overlapping exons, which have the same start and end coordinates. 
+            Save transcript information for those exons.
+
+            :param exon_annotation: Exon annotation
+            :type exon_annotation: pandas.DataFrame
+            :return: Merged exon annotation
+            :rtype: pandas.DataFrame
+            '''
+
+            exon_annotation['region'] = (exon_annotation['seqname'] + '_' + exon_annotation['start'].astype('str') + '_' + 
+                                         exon_annotation['end'].astype('str') + '_' + exon_annotation['strand'])
+            
+            aggregate_function = {'gene_id': 'first', 'transcript_id': ':'.join, 'exon_id': ':'.join, 
+                                  'seqname': 'first', 'start': 'first', 'end': 'first', 'score': 'first', 'strand': 'first'}
+            merged_exons = exon_annotation.groupby(exon_annotation['region']).aggregate(aggregate_function)
+            
+            merged_exons['score'] = 0
+            merged_exons['thickStart'] = merged_exons['start']
+            merged_exons['thickEnd'] = merged_exons['end']
+            merged_exons['itemRgb'] = 0
+            merged_exons['blockCount'] = 1
+            merged_exons['block_sizes'] = merged_exons['end'] - merged_exons['start']
+            merged_exons['blockStarts'] = 0
+            merged_exons['gene_transcript_exon_id'] = (merged_exons['gene_id'] + '_tid' + 
+                                                       merged_exons['transcript_id'] + '_eid' + 
+                                                       merged_exons['exon_id'])
+            merged_exons = merged_exons[['gene_id','gene_transcript_exon_id','seqname','start','end','score','strand',
+                                         'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes','blockStarts']]
+
+            return merged_exons
+
+        def _merge_containing_exons(unique_exons):
+            '''Merge exons that are contained in a larger exon, e.g. have the same start coordinates but different end coordinates, into one entry.
+
+            :param unique_exons: Dataframe with annotation of unique exons, where overlapping exons are merged.
+            :type unique_exons: pandas.DataFrame
+            :return: Dataframe with annotation of merged exons, where containing exons are merged.
+            :rtype: pandas.DataFrame
+            '''
+
+            aggregate_function = {'gene_id': 'first', 'gene_transcript_exon_id': ':'.join, 
+                                  'seqname': 'first', 'start': 'min', 'end': 'max', 'score': 'first', 'strand': 'first',
+                                  'thickStart': 'min','thickEnd': 'max', 'itemRgb': 'first',
+                                  'blockCount': 'first','block_sizes': 'max','blockStarts': 'first'}
+            
+            unique_exons['region_start'] = (unique_exons['seqname'] + '_' + unique_exons['start'].astype('str') + '_' + unique_exons['strand'])
+            merged_unique_exons = unique_exons.groupby(unique_exons['region_start']).aggregate(aggregate_function)
+            
+            merged_unique_exons['region_end'] = (merged_unique_exons['seqname'] + '_' + merged_unique_exons['end'].astype('str') + '_' + merged_unique_exons['strand'])
+            merged_unique_exons = merged_unique_exons.groupby(merged_unique_exons['region_end']).aggregate(aggregate_function)
+            
+            return merged_unique_exons
+
+        def _load_exon_junctions(block_size, exon_annotation):
+            '''Get all possible exon junctions from the transcript annotation.
+            Merge overlapping exons jucntions, which have the same satrt and end coordinates.
+            Save transcript information for those exons.
+
+            :param block_size: Size of the exon junction regions, i.e. <block_size> bp upstream of first exon 
+                and <block_size> bp downstream of second exon.
+            :type block_size: int
+            :return: Dataframe with annotation of exons junctions, where overlapping exons junctions are merged.
+            :rtype: pandas.DataFrame
+            '''
+            transcript_exons, transcript_info = _get_transcript_exons_and_info(exon_annotation)
+            exon_junction_list = _get_exon_junction_list(block_size, transcript_exons, transcript_info)
+            
+            exon_junctions = pd.DataFrame(exon_junction_list, 
+                                          columns=['region', 'gene_id', 'transcript_id', 'exon_id', 'seqname', 'start', 'end', 'score', 'strand', 
+                                                   'thickStart', 'thickEnd', 'itemRgb', 'blockCount', 'block_sizes', 'blockStarts'])
+            aggregate_function = {'gene_id': 'first', 'transcript_id': ':'.join, 'exon_id': ':'.join, 
+                                  'seqname': 'first', 'start': 'first', 'end': 'first', 'score': 'first', 'strand': 'first', 
+                                  'thickStart': 'first', 'thickEnd': 'first', 'itemRgb': 'first', 'blockCount': 'first', 'block_sizes': 'first', 'blockStarts': 'first'}     
+            merged_exon_junctions = exon_junctions.groupby(exon_junctions['region']).aggregate(aggregate_function)
+            
+            merged_exon_junctions['gene_transcript_exon_id'] = (merged_exon_junctions['gene_id'] + '_tid' + 
+                                                                merged_exon_junctions['transcript_id'] + '_eid' + 
+                                                                merged_exon_junctions['exon_id'])
+            merged_exon_junctions = merged_exon_junctions[['gene_id','gene_transcript_exon_id','seqname','start','end','score','strand',
+                                                           'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes','blockStarts']]
+
+            return merged_exon_junctions
+
+        def _get_transcript_exons_and_info(exon_annotation):
+            '''Get list of exons that belong to a transcript. 
+            Save information about each transcript, i.e. gene ID, chromosome and strand.
+            
+            :param exon_annotation: Exon annotation.
+            :type exon_annotation: pandas.DataFrame
+            :return: Two dictionaries: transcript - exon mapping and transcript information.
+            :rtype: dict
+            '''
+            transcripts = self.annotation.loc[self.annotation["transcript_id"] != '']
+            transcripts = sorted(list(transcripts['transcript_id'].unique()))
+            transcript_exons = {key: {} for key in transcripts}
+            transcript_info = dict()
+            
+            for (transcript_id, exon_number, exon_id, start, end, gene_id, seqname, strand) in zip(exon_annotation['transcript_id'], exon_annotation['exon_number'], exon_annotation['exon_id'], exon_annotation['start'], exon_annotation['end'], exon_annotation['gene_id'], exon_annotation['seqname'], exon_annotation['strand']):
+                transcript_exons[transcript_id][int(exon_number)] = [exon_id, start, end]
+                transcript_info[transcript_id] = [gene_id, seqname, strand]
+                
+            if not ('transcript' in self.annotation['feature'].values):
+                delete_ids = []
+                for transcript_id in transcript_exons:
+                    if transcript_id not in transcript_info:
+                        delete_ids.append(transcript_id)
+                for transcript_id in delete_ids:
+                    del transcript_exons[transcript_id]
+                
+            return transcript_exons, transcript_info
+
+        def _get_exon_junction_list(block_size, transcript_exons, transcript_info):
+            '''Get list of all possible exon junctions and save all required information for bed12 file.
+
+            :param block_size: Size of the exon junction regions, i.e. <block_size> bp upstream of first exon 
+                and <block_size> bp downstream of second exon.
+            :type block_size: int
+            :param transcript_exons: Transcript - exon mapping.
+            :type transcript_exons: dict
+            :param transcript_info: Transcript information.
+            :type transcript_info: dict
+            :return: List of exon junctions.
+            :rtype: list
+            '''
+            exon_junction_list = []
+
+            for transcript, exons in transcript_exons.items():
+                gene_id = transcript_info[transcript][0]
+                seqname = transcript_info[transcript][1]
+                strand = transcript_info[transcript][2]
+
+                if strand == '+':
+                    exons = [entry[1] for entry in sorted(exons.items())] #return only exon attributes sorted by exon number
+                elif strand == '-':
+                    exons = [entry[1] for entry in sorted(exons.items(), reverse=True)] #return only exon attributes sorted by exon number -> reverse sort on minus strand
+                
+                for idx, attributes in enumerate(exons):
+                    if idx == 0: #first exon of transcript
+                        exon_upstream = attributes
+                        exons_small = []
+                    elif ((idx+1) < len(exons)) & ((attributes[2] - attributes[1]) < block_size): #if exon is not the last exon of transcript and shorter than probe block_size but not the last exon -> create sequence with neighboring exons
+                        exons_small.append(attributes)
+                    else:
+                        exon_downstream = attributes
+                        block_size_up = min(block_size, (exon_upstream[2] - exon_upstream[1])) #catch case that first or last exon < block_size
+                        block_size_down = min(block_size, (exon_downstream[2] - exon_downstream[1])) #catch case that first or last exon < block_size
+                        start_up = exon_upstream[2] - block_size_up
+                        end_down = exon_downstream[1] + block_size_down
+                        
+                        if exons_small == []:
+                            blockCount = 2
+                            block_size_length_entry = '{},{}'.format(block_size_up, block_size_down)
+                            block_size_start_entry = '{},{}'.format(0, exon_downstream[1] - start_up)
+                        else:
+                            blockCount = len(exons_small) + 2
+                            block_size_length_entry = str(block_size_up) + ',' + ','.join([str(attributes[2] - attributes[1]) for attributes in exons_small]) + ',' + str(block_size_down) 
+                            block_size_start_entry = '0,' + ','.join([str(attributes[1] - start_up,) for attributes in exons_small]) + ',' + str(exon_downstream[1] - start_up) 
+                            exons_small = []
+
+                        exon_junction_list.append(['{}_{}_{}_{}'.format(seqname, start_up, end_down, strand), gene_id, transcript, '{}_{}'.format(exon_upstream[0], exon_downstream[0]),
+                                                    seqname, start_up, end_down, 0, strand, start_up, end_down, 0, blockCount, block_size_length_entry, block_size_start_entry])
+                        exon_upstream = attributes
+            
+            return exon_junction_list
+        
+        # get annotation of exons and  
+        exons_annotation = _load_exon_annotation()
+        # merge exon annotations for the same region
+        unique_exons = _load_unique_exons(exons_annotation)
+        if not oligos: # only for the reference class
+            unique_exons = _merge_containing_exons(unique_exons)
+        # get exon junction annotation
+        exon_junctions_probes = _load_exon_junctions(block_size, exons_annotation)
+        # concatenate the two annotations
+        gene_transcript_annotation = pd.concat([unique_exons, exon_junctions_probes])
+        gene_transcript_annotation = gene_transcript_annotation.sort_values(by=['gene_id'])
+        gene_transcript_annotation.reset_index(inplace=True, drop=True)
+        # save the gene transcript annotation
+        file_gene_transcript_annotation = os.path.join(dir_output, 'gene_transcript.bed')
+        # for the oligos we don't need the fasta file and we need the gene, transcript, exon informations
+        if oligos:
+            file_gene_transcript_fasta = None
+            gene_transcript_annotation[['seqname','start','end', 'gene_id', 'gene_transcript_exon_id','score','strand',
+                                    'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes',
+                                    'blockStarts']].to_csv(file_gene_transcript_annotation, sep='\t', header=False, index = False)
+        else:
+            gene_transcript_annotation[['seqname','start','end', 'gene_id','score','strand',
+                                    'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes',
+                                    'blockStarts']].to_csv(file_gene_transcript_annotation, sep='\t', header=False, index = False)
+            # create the fasta file 
+            file_gene_transcript_fasta = os.path.join(dir_output, 'gene_transcript.fasta')
+            data_parser.get_sequence_from_annotation(file_gene_transcript_annotation, self.file_sequence, file_gene_transcript_fasta, split=True)
+
+        return file_gene_transcript_annotation, file_gene_transcript_fasta
+
+    def __generate_gene_CDS():
+        ''''Creates a fasta file containing the whole transcriptome.'''
+        pass
+
+    def _create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
+        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+        will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
+
+        :param genes: genes for which compute the probes, defaults to None
+        :type genes: list of str, optional
+        :param region: region ofrm whihc generate the probes, it can be 'genome', 'gene_transcript', 'gene_CDS', defaults to 'gene_transcript'
+        :type region: str, optional
+        :param number_batchs: probes are computes in batches of genes, defaults to 1
+        :type number_batchs: int, optional
+        :param dir_output: folder where the file will be written, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param write: write the file, defaults to True
+        :type write: bool, optional
+        '''
+
+        def create_target_region():
+            '''cretares the annotation file for the specified region.
+            '''
+
+            if region == 'genome':
+                file_region_annotation = None
+                #TODO
+            elif region == 'gene_transcript':
+                file_region_annotation, _ = self.__generate_gene_transcript(self.probe_length_max - 1, True, dir_output)
+            elif region == 'gene_CDS':
+                file_region_annotation = None
+                #TODO
+            else:
+                raise ValueError(f'The given region does not exists. You selected {region}')
+            return file_region_annotation
+
+        def get_gene_list_from_annotation():
+            '''generates all the different genes in the annotation file of the specified region.
+            '''
+
+            genes = self.annotation.loc[self.annotation['feature'] == 'gene']
+            genes = list(genes['gene_id'].unique())
+            random.shuffle(genes)
+            return genes
+
+        file_region_annotation = create_target_region()
+        if genes is None:
+           genes = get_gene_list_from_annotation()
+        self.oligos_DB = self.__generate_oligos(file_region_annotation, genes, number_batchs, dir_output) 
+        if write:
+            self.write_oligos_DB()
+
+        #clean folder
+        os.remove(file_region_annotation)
+
+    def __generate_oligos(self,file_region_annotation, genes, number_batchs, dir_output = './output/annotation'):
+        '''Get the fasta sequence of all possible probes with user-defined length for all input genes and store the in a dictionary. 
+        Generated probes are filtered by the filters give in input and the features computed for the  filters are added to the dictionary.
+
+        :param file_region_annotation: path to the gtf annotaiton file of the region 
+        :type file_region_annotation: str
+        :param genes: genes for which the probes are computed
+        :type genes: list of str
+        :param number_batchs: probes are computed for a batch of genes
+        :type number_batchs: int
+        :param dir_output: directory where temporary diles are written, defaults to './output/annotation'
+        :type dir_output: str, optional
+        '''
+
+        def _get_probes(batch_id, genes_batch):
+            '''Get the fasta sequence of all possible probes for all genes in the batch.
+
+            :param batch_id: Batch ID.
+            :type batch_id: int
+            :param genes_batch: List of genes for which probes should be designed.
+            :type genes_batch: list
+            '''
+            
+            file_region_bed_batch = os.path.join(dir_output, 'region_batch{}.bed'.format(batch_id))
+            file_region_fasta_batch = os.path.join(dir_output, 'region_batch{}.fna'.format(batch_id))
+            
+            _get_region_fasta(genes_batch, file_region_bed_batch, file_region_fasta_batch)
+            gene_probes_batch = _get_probes_info(genes_batch, file_region_fasta_batch)
+
+            os.remove(file_region_bed_batch)
+            os.remove(file_region_fasta_batch)
+
+            return gene_probes_batch
+
+        def _get_region_fasta(genes_batch, file_region_bed_batch, file_region_fasta_batch):
+            '''Extract transcripts for the current batch and write transcript regions to bed file. 
+            Get sequence for annotated transcript regions (bed file) from genome sequence (fasta file) and write transcriptome sequences to fasta file.
+
+            :param genes_batch: List of genes for which probes should be designed.
+            :type genes_batch: list
+            :param file_region_bed_batch: Path to bed transcriptome annotation output file.
+            :type file_region_bed_batch: string
+            :param file_region_fasta_batch: Path to fasta transcriptome sequence output file.
+            :type file_region_fasta_batch: string
+            '''
+
+            region_annotation_batch = region_annotation.loc[region_annotation['gene_id'].isin(genes_batch)].copy()
+            region_annotation_batch = region_annotation_batch.sort_values(by=['gene_id'])
+            region_annotation_batch[['seqname','start','end', 'gene_transcript_exon_id','score','strand',
+                                            'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes',
+                                            'blockStarts']].to_csv(file_region_bed_batch, sep='\t', header=False, index = False)
+            
+            # get sequence for exons
+            data_parser.get_sequence_from_annotation(file_region_bed_batch, self.file_sequence, file_region_fasta_batch, split=True)
+
+        def _parse_header(header):
+            '''Helper function to parse the header of each exon fasta entry.
+
+            :param header: Header of fasta entry.
+            :type header: string
+            :return: Parsed header information, i.e.
+                gene_id, transcript_id, exon_id and position (chromosome, start, strand)
+            :rtype: string
+            '''
+
+            identifier = header.split('::')[0]
+            gene_id = identifier.split('_tid')[0]
+            transcript_id = identifier.split('_tid')[1].split('_eid')[0]
+            exon_id = identifier.split('_eid')[1]
+
+            coordinates = header.split('::')[1]
+            chrom = coordinates.split(':')[0]
+            start = int(coordinates.split(':')[1].split('-')[0])
+            strand = coordinates.split('(')[1].split(')')[0]
+
+            return gene_id, transcript_id, exon_id, chrom, start, strand
+        
+        def _get_probes_info(genes_batch, file_region_fasta_batch):
+            '''Merge all probes with identical sequence that come from the same gene into one fasta entry.
+            Filter all probes based on user-defined filters and collect the additional information about each probe. 
+
+            :param genes_batch: List of genes for which probes should be designed.
+            :type genes_batch: list
+            :param file_region_fasta_batch: Path to fasta transcriptome sequence output file.
+            :type file_region_fasta_batch: string
+            :return: Mapping of probes to corresponding genes with additional information about each probe, i.e.
+                position (chromosome, start, end, strand), gene_id, transcript_id, exon_id
+            :rtype: dict
+            '''
+
+            gene_probes = {key: {} for key in genes_batch}
+            total_probes = 0
+            loaded_probes = 0
+
+            # parse the exon fasta sequence file
+            for exon in SeqIO.parse(file_region_fasta_batch, "fasta"):
+                sequence = exon.seq
+
+                for probe_length in range(self.probe_length_min, self.probe_length_max + 1):
+                    if len(sequence) > probe_length:
+                        number_probes = len(sequence)-(probe_length-1)
+                        probes_sequence = [sequence[i:i+probe_length] for i in range(number_probes)]
+
+                        for i in range(number_probes):
+                            total_probes +=1
+                            probe_sequence = probes_sequence[i]
+     
+                            gene_id, transcript_id, exon_id, chrom, start, strand = _parse_header(exon.id)
+                            probe_start = start + i
+                            probe_end = start + i + probe_length
+
+                            # if we fulfill all the conditions, add the probe to the list of probes for this gene (still to implent)
+                            # fulfills, info = filter
+                            # if fulfills:  add the probe to the list of probes for this gene
+                            if probe_sequence in gene_probes[gene_id]:
+                                gene_probes[gene_id][probe_sequence]['transcript_id'].append(transcript_id)
+                                gene_probes[gene_id][probe_sequence]['exon_id'].append(exon_id)
+                                gene_probes[gene_id][probe_sequence]['start'].append(probe_start)
+                                gene_probes[gene_id][probe_sequence]['end'].append(probe_end)
+                            else:
+                                loaded_probes += 1
+                                gene_probes[gene_id][probe_sequence] = {'transcript_id': [transcript_id], 'exon_id': [exon_id], 'chromosome': chrom, 'start': [probe_start], 
+                                            'end': [probe_end], 'strand': strand}
+        
+            return gene_probes
+
+        # create index file
+        pyfaidx.Fasta(self.file_sequence)
+
+        region_annotation = pd.read_csv(file_region_annotation, sep='\t', names=['seqname','start','end', 'gene_id', 'gene_transcript_exon_id','score','strand',
+                                    'thickStart','thickEnd', 'itemRgb','blockCount','block_sizes', 'blockStarts'])
+
+        #keep the batch structure for parellalization
+        batch_size = int(len(genes) / number_batchs) + (len(genes) % number_batchs > 0)
+        probes = {}
+        for batch_id in range(number_batchs): 
+            genes_batch = genes[(batch_size * batch_id):(min(batch_size * (batch_id+1), len(genes)+1))]
+            probes.update(_get_probes(batch_id, genes_batch))
+
+        # remove index file
+        os.remove('{}.fai'.format(self.file_sequence))
+
+        return probes
+
+    def filter_oligos(self):
+        '''applies the used-defined filters.
+        '''
+        pass
+
+
+class NcbiDB(BaseDB):
+    '''Class to create reference and oligos DB using gtf and fasta files taken from the NCBI server'''
+
+    def __init__(self, probe_length_min, probe_length_max, species = None, genome_assembly = None, annotation_release = None, dir_output='./output/annotation', filters = None):
+        '''Sets species, genome_assembly, annotation_release to a predefined value if thay are not given in input
+            Dowloads the fasta and annotation files from the NCBI server and stores them in the dir_output folder
+
+        :param probe_length_min: minimum length of the probes created
+        :type probe_length_min: int
+        :param probe_length_max: maximum length of the probes created
+        :type probe_length_max: int
+        :param species: species of the files to dowload, defaults to None
+        :type species: str, optional
+        :param genome_assembly: genome_assembly of the files to dowload, defaults to None
+        :type genome_assembly: str, optional
+        :param annotation_release: annotation_release of the files to dowload, defaults to None
+        :type annotation_release: str, optional
+        :param dir_output: directory where the files are saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param filters: list of filters classes already initialized, defaults to None
+        :type filters: list of classes, optional
+        '''
         if species is None:
-            warnings.warn(f"No species defined. Using default species {self.species}!")
-            species = self.species
+            species = 'human'
+            warnings.warn(f'No species defined. Using default species {species}!')
 
         if genome_assembly is None:
-            warnings.warn(
-                f"No genome assembly defined. Using default assembly {self.genome_assembly}!"
-            )
-            genome_assembly = self.genome_assembly
+            genome_assembly = 'hg38'
+            warnings.warn(f'No genome assembly defined. Using default assembly {genome_assembly}!')
 
         if annotation_release is None:
-            warnings.warn(
-                f"No ncbi annotation release defined. Using default release {self.annotation_release}!"
-            )
-            annotation_release = self.annotation_release
+            annotation_release = 'current'
+            warnings.warn(f'No annotation release defined. Using default release {annotation_release}!')
 
-        if annotation_source == "NCBI":
-            FTP = ftp_loader.FTPLoaderNCBI(species, genome_assembly, annotation_release)
-        elif annotation_source == "ensemble":
-            FTP = ftp_loader.FtpLoaderEnsemble(
-                species, genome_assembly, annotation_release
-            )
+        super().__init__(probe_length_min, probe_length_max, species, genome_assembly, annotation_release)
+        
+        Path(dir_output).mkdir(parents=True, exist_ok=True)
+        ftp = ftp_loader.FTPLoaderNCBI(dir_output, species, genome_assembly, annotation_release)
+        self.file_annotation = ftp.download_files('gtf')
+        self.file_sequence = ftp.download_files('fasta')
+        self.annotation = gtfparse.read_gtf(self.file_annotation)
+    
+    def create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
+        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
 
-        file_annotation = FTP.download_gtf(dir_output)
-        file_sequence = FTP.download_fasta(dir_output)
-
-        return file_annotation, file_sequence
-
-    def _get_gene_transcript(
-        self, file_sequence, file_annotation, blockSize, dir_output
-    ):
-        pass
-
-    """
-    def _get_gene(self, file_sequence, file_annotation, dir_output):
-        pass
-
-    def _get_gene_CDS(self, file_sequence, file_annotation, blockSize, dir_output):
-        pass
-    """
-
-
-class ReferenceDB(BaseDB):
-    """_summary_"""
-
-    def __init__(self, blockSize=200) -> None:
-        super().__init__()
-
-        self.file_DB = None
-        self.blockSize = blockSize  # maximum oligo length of "long oligos" is 180
-
-    def create_DB_from_ncbi_annotation(
-        self,
-        species=None,
-        genome_assembly=None,
-        annotation_release=None,
-        genome=False,
-        gene_transcript=True,
-        dir_output="./annotation",
-    ):
+        :param genome: create the reference file for the whole genome, defaults to False
+        :type genome: bool, optional
+        :param gene_transcript: create the reference file for the gene transcript, defaults to True
+        :type gene_transcript: bool, optional
+        :param gene_CDS: create the reference file for the coding region, defaults to False
+        :type gene_CDS: bool, optional
+        :param dir_output: folder where the fasta file will be saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param block_size: size of the exon junctions, defaults to None
+        :type block_size: int, optional
+        '''
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
+        self.file_reference_DB = os.path.join(dir_output, f'reference_DB_{self.species}_{self.genome_assembly}_NCBI_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}')
+        self._create_reference_DB(genome, gene_transcript, gene_CDS, dir_output, block_size)
 
-        file_annotation, file_sequence = self.download_annotation(
-            species, genome_assembly, "NCBI", annotation_release, dir_output
-        )
-        files_fasta = self._get_fasta_files(
-            self,
-            genome,
-            gene_transcript,
-            file_sequence,
-            file_annotation,
-            self.blockSize,
-            dir_output,
-        )
+    def create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
+        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+        will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
 
-        self.file_DB = os.path.join(
-            dir_output,
-            f"reference_DB_{self.species}_{self.genome_assembly}_NCBI_release{self.annotation_release}_genome{genome}_gene_transcript{gene_transcript}",
-        )
-        data_parser.merge_fasta(files_fasta, self.file_DB)
-
-    def create_DB_from_ensemble_annotation(
-        self,
-        species=None,
-        genome_assembly=None,
-        annotation_release=None,
-        genome=False,
-        gene_transcript=True,
-        dir_output="./annotation",
-    ):
+        :param genes: genes for which compute the probes, defaults to None
+        :type genes: list of str, optional
+        :param region: region ofrm whihc generate the probes, it can be 'genome', 'gene_transcript', 'gene_CDS', defaults to 'gene_transcript'
+        :type region: str, optional
+        :param number_batchs: probes are computes in batches of genes, defaults to 1
+        :type number_batchs: int, optional
+        :param dir_output: folder where the file will be written, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param write: write the file, defaults to True
+        :type write: bool, optional
+        '''
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
+        self.file_oligos_DB = os.path.join(dir_output, f'oligo_DB_{self.species}_{self.genome_assembly}_NCBI_release_{self.annotation_release}_{region}')
+        self._create_oligos_DB(genes, region, number_batchs, dir_output, write)
 
-        file_annotation, file_sequence = self.download_annotation(
-            species, genome_assembly, "ensemble", annotation_release, dir_output
-        )
-        files_fasta = self._get_fasta_files(
-            self,
-            genome,
-            gene_transcript,
-            file_sequence,
-            file_annotation,
-            self.blockSize,
-            dir_output,
-        )
 
-        self.file_DB = os.path.join(
-            dir_output,
-            f"reference_DB_{self.species}_{self.genome_assembly}_ensemble_release{self.annotation_release}_genome{genome}_gene_transcript{gene_transcript}",
-        )
-        data_parser.merge_fasta(files_fasta, self.file_DB)
+class EnsemblDB(BaseDB):
+    '''Class to create reference and oligos DB using gtf and fasta files taken from the Ensembl server'''
 
-    def create_DB_from_custom_annotation(
-        self,
-        file_annotation,
-        file_sequence,
-        genome=False,
-        gene_transcript=True,
-        dir_output="./annotations",
-    ):
+    def __init__(self, probe_length_min, probe_length_max, species = None, genome_assembly = None, annotation_release = None,  dir_output='./output/annotation', filters = None):
+        '''Sets species, genome_assembly, annotation_release to a predefined value if thay are not given in input
+            Dowloads the fasta and annotation files from the Ensemble server and stores them in the dir_output folder
+
+        :param probe_length_min: minimum length of the probes created
+        :type probe_length_min: int
+        :param probe_length_max: maximum length of the probes created
+        :type probe_length_max: int
+        :param species: species of the files to dowload, defaults to None
+        :type species: str, optional
+        :param genome_assembly: genome_assembly of the files to dowload, defaults to None
+        :type genome_assembly: str, optional
+        :param annotation_release: annotation_release of the files to dowload, defaults to None
+        :type annotation_release: str, optional
+        :param dir_output: directory where the files are saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param filters: list of filters classes already initialized, defaults to None
+        :type filters: list of classes, optional
+        '''
+        if species is None: #change to some standard values for Ensemble
+            species = 'human'
+            warnings.warn(f'No species defined. Using default species {species}!')
+
+        if genome_assembly is None:
+            genome_assembly = 'hg38'
+            warnings.warn(f'No genome assembly defined. Using default assembly {genome_assembly}!')
+
+        if annotation_release is None:
+            annotation_release = 'current'
+            warnings.warn(f'No annotation release defined. Using default release {annotation_release}!')
+        
+        super().__init__(probe_length_min, probe_length_max, species, genome_assembly, annotation_release)
 
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-        self.file_DB = os.path.join(
-            dir_output,
-            f"reference_DB_custom_genome{genome}_gene_transcript{gene_transcript}",
-        )
+        ftp = ftp_loader.FtpLoaderEnsembl(species, dir_output, genome_assembly, annotation_release)
+        self.file_annotation = ftp.download_files('gtf')
+        self.file_sequence = ftp.download_files('fasta')
+        self.annotation = gtfparse.read_gtf(self.file_annotation)
+
+    def create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
+        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
+
+        :param genome: create the reference file for the whole genome, defaults to False
+        :type genome: bool, optional
+        :param gene_transcript: create the reference file for the gene transcript, defaults to True
+        :type gene_transcript: bool, optional
+        :param gene_CDS: create the reference file for the coding region, defaults to False
+        :type gene_CDS: bool, optional
+        :param dir_output: folder where the fasta file will be saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param block_size: size of the exon junctions, defaults to None
+        :type block_size: int, optional
+        '''
+
+        Path(dir_output).mkdir(parents=True, exist_ok=True)
+        self.file_reference_DB = os.path.join(dir_output, f'reference_DB_{self.species}_{self.genome_assembly}_Ensembl_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}')
+        self._create_reference_DB(genome, gene_transcript, gene_CDS, dir_output, block_size)
+
+    def create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
+        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+        will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
+
+        :param genes: genes for which compute the probes, defaults to None
+        :type genes: list of str, optional
+        :param region: region ofrm whihc generate the probes, it can be 'genome', 'gene_transcript', 'gene_CDS', defaults to 'gene_transcript'
+        :type region: str, optional
+        :param number_batchs: probes are computes in batches of genes, defaults to 1
+        :type number_batchs: int, optional
+        :param dir_output: folder where the file will be written, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param write: write the file, defaults to True
+        :type write: bool, optional
+        '''
+
+        Path(dir_output).mkdir(parents=True, exist_ok=True)
+        self.file_oligos_DB = os.path.join(dir_output, f'oligo_DB_{self.species}_{self.genome_assembly}_Ensembl_release_{self.annotation_release}_{region}')
+        self._create_oligos_DB(genes, region, number_batchs, dir_output, write)
+
+
+class CustomDB(BaseDB):
+    '''Class to create reference and oligos DB where gtf and fasta files are given by the user'''
+
+    def __init__(self, probe_length_min, probe_length_max, species=None, genome_assembly=None, annotation_release=None, file_annotation = None, file_sequence = None, filters = None):
+        '''Sets species, genome_assembly, annotation_release to 'unknown' if thay are not given in input
+            Saves the path of the user defined annoation and fasta file
+
+        :param probe_length_min: minimum length of the probes created
+        :type probe_length_min: int
+        :param probe_length_max: maximum length of the probes created
+        :type probe_length_max: int
+        :param species: species of the files to dowload, defaults to None
+        :type species: str, optional
+        :param genome_assembly: genome_assembly of the files to dowload, defaults to None
+        :type genome_assembly: str, optional
+        :param annotation_release: annotation_release of the files to dowload, defaults to None
+        :type annotation_release: str, optional
+        :param file_annotation: path to the gtf annotation file, defaults to None
+        :type file_annotation: str, optional
+        :param file_sequence: path to the fasta file, defaults to None
+        :type file_sequence: str, optional
+        :param filters: list of filters classes already initialized, defaults to None
+        :type filters: list of classes, optional
+        '''
+        if species is None:
+            species = 'unknown'
+            warnings.warn(f'Species not specified.')
+
+        if genome_assembly is None:
+            genome_assembly = 'unknown'
+            warnings.warn(f'Genome assembly not specified.')
+
+        if annotation_release is None:
+            annotation_release = 'unknown'
+            warnings.warn(f'Annotation release not specified.')
+
+        super().__init__(probe_length_min, probe_length_max, species, genome_assembly, annotation_release, filters)
+
+        # check the filles format
+        if file_annotation == None:
+            raise ValueError('Annotation File not defined!')
+        
+        if file_sequence == None:
+            raise ValueError('Sequence File not defined!')
 
         if not data_parser.check_gtf_format(file_annotation):
-            raise ValueError("Annotation File has incorrect format!")
-            os._exit(0)
+            raise ValueError('Annotation File has incorrect format!')
+                
         if not data_parser.check_fasta_format(file_sequence):
-            raise ValueError("Sequence File has incorrect format!")
-            os._exit(0)
+            raise ValueError('Sequence File has incorrect format!')
+        
+        self.file_annotation = file_annotation
+        self.file_sequence = file_sequence
+        self.annotation = gtfparse.read_gtf(self.file_annotation)
 
-        files_fasta = self._get_fasta_files(
-            self,
-            genome,
-            gene_transcript,
-            file_sequence,
-            file_annotation,
-            self.blockSize,
-            dir_output,
-        )
-        data_parser.merge_fasta(files_fasta, self.file_DB)
+    def create_reference_DB(self, genome=False, gene_transcript=True, gene_CDS = False, dir_output='./output/annotation', block_size = None):
+        '''Creates a fasta file for each of the region selected (genome, gene_transcript, gene_CDS) which will be used for alignements. 
 
-    def _get_fasta_files(
-        self,
-        genome,
-        gene_transcript,
-        file_sequence,
-        file_annotation,
-        blockSize,
-        dir_output,
-    ):
+        :param genome: create the reference file for the whole genome, defaults to False
+        :type genome: bool, optional
+        :param gene_transcript: create the reference file for the gene transcript, defaults to True
+        :type gene_transcript: bool, optional
+        :param gene_CDS: create the reference file for the coding region, defaults to False
+        :type gene_CDS: bool, optional
+        :param dir_output: folder where the fasta file will be saved, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param block_size: size of the exon junctions, defaults to None
+        :type block_size: int, optional
+        '''
 
-        files_fasta = []
+        Path(dir_output).mkdir(parents=True, exist_ok=True)
+        self.file_reference_DB = self.file_reference_DB = os.path.join(dir_output, f'reference_DB_{self.species}_{self.genome_assembly}_Custom_release_{self.annotation_release}_genome_{genome}_gene_transcript_{gene_transcript}')
+        self._create_reference_DB(genome, gene_transcript, gene_CDS, dir_output, block_size)
 
-        if genome:
-            file_genome = os.path.join(dir_output, "genome.fna")
-            shutil.copyfile(file_sequence, file_genome)
-            files_fasta.append(file_genome)
+    def create_oligos_DB(self, genes = None, region='gene_transcript', number_batchs = 1, dir_output='./output/annotation', write = True):
+        '''creates the DB containing all the oligo sequence extracted form the given <region> and belonging the the specified genes. If no genes are specified then 
+        will be used all the genes. The DB is a dictionary data structure and can be written in a tsv format by setting <write> = True.
 
-        if gene_transcript:
-            file_gene_transcript = self._get_gene_transcript(
-                file_sequence, file_annotation, blockSize, dir_output
-            )
-            files_fasta.append(file_gene_transcript)
+        :param genes: genes for which compute the probes, defaults to None
+        :type genes: list of str, optional
+        :param region: region ofrm whihc generate the probes, it can be 'genome', 'gene_transcript', 'gene_CDS', defaults to 'gene_transcript'
+        :type region: str, optional
+        :param number_batchs: probes are computes in batches of genes, defaults to 1
+        :type number_batchs: int, optional
+        :param dir_output: folder where the file will be written, defaults to './output/annotation'
+        :type dir_output: str, optional
+        :param write: write the file, defaults to True
+        :type write: bool, optional
+        '''
 
-        return files_fasta
-
-
-class OligoDB(BaseDB):
-    """_summary_"""
-
-    def __init__(self, probe_length_min, probe_length_max) -> None:
-        super().__init__()
-
-        self.probe_length_min = probe_length_min
-        self.probe_length_max = probe_length_max
-        self.blockSize = probe_length_max
-
-        self.file_DB = None
-        self.DB = None
-
-        self.annotation_source = None
-
-    def generate_DB_from_ncbi_annotation(
-        self,
-        genes=None,
-        region="gene_transcript",
-        species=None,
-        genome_assembly=None,
-        annotation_release=None,
-        dir_output="./annotation",
-    ):
-
-        file_annotation, file_sequence = self.download_annotation(
-            species, genome_assembly, "NCBI", annotation_release, dir_output
-        )
-        file_region = self._create_target_regions(
-            genes, region, file_annotation, file_sequence, dir_output
-        )
-        self.DB = self._generate_oligos(file_region)
-
-    def generate_DB_from_ensemble_annotation(
-        self,
-        genes=None,
-        region="gene_transcript",
-        species=None,
-        genome_assembly=None,
-        annotation_release=None,
-        dir_output="./annotation",
-    ):
-
-        file_annotation, file_sequence = self.download_annotation(
-            species, genome_assembly, "ensemble", annotation_release, dir_output
-        )
-        file_region = self._create_target_regions(
-            genes, region, file_annotation, file_sequence, dir_output
-        )
-        self.DB = self._generate_oligos(file_region)
-
-    def generate_DB_from_custom_annotation(
-        self,
-        file_annotation,
-        file_sequence,
-        genes=None,
-        region="gene_transcript",
-        dir_output="./annotation",
-    ):
-
-        self.annotation_source = "custom"
-
-        if not data_parser.check_gtf_format(file_annotation):
-            raise ValueError("Annotation File has incorrect format!")
-            os._exit(0)
-        if not data_parser.check_fasta_format(file_sequence):
-            raise ValueError("Sequence File has incorrect format!")
-            os._exit(0)
-
-        file_region = self._create_target_regions(
-            genes, region, file_annotation, file_sequence, dir_output
-        )
-        self.DB = self._generate_oligos(file_region)
-
-    def write_DB(self, dir_output):
-        # self.file_DB = ...
-        # -> output DB as fasta file
-        pass
-
-    def _create_target_regions(
-        self, genes, region, file_annotation, file_sequence, dir_output
-    ):
-        if genes is None:
-            genes = self._get_gene_list_from_annotation(file_annotation)
-
-        if region == "gene":
-            file_region = self._get_gene(file_sequence, file_annotation, dir_output)
-
-        if region == "gene_transcript":
-            file_region = self._get_gene_transcript(
-                file_sequence, file_annotation, self.blockSize, dir_output
-            )
-
-        if region == "gene_CDS":
-            file_region = self._get_gene_CDS(
-                file_sequence, file_annotation, self.blockSize, dir_output
-            )
-
-        return file_region
-
-    def _get_gene_list_from_annotation(self, file_annotation):
-        gene_annotation = data_parser.read_gtf(file_annotation)
-        genes = gene_annotation.loc[gene_annotation["feature"] == "gene"]
-        genes = list(genes["gene_id"].unique())
-        random.shuffle(genes)
-
-        return genes
-
-    def _generate_oligos(self, file_region):
-        pass
-
-    """
-    def mask_prohibited_sequences(self):
-        pass
-
-
-    def mask_repeats(self):
-        pass
-
-
-    def filter_xyz(self):
-        #wrap different filter from 'oligo_filter'
-        pass
-    """
+        Path(dir_output).mkdir(parents=True, exist_ok=True)
+        self.file_oligos_DB = os.path.join(dir_output, f'oligo_DB_{self.species}_{self.genome_assembly}_Custom_release_{self.annotation_release}_{region}')
+        self._create_oligos_DB(genes, region, number_batchs, dir_output, write)

--- a/oligo_designer_toolsuite/IO/_ftp_loader.py
+++ b/oligo_designer_toolsuite/IO/_ftp_loader.py
@@ -97,7 +97,7 @@ class BaseFtpLoader:
                 )
 
 
-class FtpLoaderEnsemble(BaseFtpLoader):
+class FtpLoaderEnsembl(BaseFtpLoader):
     """Class for downloading annotations from Ensembl, inheriting from BaseFtpLoader.
     :param species: available species: human or mouse
     :type species: string
@@ -377,7 +377,7 @@ class FTPLoaderNCBI(BaseFtpLoader):
         if file_type.casefold() == "gtf".casefold():
             self._map_chr_names_gene_gtf(output_file, mapping)
 
-        elif file_type.casefold() == "gtf".casefold():
+        elif file_type.casefold() == "fasta".casefold():
             self._map_chr_names_genome_fasta(output_file, mapping)
 
         return output_file

--- a/oligo_designer_toolsuite/IO/test_DB.ipynb
+++ b/oligo_designer_toolsuite/IO/test_DB.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Test DB class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/output/annotations\n"
+     ]
+    }
+   ],
+   "source": [
+    "from _database import NcbiDB, EnsemblDB, CustomDB\n",
+    "import os\n",
+    "\n",
+    "os.chdir('../../' )\n",
+    "cwd = os.getcwd()\n",
+    "dir_output  = os.path.join(cwd, 'output/annotations')\n",
+    "print(dir_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test the NCBI creator\n",
+    "\n",
+    "Check if the files are dowloaded correclty from the server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/oligo_designer_toolsuite/IO/_database_new.py:531: UserWarning: No species defined. Using default species human!\n",
+      "  warnings.warn(f'No species defined. Using default species {species}!')\n",
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/oligo_designer_toolsuite/IO/_database_new.py:535: UserWarning: No genome assembly defined. Using default assembly hg38!\n",
+      "  warnings.warn(f'No genome assembly defined. Using default assembly {genome_assembly}!')\n",
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/oligo_designer_toolsuite/IO/_database_new.py:539: UserWarning: No annotation release defined. Using default release current!\n",
+      "  warnings.warn(f'No annotation release defined. Using default release {annotation_release}!')\n",
+      "/home/francesco/miniconda3/envs/oligo/lib/python3.10/site-packages/gtfparse/read_gtf.py:82: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version. Use on_bad_lines in the future.\n",
+      "\n",
+      "\n",
+      "  chunk_iterator = pd.read_csv(\n",
+      "/home/francesco/miniconda3/envs/oligo/lib/python3.10/site-packages/gtfparse/read_gtf.py:82: FutureWarning: The warn_bad_lines argument has been deprecated and will be removed in a future version. Use on_bad_lines in the future.\n",
+      "\n",
+      "\n",
+      "  chunk_iterator = pd.read_csv(\n",
+      "INFO:root:Extracted GTF attributes: ['gene_id', 'transcript_id', 'db_xref', 'description', 'gbkey', 'gene', 'gene_biotype', 'pseudo', 'product', 'transcript_biotype', 'exon_number', 'gene_synonym', 'model_evidence', 'tag', 'protein_id', 'experiment', 'inference', 'note', 'part', 'exception', 'isoform', 'anticodon', 'partial', 'The', 'transl_except', 'non-AUG', 'standard_name', 'source', 'similar', 'substituted', 'transferase', 'deleted', 'codons', '12S', '16S', 'transl_table', 'ATPase']\n"
+     ]
+    }
+   ],
+   "source": [
+    "ncbi = NcbiDB(probe_length_min = 20, probe_length_max=30, dir_output=dir_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test the creation of DB\n",
+    "\n",
+    "Load the previously dowloaded files and create the reference and oligo DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/oligo_designer_toolsuite/IO/_database.py:746: UserWarning: Species not specified.\n",
+      "  warnings.warn(f'Species not specified.')\n",
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/oligo_designer_toolsuite/IO/_database.py:750: UserWarning: Genome assembly not specified.\n",
+      "  warnings.warn(f'Genome assembly not specified.')\n",
+      "/home/francesco/Desktop/Work/oligo-designer-toolsuite/oligo_designer_toolsuite/IO/_database.py:754: UserWarning: Annotation release not specified.\n",
+      "  warnings.warn(f'Annotation release not specified.')\n",
+      "/home/francesco/miniconda3/envs/oligo/lib/python3.10/site-packages/gtfparse/read_gtf.py:82: FutureWarning: The error_bad_lines argument has been deprecated and will be removed in a future version. Use on_bad_lines in the future.\n",
+      "\n",
+      "\n",
+      "  chunk_iterator = pd.read_csv(\n",
+      "/home/francesco/miniconda3/envs/oligo/lib/python3.10/site-packages/gtfparse/read_gtf.py:82: FutureWarning: The warn_bad_lines argument has been deprecated and will be removed in a future version. Use on_bad_lines in the future.\n",
+      "\n",
+      "\n",
+      "  chunk_iterator = pd.read_csv(\n",
+      "INFO:root:Extracted GTF attributes: ['gene_id', 'transcript_id', 'db_xref', 'description', 'gbkey', 'gene', 'gene_biotype', 'pseudo', 'product', 'transcript_biotype', 'exon_number', 'gene_synonym', 'model_evidence', 'tag', 'protein_id', 'experiment', 'inference', 'note', 'part', 'exception', 'isoform', 'anticodon', 'partial', 'The', 'transl_except', 'non-AUG', 'standard_name', 'source', 'similar', 'substituted', 'transferase', 'deleted', 'codons', '12S', '16S', 'transl_table', 'ATPase']\n"
+     ]
+    }
+   ],
+   "source": [
+    "annotation = dir_output+'/GCF_000001405.40_GRCh38.p14_genomic.gtf'\n",
+    "sequence = dir_output+'/GCF_000001405.40_GRCh38.p14_genomic.fna'\n",
+    "custom = CustomDB(probe_length_min = 30, probe_length_max=40, file_annotation=annotation, file_sequence=sequence)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom.create_reference_DB(dir_output=dir_output)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['gene_id', 'probe_sequence', 'transcript_id', 'exon_id', 'chromosome', 'start', 'end', 'strand']\n"
+     ]
+    }
+   ],
+   "source": [
+    "genes = ['WASH7P', 'DDX11L1', 'TRNT', 'NOC2L', 'PLEKHN1', 'AGRN','UBE2J2', 'DVL1', 'MIB2', 'LOC112268402_1']\n",
+    "custom.create_oligos_DB(genes = genes, batch_size = 2, dir_output=dir_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test reading an oligos_DB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom.read_oligos_DB(dir_output + '/oligo_DB_unknown_unknown_Custom_release_unknown_gene_transcript')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "list of all the genes in the DB:\n",
+      "dict_keys(['AGRN', 'DDX11L1', 'DVL1', 'LOC112268402_1', 'MIB2', 'NOC2L', 'PLEKHN1', 'TRNT', 'UBE2J2', 'WASH7P'])\n",
+      "Features of the first probe of the DB:\n",
+      "{'transcript_id': ['XM_011542248.3:XM_017002475.2:XM_017002474.2:NM_001367552.1:XM_047431794.1:NM_001160184.2:NM_032129.3:XM_017002478.3:XM_047431795.1:XM_017002479.2'], 'exon_id': ['XM_011542248.3_exon3:XM_017002475.2_exon3:XM_017002474.2_exon3:NM_001367552.1_exon3:XM_047431794.1_exon3:NM_001160184.2_exon3:NM_032129.3_exon3:XM_017002478.3_exon3:XM_047431795.1_exon3:XM_017002479.2_exon3'], 'chromosome': 1, 'start': ['970374'], 'end': ['970413'], 'strand': '+'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"list of all the genes in the DB:\")\n",
+    "print(custom.oligos_DB.keys())\n",
+    "gene = list(custom.oligos_DB.keys())[6]\n",
+    "probe = list(custom.oligos_DB[gene].keys())[20]\n",
+    "print(\"Features of the first probe of the DB:\")\n",
+    "print(custom.oligos_DB[gene][probe])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('oligo')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "7ff94d65164c54a2126c7dc0869520902e3a005d5dddb9f8c3667ad0fd9373c9"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/oligo_designer_toolsuite/IO/test_DB.ipynb
+++ b/oligo_designer_toolsuite/IO/test_DB.ipynb
@@ -135,7 +135,7 @@
     }
    ],
    "source": [
-    "genes = ['WASH7P', 'DDX11L1', 'TRNT', 'NOC2L', 'PLEKHN1', 'AGRN','UBE2J2', 'DVL1', 'MIB2', 'LOC112268402_1']\n",
+    "genes = ['WASH7P', 'DDX11L1', 'TRNT', 'NOC2L', 'PLEKHN1', 'AGRN','UBE2J2', 'DVL1', 'MIB2', 'LOC112268402_1' ]\n",
     "custom.create_oligos_DB(genes = genes, batch_size = 2, dir_output=dir_output)"
    ]
   },


### PR DESCRIPTION
I have completed the DB_clasees and tested them. As of now they can successfully download the gtf and fasta files, create the reference_DB and Oligo_DB, write them in a file and reconstrict the oligo dictionary from a tsv file. 
Probably the tests currently are not working because I am using some functionalities of the data_parser file which haven't been pushed yet, but I have saved the output I obtained in the notebook.
Moreover, the `create_DB` functions are protected in the base class, in fact within the base class they shouldn't be called since we do not have a fasta and gtf file. They can only be called from the NCBI, Ensembl, and custom classes.

The filtering functionalities are not implemented yet, but I will add them with also the first filters so that I can also test them.

Finally, I had a couple of ideas about how to make the code more efficient, let me know what you think-
- the `gene_transcript` method could take in input also a list of genes and create the transcriptome only for those genes.  So in the case of the oligos creation, we only create the transcriptome annotation we actually need.
- in the filtering of the probes, the additional features (e.g. Tm, gc cont, ...) were computed for each sequence, even if were computed also previously for a probe with the same sequence but with a different location. Since the filters use only the sequence to compute the additional features, would It make sense to compute these features only once for all the duplicates of a probe to avoid repeating the same computation?