### PR TITLE
Cross hybrid

### DIFF
--- a/oligo_designer_toolsuite/oligo_specificity_filter/__init__.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/__init__.py
@@ -6,6 +6,7 @@ from ._filter_base import AlignmentSpecificityFilter, SpecificityFilterBase
 from ._filter_blastn import Blastn
 from ._filter_bowtie import Bowtie
 from ._filter_bowtie2 import Bowtie2
+from ._filter_cross_hybridization import CrossHybridizationFilter
 from ._filter_exact_matches import ExactMatches
 from ._filter_seed_region import BowtieSeedRegion
 from ._seed_region_creation import (
@@ -29,4 +30,5 @@ __all__ = [
     "SeedRegionCreationStandard",
     "SeedRegionCreationPercentage",
     "LigationRegionCreation",
+    "CrossHybridizationFilter",
 ]

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
@@ -121,7 +121,7 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
             filter_same_region_matches=False,
         )
         matches = matches[1]
-        return list(zip(matches["query"].values, matches["target"].values))
+        return list(zip(matches["query"].values, matches["reference"].values))
 
     # TODO: Both these functions are temporary, should be solved with database.write_to_fasta
     def _create_fasta_file(self, database, directory, region):

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
@@ -67,6 +67,7 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
     def _create_index(self, file_reference: str, n_jobs: int):
         """
         Abstract method for creating an index based on the provided file reference.
+        The index serves as a database specific to the alignment tool, used for facilitating the alignment processes.
 
         :param file_reference: path to the file that will be used as reference for the alignment.
         :type file_reference: str
@@ -121,7 +122,10 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
         )
         return filtered_database_region
 
-    def get_matching_oligo_pairs(self, database: dict, reference_fasta: str, **kwargs):
+    @abstractmethod
+    def get_matching_oligo_pairs(
+        self, database: dict, reference_fasta: str, n_jobs: int
+    ):
         """
         Retrieve matching oligo pairs between a reference FASTA and a database. It returns a list of pairs, where each pair
         contains the name of the oligo from the database and its corresponding match from the reference.
@@ -130,21 +134,10 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
         :type database: dict
         :param reference_fasta: path to the file that is used as an reference for the alignment
         :type reference_fasta: str
-        :param kwargs: Additional keyword arguments to customize the search.
 
         :return: A list of matching oligo pairs.
         :rtype: list of tuple
         """
-        database_name = self._create_index(reference_fasta, n_jobs=1)
-        matches = self._run_search(
-            database,
-            region=None,
-            index_name=database_name,
-            filter_same_region_matches=False,
-            **kwargs,
-        )
-        matches = matches[1]
-        return list(zip(matches["query"].values, matches["reference"].values))
 
     # TODO: Both these functions are temporary, should be solved with database.write_to_fasta
     def _create_fasta_file(self, database, directory, region):

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
@@ -14,6 +14,8 @@ from Bio.SeqRecord import SeqRecord
 # Oligo Specificity Filter Classes
 ############################################
 class SpecificityFilterBase(ABC):
+    "This is the base class for all specificity filter classes"
+
     @abstractmethod
     def apply(self, database: dict, file_reference: str, n_jobs: int):
         """Apply filter to list of all possible oligos in oligo_info dictionary and filter out the oligos which don't fulfill the requirements.
@@ -21,8 +23,8 @@ class SpecificityFilterBase(ABC):
 
         :param database: database containing the oligos and their features
         :type database: dict
-        :param index_name: path to the file that is used as an index for the alignment
-        :type index_name: str
+        :param file_reference: path to the file that is used as an reference for the alignment
+        :type file_reference: str
         :param n_jobs: number of simultaneous parallel computations
         :type n_jobs: int
         :return: oligo info of user-specified genes
@@ -49,9 +51,9 @@ class SpecificityFilterBase(ABC):
 
 
 class AlignmentSpecificityFilter(SpecificityFilterBase):
-    """This is the base class for all specificity filter classes
-
-    :param dir_specificity: directory where alignement temporary files can be written
+    """
+    This is the base class for all specificity filter classes which are based on an alignment tool
+    :param dir_specificity: directory where alignment temporary files can be written
     :type dir_specificity: str
     """
 
@@ -66,7 +68,7 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
         """
         Abstract method for creating an index based on the provided file reference.
 
-        :param file_reference: path to the file that will be used as reference for the alignement.
+        :param file_reference: path to the file that will be used as reference for the alignment.
         :type file_reference: str
         :param n_jobs: number of jobs for parallel processing during index creation.
         :type n_jobs: int
@@ -78,7 +80,7 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
     @abstractmethod
     def _run_search(self, database, region, index_name, filter_same_region_matches):
         """
-        Abstract method for running a search of database region and the against the provided index, and optionally filters matches from the same region.
+        Abstract method for running a search of database region and the against the provided index.
 
         :param database: database containing the oligos
         :type database: dict
@@ -93,10 +95,26 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
         """
 
     def _run_filter(
-        self, database, region, database_name, filter_same_region_matches=True, **kwargs
+        self, database, region, index_name, filter_same_region_matches=True, **kwargs
     ):
+        """
+        Filters a database region based on alignment matches.
+
+        :param database: database containing the oligos.
+        :type database: dict
+        :param region: id of the region processed
+        :type region: str
+        :param index_name: path of the database or index to search against
+        :type index_name: str
+        :param filter_same_region_matches: Whether to filter matches within the same region (default is True).
+        :type filter_same_region_matches: bool
+        :param kwargs: Additional keyword arguments to customize the search.
+
+        :return: The filtered database region containing matching oligos.
+        :rtype: dict
+        """
         matching_oligos, _ = self._run_search(
-            database, region, database_name, filter_same_region_matches, **kwargs
+            database, region, index_name, filter_same_region_matches, **kwargs
         )
         filtered_database_region = self._filter_matching_oligos(
             database[region], matching_oligos
@@ -104,14 +122,18 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
         return filtered_database_region
 
     def get_matching_oligo_pairs(self, database: dict, reference_fasta: str, **kwargs):
-        """_summary_
+        """
+        Retrieve matching oligo pairs between a reference FASTA and a database. It returns a list of pairs, where each pair
+        contains the name of the oligo from the database and its corresponding match from the reference.
 
-        :param database: _description_
+        :param database: database containing the oligos.
         :type database: dict
-        :param reference_fasta: _description_
+        :param reference_fasta: path to the file that is used as an reference for the alignment
         :type reference_fasta: str
-        :return: _description_
-        :rtype: _type_
+        :param kwargs: Additional keyword arguments to customize the search.
+
+        :return: A list of matching oligo pairs.
+        :rtype: list of tuple
         """
         database_name = self._create_index(reference_fasta, n_jobs=1)
         matches = self._run_search(
@@ -126,19 +148,6 @@ class AlignmentSpecificityFilter(SpecificityFilterBase):
 
     # TODO: Both these functions are temporary, should be solved with database.write_to_fasta
     def _create_fasta_file(self, database, directory, region):
-        """
-        Temporary function
-        Creates a fasta file with all the oligos of a specific gene. The fasta files are then used by the alignement tools.
-
-        :param database: database with all the oligos contained
-        :type database: dict
-        :param dir: path to the directory where the files will be stored
-        :type dir: str
-        :param region: id of the region we are processing
-        :type region: str
-        :return: path of the fasta file generated
-        :rtype: str
-        """
         file_fasta_region = os.path.join(directory, f"oligos_{region}.fna")
         output = []
         for oligo_id in database[region].keys():

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -177,7 +177,7 @@ class Blastn(AlignmentSpecificityFilter):
             low_memory=False,
             names=[
                 "query",
-                "target",
+                "reference",
                 "alignment_length",
                 "query_start",
                 "query_end",
@@ -186,7 +186,7 @@ class Blastn(AlignmentSpecificityFilter):
             engine="c",
             dtype={
                 "query": str,
-                "target": str,
+                "reference": str,
                 "alignment_length": int,
                 "query_start": int,
                 "query_end": int,
@@ -197,8 +197,8 @@ class Blastn(AlignmentSpecificityFilter):
         blast_results["query_region_id"] = (
             blast_results["query"].str.split(REGION_SEPARATOR_OLIGO).str[0]
         )
-        blast_results["target_region_id"] = (
-            blast_results["target"].str.split(REGION_SEPARATOR_ANNOTATION).str[0]
+        blast_results["reference_region_id"] = (
+            blast_results["reference"].str.split(REGION_SEPARATOR_ANNOTATION).str[0]
         )
         return blast_results
 

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -214,7 +214,7 @@ class Blastn(AlignmentSpecificityFilter):
 
         if filter_same_region_matches:
             blast_matches = blast_results[
-                blast_results["query_region_id"] != blast_results["target_region_id"]
+                blast_results["query_region_id"] != blast_results["reference_region_id"]
             ]
         else:
             blast_matches = blast_results

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -234,3 +234,11 @@ class Blastn(AlignmentSpecificityFilter):
         oligos_with_match = blast_matches_filtered["query"].unique()
 
         return oligos_with_match, blast_matches_filtered
+
+    def get_matching_oligo_pairs(self, database: dict, reference_fasta: str, **kwargs):
+        return super().get_matching_oligo_pairs(
+            database,
+            reference_fasta,
+            outfmt="6 qseqid sseqid length qstart qend qlen",
+            num_threads=1,
+        )

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -26,7 +26,7 @@ class Blastn(AlignmentSpecificityFilter):
     """This class filters oligos based on the blast alignment tool. All the oligos which have a match with a percentage identity higher
     than the one given in input are filtered out.
 
-    :param dir_specificity: directory where alignement temporary files can be written
+    :param dir_specificity: directory where alignment temporary files can be written
     :type dir_specificity: str
     :param word_size: word size for the blastn seed (exact match to target)
     :type word_size: int
@@ -71,16 +71,18 @@ class Blastn(AlignmentSpecificityFilter):
         Path(self.dir_fasta).mkdir(parents=True, exist_ok=True)
 
     def apply(self, database: dict, file_reference: str, n_jobs: int):
-        """Apply the blastn filter in parallel on the given ``database``. Each jobs filters a single region, and  at the same time are generated at most ``n_job`` jobs.
+        """
+        Apply the blastn filter in parallel on the given ``database``. Each job filters a
+        single region, and at the same time, at most ``n_jobs`` jobs are generated.
         The filtered database is returned.
 
-        :param database: database containing the oligos and their features
+        :param database: Database containing the oligos and their features.
         :type database: dict
-        :param file_reference: path to the file that will be used as reference for the alignement
+        :param file_reference: Path to the file that will be used as reference for the alignment.
         :type file_reference: str
-        :param n_jobs: number of simultaneous parallel computations
+        :param n_jobs: Number of simultaneous parallel computations.
         :type n_jobs: int
-        :return: oligo info of user-specified regions
+        :return: Oligo info of user-specified regions.
         :rtype: dict
         """
 
@@ -103,6 +105,16 @@ class Blastn(AlignmentSpecificityFilter):
         return database
 
     def _create_index(self, file_reference: str, n_jobs: int):
+        """
+        Create a Blastn database index.
+
+        :param file_reference: Path to the reference file used for creating the index.
+        :type file_reference: str
+        :param n_jobs: Number of simultaneous parallel computations (currently unused)
+        :type n_jobs: int
+        :return: The name of the created database index.
+        :rtype: str
+        """
         # create blast database
         database_exists = False
         database_name = os.path.basename(file_reference)
@@ -122,17 +134,25 @@ class Blastn(AlignmentSpecificityFilter):
         return database_name
 
     def _run_search(
-        self, database, region, index_name, filter_same_region_matches=True, **kwargs
+        self, database, region, index_name, filter_same_region_matches, **kwargs
     ):
-        """Run BlastN alignment tool to find regions of local similarity between sequences, where sequences are oligos and background sequences (e.g. transcript, genome, etc.).
-        BlastN identifies the transcript regions where oligos match with a certain coverage and similarity.
+        """
+        Run BlastN alignment tool to find regions of local similarity between sequences,
+        where sequences are oligos and background sequences (e.g., transcript, genome, etc.).
+        BlastN identifies the transcript regions where oligos match.
 
-        :param database: database containing the oligos
+        :param database: Database containing the oligos.
         :type database: dict
-        :param region: id of the region processed
+        :param region: ID of the region processed.
         :type region: str
-        :param database_name: path to the blatn database
-        :type database_name: str
+        :param index_name: Name of the Blastn database index.
+        :type index_name: str
+        :param filter_same_region_matches: Whether to filter out results within the same.
+        :type filter_same_region_matches: bool
+        :param kwargs: Additional keyword arguments for the BlastN command.
+        :type kwargs: dict
+        :return: A tuple containing: an array of oligos with matches, and a dataframe containing alignment match data
+        :rtype: (numpy.ndarray, pandas.DataFrame)
         """
         # TODO: This part has to change
         if region is not None:
@@ -169,7 +189,14 @@ class Blastn(AlignmentSpecificityFilter):
         )
 
     def _read_blast_output(self, file_blast_region):
-        """Load the output of the BlastN alignment search into a DataFrame and process the results."""
+        """
+        Load the output of the BlastN alignment search into a DataFrame and process the results.
+
+        :param file_blast_region: Path to the BlastN output file.
+        :type file_blast_region: str
+        :return: Processed BlastN results as a DataFrame.
+        :rtype: pandas.DataFrame
+        """
 
         blast_results = pd.read_csv(
             file_blast_region,
@@ -204,13 +231,14 @@ class Blastn(AlignmentSpecificityFilter):
         return blast_results
 
     def _find_matching_oligos(self, blast_results, filter_same_region_matches=True):
-        """Use the results of the BlastN alignement search to remove oligos with high similarity,
-        oligo coverage and ligation site coverage based on user defined thresholds.
+        """Use the results of the BlastN alignement search to remove oligos.
 
         :param blast_results: DataFrame with processed blast alignment search results.
         :type blast_results: pandas.DataFrame:
-        param blast_results: Boolean indicating whether to filter out results with the same region_id, defaults to True.
-        :type blast_results: bool
+        param filter_same_region_matches: Whether to filter out results within the same region (default is True)
+        :type filter_same_region_matches: bool
+        :return: A tuple containing: an array of oligos with matches, and a dataframe containing alignment match data
+        :rtype: (numpy.ndarray, pandas.DataFrame)
         """
 
         if filter_same_region_matches:
@@ -236,6 +264,19 @@ class Blastn(AlignmentSpecificityFilter):
         return oligos_with_match, blast_matches_filtered
 
     def get_matching_oligo_pairs(self, database: dict, reference_fasta: str, **kwargs):
+        """
+        Retrieve matching oligo pairs between a reference FASTA and a database. It returns a list of pairs, where each pair
+        contains the name of the oligo from the database and its corresponding match from the reference.
+
+        :param database: database containing the oligos.
+        :type database: dict
+        :param reference_fasta: path to the file that is used as an reference for the alignment
+        :type reference_fasta: str
+        :param kwargs: Additional keyword arguments to customize the search.
+
+        :return: A list of matching oligo pairs.
+        :rtype: list of tuple
+        """
         return super().get_matching_oligo_pairs(
             database,
             reference_fasta,

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -272,3 +272,28 @@ class Bowtie(AlignmentSpecificityFilter):
         oligos_with_match = bowtie_matches["query"].unique()
 
         return oligos_with_match, bowtie_matches
+
+    def get_matching_oligo_pairs(
+        self, database: dict, reference_fasta: str, n_jobs: int
+    ):
+        """
+        Retrieve matching oligo pairs between a reference FASTA and a database. It returns a list of pairs, where each pair
+        contains the name of the oligo from the database and its corresponding match from the reference.
+
+        :param database: database containing the oligos.
+        :type database: dict
+        :param reference_fasta: path to the file that is used as an reference for the alignment
+        :type reference_fasta: str
+
+        :return: A list of matching oligo pairs.
+        :rtype: list of tuple
+        """
+        database_name = self._create_index(reference_fasta, n_jobs=n_jobs)
+        matches = self._run_search(
+            database,
+            region=None,
+            index_name=database_name,
+            filter_same_region_matches=False,
+        )
+        matches = matches[1]
+        return list(zip(matches["query"].values, matches["reference"].values))

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -29,9 +29,9 @@ class Bowtie(AlignmentSpecificityFilter):
 
     Use ``conda install -c bioconda bowtie`` to install Bowtie package
 
-    :param dir_specificity: directory where alignement temporary files can be written
+    :param dir_specificity: directory where alignment temporary files can be written
     :type dir_specificity: str
-    :param num_mismatches: Threshold value on the number of mismatches required for each oligo. ligos where the number of mismatches greater than this threshhold are considered valid. Possible values range from 0 to 3.
+    :param num_mismatches: Threshold value on the number of mismatches required for each oligo. oligos where the number of mismatches greater than this threshold are considered valid. Possible values range from 0 to 3.
     :type num_mismatches: int
     :param mismatch_region: The region of the oligo where the mismatches are considered. Oligos that have less than or equal to num_mismatches in the first L bases (where L is 5 or greater) are filtered out. If ``None`` then the whole sequence is considered, defaults to None
     :type mismatch_region: int
@@ -69,16 +69,17 @@ class Bowtie(AlignmentSpecificityFilter):
         Path(self.dir_fasta).mkdir(parents=True, exist_ok=True)
 
     def apply(self, database: dict, file_reference: str, n_jobs: int):
-        """Apply the bowtie filter in parallel on the given ``database``. Each jobs filters a single region, and  at the same time are generated at most ``n_job`` jobs.
+        """
+        Apply the Bowtie filter in parallel on the given ``database``. Each job filters a single region, and up to ``n_jobs`` are run simultaneously.
         The filtered database is returned.
 
-        :param database: database containing the oligos and their features
+        :param database: Database containing the oligos and their features.
         :type database: dict
-        :param file_reference: path to the file that will be used as reference for the alignement
+        :param file_reference: Path to the file that will be used as a reference for the alignment.
         :type file_reference: str
-        :param n_jobs: number of simultaneous parallel computations
+        :param n_jobs: Number of simultaneous parallel computations.
         :type n_jobs: int
-        :return: oligo info of user-specified regions
+        :return: Oligo info of user-specified regions.
         :rtype: dict
         """
         index_name = self._create_index(file_reference, n_jobs=n_jobs)
@@ -96,6 +97,16 @@ class Bowtie(AlignmentSpecificityFilter):
         return database
 
     def _create_index(self, file_reference: str, n_jobs: int):
+        """
+        Create a Bowtie database index.
+
+        :param file_reference: Path to the reference file used for creating the index.
+        :type file_reference: str
+        :param n_jobs: Number of simultaneous parallel computations (currently unused)
+        :type n_jobs: int
+        :return: The name of the created database index.
+        :rtype: str
+        """
         # Some bowtie initializations, change the names
         index_exists = False
         index_name = os.path.basename(file_reference)
@@ -123,11 +134,19 @@ class Bowtie(AlignmentSpecificityFilter):
         """Run Bowtie alignment tool to find regions of local similarity between sequences, where sequences are oligos and transcripts.
         Bowtie identifies all alignments between the oligos and transcripts and returns the number of mismatches and mismatch position for each alignment.
 
-        :param databse: database containing the oligos
-        :type databse: dict
-        :param region: id of the region processed
+
+        :param database: Database containing the oligos.
+        :type database: dict
+        :param region: ID of the region processed.
         :type region: str
+        :param index_name: Name of the Blastn database index.
+        :type index_name: str
+        :param filter_same_region_matches: Whether to filter out results within the same.
+        :type filter_same_region_matches: bool
+        :return: A tuple containing: an array of oligos with matches, and a dataframe containing alignment match data
+        :rtype: (numpy.ndarray, pandas.DataFrame)
         """
+
         # TODO: This part has to change
         if region is not None:
             file_oligo_fasta_gene = self._create_fasta_file(
@@ -230,8 +249,12 @@ class Bowtie(AlignmentSpecificityFilter):
     def _find_matching_oligos(self, bowtie_results, filter_same_gene_matches=True):
         """Use the results of the Bowtie alignment search to identify oligos with high similarity (i.e. low number of mismatches) based on user defined thresholds.
 
-        :param bowtie_results: DataFrame with processed bowtie alignment search results.
-        :type bowtie_results: pandas.DataFrame
+        :param bowtie_results: DataFrame with processed blast alignment search results.
+        :type bowtie_results: pandas.DataFrame:
+        param filter_same_region_matches: Whether to filter out results within the same region (default is True)
+        :type filter_same_region_matches: bool
+        :return: A tuple containing: an array of oligos with matches, and a dataframe containing alignment match data
+        :rtype: (numpy.ndarray, pandas.DataFrame)
         """
 
         if filter_same_gene_matches:

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -119,7 +119,7 @@ class Bowtie(AlignmentSpecificityFilter):
 
         return index_name
 
-    def _run_search(self, database, region, index_name, filter_same_gene_matches):
+    def _run_search(self, database, region, index_name, filter_same_region_matches):
         """Run Bowtie alignment tool to find regions of local similarity between sequences, where sequences are oligos and transcripts.
         Bowtie identifies all alignments between the oligos and transcripts and returns the number of mismatches and mismatch position for each alignment.
 
@@ -185,7 +185,7 @@ class Bowtie(AlignmentSpecificityFilter):
 
         # filter the DB based on the bowtie results
         return self._find_matching_oligos(
-            bowtie_results, filter_same_gene_matches=filter_same_gene_matches
+            bowtie_results, filter_same_gene_matches=filter_same_region_matches
         )
 
     def _read_bowtie_output(self, file_bowtie_gene):

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
@@ -72,6 +72,7 @@ class CrossHybridizationFilter(SpecificityFilterBase):
         matching_oligo_pairs = self.specificity_filter.get_matching_oligo_pairs(
             oligo_database, database_name
         )
+        print(matching_oligo_pairs)
         return nx.from_edgelist(matching_oligo_pairs)
 
     def _count_oligos_per_region(self, oligo_database):

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
@@ -1,0 +1,78 @@
+############################################
+# imports
+############################################
+
+import networkx as nx
+
+from . import AlignmentSpecificityFilter, SpecificityFilterBase
+
+############################################
+# Oligo Blast Filter Classes
+############################################
+
+
+class CrossHybridizationFilter(SpecificityFilterBase):
+    """
+    This class implements a cross-hybridization filter for oligos. It constructs a graph representation of oligo interactions using an alignment method, then applies a policy to remove oligos which cross-hybridize.
+    The class provides methods to create a cross-hybridization graph, and apply the chosen policy to filter out oligos.
+    The policy is a function that determines which oligos to remove in case of cross-hybridization (can be imported from oligo_designer_toolsuite.oligo_specificity_filter.cross_hybridization_policies, or you can provide your own).
+
+    :param specificity_filter: An instance of AlignmentSpecificityFilter class that provides matching oligo pairs based on an alignment criteria.
+    :type specificity_filter: AlignmentSpecificityFilter
+    :param policy: A function that defines the strategy for oligo removal. It takes the graph and a dictionary where keys are the databse regions as inputs and returns a dictionary of removed oligos.
+    :type policy: function
+    :param dir_cross_hybridization: Directory where files produced during the cross hybridization check are stored.
+    :type dir_cross_hybridization: str
+    """
+
+    def __init__(
+        self,
+        specificity_filter: AlignmentSpecificityFilter,
+        policy,
+        dir_cross_hybridization,
+    ):
+        self.specificity_filter = specificity_filter
+        self.policy = policy
+        self.dir_cross_hybridization = dir_cross_hybridization
+
+    def apply(self, database: dict, file_reference: str, n_jobs: int):
+        """
+        Applies the cross-hybridization filter to an oligo database. First, it constructs a graph of oligo interactions. Then, it identifies cross-hybridizing oligos, and filters one of them out based on the specified policy.
+
+        :param database: The oligo database to be filtered.
+        :type database: dict
+        :param file_reference: Path to the reference file containing all oligos in fasta.
+        :type file_reference: str
+        :param n_jobs: Number of parallel jobs to use for parallel processing (currently not implemented).
+        :type n_jobs: int
+        :return: Updated oligo database with cross-hybridizing oligos removed.
+        :rtype: dict
+        """
+        # Not in parallel for now
+        oligos_per_region = self._count_oligos_per_region(database)
+        regions = list(database.keys())
+
+        cross_hybridization_graph = self._create_cross_hybridization_graph(
+            database, file_reference
+        )
+        matching_oligos = self.policy(cross_hybridization_graph, oligos_per_region)
+
+        for region in regions:
+            filtered_database_region = self._filter_matching_oligos(
+                database[region],
+                matching_oligos[region],
+            )
+            database[region] = filtered_database_region
+        return database
+
+    def _create_cross_hybridization_graph(
+        self, oligo_database: dict, reference_fasta: str
+    ):
+        database_name = self.specificity_filter._create_index(reference_fasta, n_jobs=1)
+        matching_oligo_pairs = self.specificity_filter.get_matching_oligo_pairs(
+            oligo_database, database_name
+        )
+        return nx.from_edgelist(matching_oligo_pairs)
+
+    def _count_oligos_per_region(self, oligo_database):
+        return {region: len(oligo_database[region]) for region in oligo_database.keys()}

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
@@ -68,6 +68,16 @@ class CrossHybridizationFilter(SpecificityFilterBase):
     def _create_cross_hybridization_graph(
         self, oligo_database: dict, reference_fasta: str
     ):
+        """
+        Create a cross-hybridization graph based on matching oligo pairs. Where nodes are oligos and edges indicate that the oligos match
+
+        :param oligo_database: The oligo database
+        :type oligo_database: dict
+        :param reference_fasta: The path to the reference FASTA file.
+        :type reference_fasta: str
+        :return: A graph representing cross-hybridization relationships between oligos.
+        :rtype: networkx.Graph
+        """
         matching_oligo_pairs = self.specificity_filter.get_matching_oligo_pairs(
             oligo_database, reference_fasta
         )
@@ -75,4 +85,12 @@ class CrossHybridizationFilter(SpecificityFilterBase):
         return nx.from_edgelist(matching_oligo_pairs)
 
     def _count_oligos_per_region(self, oligo_database):
+        """
+        Count the number of oligos per region in the provided oligo database.
+
+        :param oligo_database: A dictionary containing oligos grouped by regions.
+        :type oligo_database: dict
+        :return: A dictionary mapping region names to the number of oligos in each region.
+        :rtype: dict
+        """
         return {region: len(oligo_database[region]) for region in oligo_database.keys()}

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_cross_hybridization.py
@@ -68,9 +68,8 @@ class CrossHybridizationFilter(SpecificityFilterBase):
     def _create_cross_hybridization_graph(
         self, oligo_database: dict, reference_fasta: str
     ):
-        database_name = self.specificity_filter._create_index(reference_fasta, n_jobs=1)
         matching_oligo_pairs = self.specificity_filter.get_matching_oligo_pairs(
-            oligo_database, database_name
+            oligo_database, reference_fasta
         )
         print(matching_oligo_pairs)
         return nx.from_edgelist(matching_oligo_pairs)

--- a/oligo_designer_toolsuite/oligo_specificity_filter/cross_hybridization_policies.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/cross_hybridization_policies.py
@@ -1,63 +1,113 @@
+from abc import ABC, abstractmethod
+
 import networkx as nx
 
 from oligo_designer_toolsuite.constants import REGION_SEPARATOR_OLIGO
+from oligo_designer_toolsuite.database import OligoDatabase
 
 
-# Policies
-def _oligo_to_region(oligo_name: str):
-    return oligo_name.split(REGION_SEPARATOR_OLIGO)[0]
+class CrossHybridizationPolicy(ABC):
+    """
+    This is the base class for all cross-hybridization policies.
+    """
+
+    @abstractmethod
+    def apply(self, graph: nx.Graph, oligo_database: OligoDatabase):
+        """
+        Apply the cross-hybridization policy to a graph of oligos.
+        :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
+        :type graph: nx.Graph
+        :param oligo_database: The oligo database.
+        :type oligo_database: OligoDatabase
+
+        :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
+        :rtype: dict
+        """
+
+    def _oligo_to_region(self, oligo: str) -> str:
+        """
+        Extract the region from an oligo ID.
+        :param oligo: The oligo ID.
+        :type oligo: str
+        :return: The region.
+        :rtype: str
+        """
+        return oligo.split(REGION_SEPARATOR_OLIGO)[0]
+
+    def _count_oligos_per_region(self, oligo_database):
+        """
+        Count the number of oligos per region in the provided oligo database.
+
+        :param oligo_database: A dictionary containing oligos grouped by regions.
+        :type oligo_database: dict
+        :return: A dictionary mapping region names to the number of oligos in each region.
+        :rtype: dict
+        """
+        return {region: len(oligo_database[region]) for region in oligo_database.keys()}
 
 
-def remove_by_bigger_region_policy(
-    graph: nx.Graph, oligos_per_region: dict
-) -> dict[str, list[str]]:
+class RemoveByBiggerRegionPolicy(CrossHybridizationPolicy):
     """
     Iteratively removes oligos (graph nodes) by comparing the number of oligos per region. In each iteration, the oligo from the region with the bigger number of oligos is removed. The process is repeated until there are no edges in the graph anymore.
-
-    :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
-    :type graph: nx.Graph
-    :param oligos_per_region: Dictionary mapping each region to its number of oligos. Nodes from regions with more oligos are prioritized for removal.
-    :type oligos_per_region: dict
-    :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
-    :rtype: dict
     """
 
-    removed_oligos = {oligo_region: [] for oligo_region in oligos_per_region.keys()}
+    def apply(
+        self, graph: nx.Graph, oligo_database: OligoDatabase
+    ) -> dict[str, list[str]]:
+        """
+        Apply the cross-hybridization policy to a graph of oligos.
+        :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
+        :type graph: nx.Graph
+        :param oligo_database: The oligo database.
+        :type oligo_database: OligoDatabase
 
-    while graph.number_of_edges() > 0:
-        edge = list(graph.edges)[0]
-        region_0 = _oligo_to_region(edge[0])
-        region_1 = _oligo_to_region(edge[1])
-        if oligos_per_region[region_0] > oligos_per_region[region_1]:
-            graph.remove_node(edge[0])
-            removed_oligos[region_0].append(edge[0])
-            oligos_per_region[region_0] -= 1
-        else:
-            graph.remove_node(edge[1])
-            removed_oligos[region_1].append(edge[1])
-            oligos_per_region[region_1] -= 1
-    return removed_oligos
+        :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
+        :rtype: dict
+        """
+        oligos_per_region = self._count_oligos_per_region(oligo_database)
+        removed_oligos = {oligo_region: [] for oligo_region in oligos_per_region.keys()}
+
+        while graph.number_of_edges() > 0:
+            edge = list(graph.edges)[0]
+            region_0 = self._oligo_to_region(edge[0])
+            region_1 = self._oligo_to_region(edge[1])
+            if oligos_per_region[region_0] > oligos_per_region[region_1]:
+                graph.remove_node(edge[0])
+                removed_oligos[region_0].append(edge[0])
+                oligos_per_region[region_0] -= 1
+            else:
+                graph.remove_node(edge[1])
+                removed_oligos[region_1].append(edge[1])
+                oligos_per_region[region_1] -= 1
+        return removed_oligos
 
 
-def remove_by_degree_policy(
-    graph: nx.Graph, oligos_per_region: dict
-) -> dict[str, list[str]]:
+class RemoveByDegreePolicy(CrossHybridizationPolicy):
     """
     Iteratively removes nodes with the highest degree from a graph until there are no edges left. The degree of a node is the number of connections it has with other nodes. This method targets nodes (oligos) that are most interconnected first.
-
-    :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
-    :type graph: nx.Graph
-    :param oligos_per_region: Dictionary mapping each region to its number of oligos.
-    :type oligos_per_region: dict
-    :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
-    :rtype: dict
     """
-    removed_oligos = {oligo_region: [] for oligo_region in oligos_per_region.keys()}
 
-    while graph.number_of_edges() > 0:
-        degrees = dict(graph.degree())
-        if degrees:
-            max_degree_node = max(degrees, key=degrees.get)
-            graph.remove_node(max_degree_node)
-            removed_oligos[_oligo_to_region(max_degree_node)].append(max_degree_node)
-    return removed_oligos
+    def apply(
+        self, graph: nx.Graph, oligo_database: OligoDatabase
+    ) -> dict[str, list[str]]:
+        """
+        Apply the cross-hybridization policy to a graph of oligos.
+        :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
+        :type graph: nx.Graph
+        :param oligo_database: The oligo database.
+        :type oligo_database: OligoDatabase
+
+        :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
+        :rtype: dict
+        """
+        removed_oligos = {oligo_region: [] for oligo_region in oligo_database.keys()}
+
+        while graph.number_of_edges() > 0:
+            degrees = dict(graph.degree())
+            if degrees:
+                max_degree_node = max(degrees, key=degrees.get)
+                graph.remove_node(max_degree_node)
+                removed_oligos[self._oligo_to_region(max_degree_node)].append(
+                    max_degree_node
+                )
+        return removed_oligos

--- a/oligo_designer_toolsuite/oligo_specificity_filter/cross_hybridization_policies.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/cross_hybridization_policies.py
@@ -1,0 +1,63 @@
+import networkx as nx
+
+from oligo_designer_toolsuite.constants import REGION_SEPARATOR_OLIGO
+
+
+# Policies
+def _oligo_to_region(oligo_name: str):
+    return oligo_name.split(REGION_SEPARATOR_OLIGO)[0]
+
+
+def remove_by_bigger_region_policy(
+    graph: nx.Graph, oligos_per_region: dict
+) -> dict[str, list[str]]:
+    """
+    Iteratively removes oligos (graph nodes) by comparing the number of oligos per region. In each iteration, the oligo from the region with the bigger number of oligos is removed. The process is repeated until there are no edges in the graph anymore.
+
+    :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
+    :type graph: nx.Graph
+    :param oligos_per_region: Dictionary mapping each region to its number of oligos. Nodes from regions with more oligos are prioritized for removal.
+    :type oligos_per_region: dict
+    :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
+    :rtype: dict
+    """
+
+    removed_oligos = {oligo_region: [] for oligo_region in oligos_per_region.keys()}
+
+    while graph.number_of_edges() > 0:
+        edge = list(graph.edges)[0]
+        region_0 = _oligo_to_region(edge[0])
+        region_1 = _oligo_to_region(edge[1])
+        if oligos_per_region[region_0] > oligos_per_region[region_1]:
+            graph.remove_node(edge[0])
+            removed_oligos[region_0].append(edge[0])
+            oligos_per_region[region_0] -= 1
+        else:
+            graph.remove_node(edge[1])
+            removed_oligos[region_1].append(edge[1])
+            oligos_per_region[region_1] -= 1
+    return removed_oligos
+
+
+def remove_by_degree_policy(
+    graph: nx.Graph, oligos_per_region: dict
+) -> dict[str, list[str]]:
+    """
+    Iteratively removes nodes with the highest degree from a graph until there are no edges left. The degree of a node is the number of connections it has with other nodes. This method targets nodes (oligos) that are most interconnected first.
+
+    :param graph: Graph where nodes represent oligos and edges indicate cross-hybridization between pairs of oligos.
+    :type graph: nx.Graph
+    :param oligos_per_region: Dictionary mapping each region to its number of oligos.
+    :type oligos_per_region: dict
+    :return: Dictionary where each key is a region and the value is a list of oligos removed from that region.
+    :rtype: dict
+    """
+    removed_oligos = {oligo_region: [] for oligo_region in oligos_per_region.keys()}
+
+    while graph.number_of_edges() > 0:
+        degrees = dict(graph.degree())
+        if degrees:
+            max_degree_node = max(degrees, key=degrees.get)
+            graph.remove_node(max_degree_node)
+            removed_oligos[_oligo_to_region(max_degree_node)].append(max_degree_node)
+    return removed_oligos

--- a/oligo_designer_toolsuite/utils/__init__.py
+++ b/oligo_designer_toolsuite/utils/__init__.py
@@ -3,8 +3,8 @@ This module provides all additional functionalities that are needed for oligo de
 """
 
 from ._data_parser import (
-    check_gff_format,
     check_fasta_format,
+    check_gff_format,
     check_tsv_format,
     get_sequence_from_annotation,
     merge_fasta,
@@ -13,13 +13,13 @@ from ._data_parser import (
 from ._ftp_loader import BaseFtpLoader, FtpLoaderEnsembl, FtpLoaderNCBI
 from ._gff_parser import GffParser
 from ._sequence_design import (
-    generate_random_sequence,
-    generate_binary_sequences,
-    generate_codebook,
-    get_barcode,
     SCRINSHOT_or_ISS_backbone_sequence,
     convert_complementary_seq_to_arms,
     create_seqfish_plus_barcodes,
+    generate_binary_sequences,
+    generate_codebook,
+    generate_random_sequence,
+    get_barcode,
 )
 
 __all__ = [

--- a/tests/data/specificity_filter/oligo_DB_cross_hybridization.tsv
+++ b/tests/data/specificity_filter/oligo_DB_cross_hybridization.tsv
@@ -1,0 +1,21 @@
+region_id	oligo_id	sequence	chromosome	start	end	strand	length	additional_information_fasta
+region_1	region_1::oligo_1	CTCACTCGACTCTTACACAGTCATA		0	0		25
+region_1	region_1::oligo_2	TATAACCCTGAGGAGGTATACCTAG		0	0		25
+region_1	region_1::oligo_3	CGATTCGGAGATGTTTGATTGTCCG		0	0		25
+region_1	region_1::oligo_4	AAGAAGAGAGCTGAGTATCTCCTGG		0	0		25
+region_1	region_1::oligo_5	AGCAAAGTCTTTGAGGTATCTATGG		0	0		25
+region_1	region_1::oligo_6	ACTTGATGAACTACGTAGTCGTATT		0	0		25
+region_1	region_1::oligo_7	CACTACTAGTTCCTGTGGTAGAGCG		0	0		25
+region_1	region_1::oligo_8	ACTGAGGATATATAGAATGGCGTTC		0	0		25
+region_2	region_2::oligo_1	GAACGCCATTCTATATATCCTCAGT		0	0		25
+region_2	region_2::oligo_2	CAAGATTGGATAGGACTCGACCCCG		0	0		25
+region_2	region_2::oligo_3	AAATTTAGAAGACTAGTCACGCACA		0	0		25
+region_2	region_2::oligo_4	TAGTTCAGTAGCAATGAGAGGCCCG		0	0		25
+region_2	region_2::oligo_5	GATGATATTATCATGGACTATCGTC		0	0		25
+region_2	region_2::oligo_6	CGTGTTCTTCTCTGTTGTCCGCACC		0	0		25
+region_2	region_2::oligo_7	CTCACTCGACTCTTACACAGTCATA		0	0		25
+region_3	region_3::oligo_1	TATGACTGTGTAAGAGTCGAGTGAG		0	0		25
+region_3	region_3::oligo_2	CTAGGTATACCTCCTCAGGGTTATA		0	0		25
+region_3	region_3::oligo_3	CGGACAATCAAACATCTCCGAATCG		0	0		25
+region_3	region_3::oligo_4	TCAGTATTTAGAGACGTGTTGCGAC		0	0		25
+region_3	region_3::oligo_5	TGTCAGCACGACCGAAACGCGCTAT		0	0		25

--- a/tests/notebooks/sample.json
+++ b/tests/notebooks/sample.json
@@ -1,0 +1,1 @@
+{"region_1": {"region_1::oligo_4": {"sequence":

--- a/tests/test_oligo_specificity_filter.py
+++ b/tests/test_oligo_specificity_filter.py
@@ -285,7 +285,7 @@ def test_cross_hybridization_filter_blast_bigger_region_policy(tmp_path):
     blastn = Blastn(
         tmp_path,
         word_size=word_size,
-        perc_identity=percent_identity,
+        percent_identity=percent_identity,
         strand="minus",
         coverage=coverage,
     )
@@ -349,7 +349,7 @@ def test_cross_hybridization_filter_blast_degree_policy(tmp_path):
     blastn = Blastn(
         tmp_path,
         word_size=word_size,
-        perc_identity=percent_identity,
+        percent_identity=percent_identity,
         strand="minus",
         coverage=coverage,
     )

--- a/tests/test_oligo_specificity_filter.py
+++ b/tests/test_oligo_specificity_filter.py
@@ -15,8 +15,8 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     LigationRegionCreation,
 )
 from oligo_designer_toolsuite.oligo_specificity_filter.cross_hybridization_policies import (
-    remove_by_bigger_region_policy,
-    remove_by_degree_policy,
+    RemoveByBiggerRegionPolicy,
+    RemoveByDegreePolicy,
 )
 
 ############################################
@@ -291,7 +291,7 @@ def test_cross_hybridization_filter_blast_bigger_region_policy(tmp_path):
     )
     ch_filter = CrossHybridizationFilter(
         specificity_filter=blastn,
-        policy=remove_by_bigger_region_policy,
+        policy=RemoveByBiggerRegionPolicy(),
         dir_cross_hybridization=None,
     )
 
@@ -303,7 +303,7 @@ def test_cross_hybridization_filter_blast_bigger_region_policy(tmp_path):
     filtered_database = ch_filter.apply(
         database=oligo_database.database,
         file_reference=oligo_database_fasta,
-        n_jobs=None,
+        n_jobs=1,
     )
 
     filtered_oligos = {
@@ -320,7 +320,7 @@ def test_cross_hybridization_filter_bowtie_bigger_region_policy(tmp_path):
     bowtie_filter = Bowtie(tmp_path, num_mismatches, mismatch_region, strand="minus")
     ch_filter = CrossHybridizationFilter(
         specificity_filter=bowtie_filter,
-        policy=remove_by_bigger_region_policy,
+        policy=RemoveByBiggerRegionPolicy(),
         dir_cross_hybridization=None,
     )
 
@@ -332,7 +332,7 @@ def test_cross_hybridization_filter_bowtie_bigger_region_policy(tmp_path):
     filtered_database = ch_filter.apply(
         database=oligo_database.database,
         file_reference=oligo_database_fasta,
-        n_jobs=None,
+        n_jobs=1,
     )
 
     filtered_oligos = {
@@ -355,7 +355,7 @@ def test_cross_hybridization_filter_blast_degree_policy(tmp_path):
     )
     ch_filter = CrossHybridizationFilter(
         specificity_filter=blastn,
-        policy=remove_by_degree_policy,
+        policy=RemoveByDegreePolicy(),
         dir_cross_hybridization=None,
     )
 
@@ -367,7 +367,7 @@ def test_cross_hybridization_filter_blast_degree_policy(tmp_path):
     filtered_database = ch_filter.apply(
         database=oligo_database.database,
         file_reference=oligo_database_fasta,
-        n_jobs=None,
+        n_jobs=1,
     )
 
     filtered_oligos = {
@@ -384,7 +384,7 @@ def test_cross_hybridization_filter_bowtie_degree_policy(tmp_path):
     bowtie_filter = Bowtie(tmp_path, num_mismatches, mismatch_region, strand="minus")
     ch_filter = CrossHybridizationFilter(
         specificity_filter=bowtie_filter,
-        policy=remove_by_degree_policy,
+        policy=RemoveByDegreePolicy(),
         dir_cross_hybridization=None,
     )
 
@@ -396,7 +396,7 @@ def test_cross_hybridization_filter_bowtie_degree_policy(tmp_path):
     filtered_database = ch_filter.apply(
         database=oligo_database.database,
         file_reference=oligo_database_fasta,
-        n_jobs=None,
+        n_jobs=1,
     )
 
     filtered_oligos = {

--- a/tests/test_oligo_specificity_filter.py
+++ b/tests/test_oligo_specificity_filter.py
@@ -285,7 +285,7 @@ def test_cross_hybridization_filter_blast_bigger_region_policy(tmp_path):
     blastn = Blastn(
         tmp_path,
         word_size=word_size,
-        percent_identity=percent_identity,
+        perc_identity=percent_identity,
         strand="minus",
         coverage=coverage,
     )
@@ -349,7 +349,7 @@ def test_cross_hybridization_filter_blast_degree_policy(tmp_path):
     blastn = Blastn(
         tmp_path,
         word_size=word_size,
-        percent_identity=percent_identity,
+        perc_identity=percent_identity,
         strand="minus",
         coverage=coverage,
     )

--- a/tests/test_oligo_specificity_filter.py
+++ b/tests/test_oligo_specificity_filter.py
@@ -10,8 +10,13 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     Bowtie,
     Bowtie2,
     BowtieSeedRegion,
+    CrossHybridizationFilter,
     ExactMatches,
     LigationRegionCreation,
+)
+from oligo_designer_toolsuite.oligo_specificity_filter.cross_hybridization_policies import (
+    remove_by_bigger_region_policy,
+    remove_by_degree_policy,
 )
 
 ############################################
@@ -34,6 +39,9 @@ file_transcriptome_fasta_ligation = dir_annotations + "/reference_sample_ligatio
 file_oligo_info_match = dir_annotations + "/oligo_DB_match.tsv"
 file_oligo_info_no_match = dir_annotations + "/oligo_DB_no_match.tsv"
 file_oligo_info_exact_matches = dir_annotations + "/oligo_DB_exact_matches.tsv"
+file_oligo_info_cross_hybridization = (
+    dir_annotations + "/oligo_DB_cross_hybridization.tsv"
+)
 
 # blastn parameters
 word_size = 10
@@ -52,6 +60,56 @@ mismatch_region = 5
 file_oligo_info_ligation_match = dir_annotations + "/oligo_DB_ligation_match.tsv"
 file_oligo_info_ligation_nomatch = dir_annotations + "/oligo_DB_ligation_no_match.tsv"
 
+# Parameters Cross-hybridization
+expected_oligos_bigger_region = {
+    "region_1": {
+        "region_1::oligo_7",
+        "region_1::oligo_5",
+        "region_1::oligo_6",
+        "region_1::oligo_8",
+        "region_1::oligo_4",
+    },
+    "region_2": {
+        "region_2::oligo_3",
+        "region_2::oligo_2",
+        "region_2::oligo_6",
+        "region_2::oligo_5",
+        "region_2::oligo_4",
+    },
+    "region_3": {
+        "region_3::oligo_1",
+        "region_3::oligo_4",
+        "region_3::oligo_3",
+        "region_3::oligo_2",
+        "region_3::oligo_5",
+    },
+}
+
+expected_oligos_degree = {
+    "region_1": {
+        "region_1::oligo_1",
+        "region_1::oligo_4",
+        "region_1::oligo_5",
+        "region_1::oligo_6",
+        "region_1::oligo_7",
+    },
+    "region_2": {
+        "region_2::oligo_1",
+        "region_2::oligo_2",
+        "region_2::oligo_3",
+        "region_2::oligo_4",
+        "region_2::oligo_5",
+        "region_2::oligo_6",
+        "region_2::oligo_7",
+    },
+    "region_3": {
+        "region_3::oligo_2",
+        "region_3::oligo_3",
+        "region_3::oligo_4",
+        "region_3::oligo_5",
+    },
+}
+
 ############################################
 # Tests
 ############################################
@@ -63,7 +121,9 @@ def test_filter_exact_matches():
     exact_matches = ExactMatches()
     oligo_database.load_database(file_oligo_info_exact_matches)
     filtered_oligo_info_dict_match = exact_matches.apply(
-        oligo_database.database, None, n_jobs
+        database=oligo_database.database,
+        file_reference=None,
+        n_jobs=n_jobs,
     )
 
     assert (
@@ -206,3 +266,131 @@ def test_seed_filter_no_match(tmp_path):
     assert (
         "WASH7P_1" in filtered_oligo_info_dict_ligation_no_match["WASH7P"].keys()
     ), "A non matching oligo has been filtered from Seed Region Filter!"
+
+
+def test_cross_hybridization_filter_blast_bigger_region_policy(tmp_path):
+    oligo_database = OligoDatabase()
+    blastn = Blastn(
+        tmp_path,
+        word_size=word_size,
+        percent_identity=percent_identity,
+        strand="minus",
+        coverage=coverage,
+    )
+    ch_filter = CrossHybridizationFilter(
+        specificity_filter=blastn,
+        policy=remove_by_bigger_region_policy,
+        dir_cross_hybridization=None,
+    )
+
+    oligo_database.load_database(file_database=file_oligo_info_cross_hybridization)
+    oligo_database_fasta = oligo_database.write_fasta_from_database(
+        os.path.join(tmp_path, "oligo_DB_cross_hybridization")
+    )
+
+    filtered_database = ch_filter.apply(
+        database=oligo_database.database,
+        file_reference=oligo_database_fasta,
+        n_jobs=None,
+    )
+
+    filtered_oligos = {
+        key: {key_2 for key_2 in list(filtered_database[key].keys())}
+        for key in list(filtered_database.keys())
+    }
+    assert (
+        expected_oligos_bigger_region == filtered_oligos
+    ), f"The cross-hybridization filter didn't return the expected oligos. \n\nExpected:\n{expected_oligos_bigger_region}\n\nGot:\n{filtered_oligos}"
+
+
+def test_cross_hybridization_filter_bowtie_bigger_region_policy(tmp_path):
+    oligo_database = OligoDatabase()
+    bowtie_filter = Bowtie(tmp_path, num_mismatches, mismatch_region, strand="minus")
+    ch_filter = CrossHybridizationFilter(
+        specificity_filter=bowtie_filter,
+        policy=remove_by_bigger_region_policy,
+        dir_cross_hybridization=None,
+    )
+
+    oligo_database.load_database(file_database=file_oligo_info_cross_hybridization)
+    oligo_database_fasta = oligo_database.write_fasta_from_database(
+        os.path.join(tmp_path, "oligo_DB_cross_hybridization")
+    )
+
+    filtered_database = ch_filter.apply(
+        database=oligo_database.database,
+        file_reference=oligo_database_fasta,
+        n_jobs=None,
+    )
+
+    filtered_oligos = {
+        key: {key_2 for key_2 in list(filtered_database[key].keys())}
+        for key in list(filtered_database.keys())
+    }
+    assert (
+        expected_oligos_bigger_region == filtered_oligos
+    ), f"The cross-hybridization filter didn't return the expected oligos. \n\nExpected:\n{expected_oligos_bigger_region}\n\nGot:\n{filtered_oligos}"
+
+
+def test_cross_hybridization_filter_blast_degree_policy(tmp_path):
+    oligo_database = OligoDatabase()
+    blastn = Blastn(
+        tmp_path,
+        word_size=word_size,
+        percent_identity=percent_identity,
+        strand="minus",
+        coverage=coverage,
+    )
+    ch_filter = CrossHybridizationFilter(
+        specificity_filter=blastn,
+        policy=remove_by_degree_policy,
+        dir_cross_hybridization=None,
+    )
+
+    oligo_database.load_database(file_database=file_oligo_info_cross_hybridization)
+    oligo_database_fasta = oligo_database.write_fasta_from_database(
+        os.path.join(tmp_path, "oligo_DB_cross_hybridization")
+    )
+
+    filtered_database = ch_filter.apply(
+        database=oligo_database.database,
+        file_reference=oligo_database_fasta,
+        n_jobs=None,
+    )
+
+    filtered_oligos = {
+        key: {key_2 for key_2 in list(filtered_database[key].keys())}
+        for key in list(filtered_database.keys())
+    }
+    assert (
+        expected_oligos_degree == filtered_oligos
+    ), f"The cross-hybridization filter didn't return the expected oligos. \n\nExpected:\n{expected_oligos_degree}\n\nGot:\n{filtered_oligos}"
+
+
+def test_cross_hybridization_filter_bowtie_degree_policy(tmp_path):
+    oligo_database = OligoDatabase()
+    bowtie_filter = Bowtie(tmp_path, num_mismatches, mismatch_region, strand="minus")
+    ch_filter = CrossHybridizationFilter(
+        specificity_filter=bowtie_filter,
+        policy=remove_by_degree_policy,
+        dir_cross_hybridization=None,
+    )
+
+    oligo_database.load_database(file_database=file_oligo_info_cross_hybridization)
+    oligo_database_fasta = oligo_database.write_fasta_from_database(
+        os.path.join(tmp_path, "oligo_DB_cross_hybridization")
+    )
+
+    filtered_database = ch_filter.apply(
+        database=oligo_database.database,
+        file_reference=oligo_database_fasta,
+        n_jobs=None,
+    )
+
+    filtered_oligos = {
+        key: {key_2 for key_2 in list(filtered_database[key].keys())}
+        for key in list(filtered_database.keys())
+    }
+    assert (
+        expected_oligos_degree == filtered_oligos
+    ), f"The cross-hybridization filter didn't return the expected oligos. \n\nExpected:\n{expected_oligos_degree}\n\nGot:\n{filtered_oligos}"


### PR DESCRIPTION
The Cross-hybridization filter has been completed. We can now eliminate oligos that cross-hybridize with Blast or Bowtie and a specified policy.
Available policies:
- `remove_by_bigger_region_policy`: removes the oligo that comes from the region that has the bigger number of oligos
- `remove_by_degree_policy`: removes oligos that bind with the bigger number of oligos first

Remarks:
- No support yet for Bowtie2 (no strand option for now)
- The provided policies are quite naive: the removal is arbitrary if the degree or the number of oligos per region is the same.