### PR TITLE
98 oligo seq pipeline sequencing specific specificity filter for varying read length

### DIFF
--- a/data/configs/oligo_seq_probe_designer.yaml
+++ b/data/configs/oligo_seq_probe_designer.yaml
@@ -39,8 +39,9 @@ target_probe_homopolymeric_base_n: # minimum number of nucleotides to consider i
   T: 6
   C: 6
   G: 6
-target_probe_max_len_selfcomplement: 10 # The maximum length of self-complementary sequence allowed to avoid homodimer formation.
+target_probe_max_len_selfcomplement: 10 # the maximum length of self-complementary sequence allowed to avoid homodimer formation.
 target_probe_hybridization_probability_threshold: 0.001 #the lower the threshold the more stringent the filter
+target_probe_read_len_sequencing_bias: 20 # minimum length of sequencing reads.The first x bases of an oligo should not match the x bases of another oligo to account for shorter sequencing reads that would align to multiple positions.
 target_probe_GC_weight: 1 # weight of the GC content of the probe in the efficiency score
 target_probe_Tm_weight: 1 # weight of the Tm of the probe in the efficiency score
 set_size_min: 3 # minimum size of oligo sets (in case there exist no set of the optimal size) -> genes with less oligos will be filtered out and stored in regions_with_insufficient_oligos_for_db_probes

--- a/data/configs/oligo_seq_probe_designer.yaml
+++ b/data/configs/oligo_seq_probe_designer.yaml
@@ -41,7 +41,7 @@ target_probe_homopolymeric_base_n: # minimum number of nucleotides to consider i
   G: 6
 target_probe_max_len_selfcomplement: 10 # the maximum length of self-complementary sequence allowed to avoid homodimer formation.
 target_probe_hybridization_probability_threshold: 0.001 #the lower the threshold the more stringent the filter
-target_probe_read_len_sequencing_bias: 20 # minimum length of sequencing reads.The first x bases of an oligo should not match the x bases of another oligo to account for shorter sequencing reads that would align to multiple positions.
+target_probe_read_length_bias: 20 # minimum length of sequencing reads. The first <target_probe_read_length_bias> bases of an oligo should not match the <target_probe_read_length_bias> bases of another oligo to account for shorter sequencing reads that would align to multiple positions.
 target_probe_GC_weight: 1 # weight of the GC content of the probe in the efficiency score
 target_probe_Tm_weight: 1 # weight of the Tm of the probe in the efficiency score
 set_size_min: 3 # minimum size of oligo sets (in case there exist no set of the optimal size) -> genes with less oligos will be filtered out and stored in regions_with_insufficient_oligos_for_db_probes

--- a/docs/source/_api_docs/oligo_designer_toolsuite.pipelines.rst
+++ b/docs/source/_api_docs/oligo_designer_toolsuite.pipelines.rst
@@ -9,6 +9,10 @@ Module contents
 .. autosummary::
 
    GenomicRegionGenerator
+   OligoSeqProbeDesigner
+   ScrinshotProbeDesigner
+   SeqFishPlusProbeDesigner
+   MerfishProbeDesigner
 
    {% for name in oligo_designer_toolsuite.pipelines.classes %}
      {{ name }}

--- a/docs/source/_pipelines/oligoseq_probe_designer.rst
+++ b/docs/source/_pipelines/oligoseq_probe_designer.rst
@@ -68,6 +68,7 @@ For a complete explanation of all function parameters, refer to the API document
         target_probe_homopolymeric_base_n={"A": 6, "T": 6, "C": 6, "G": 6},
         target_probe_max_len_selfcomplement=10,
         target_probe_hybridization_probability_threshold=0.001,
+        target_probe_read_length_bias=20,
         target_probe_GC_weight=1,
         target_probe_Tm_weight=1,
         set_size_min=3,
@@ -119,6 +120,7 @@ Next, the probes are checked for off-target binding with any other region of a p
 Off-target regions are sequences of the background reference (e.g. transcriptome or genome) which match the probe region with a certain degree of homology but are not located within the gene region of the probe. 
 Those off-target regions are identified with the ``BlastNFilter`` or ``BowtieFilter`` (users choice) and further refined using the ``HybridizationProbabilityFilter`` which calculates the probability of the probe hybridizing to the identified potential off-target sequences.  
 Probes with a hybridization probability greater than the user-defined trheshold are removed from the database. Refining the alignment hits with the ``HybridizationProbabilityFilter`` helps to retain more probes in the database.
+In addition, we account for length biases during sequencing, where some oligos may not be sequences to their full length. Because these truncated reads can match other oligos and create alignment ambiguities, we exclude any oligos whose first x bases match.
 
 In the third step of the pipeline, the best sets of non-overlapping probes are identified for each gene. 
 The ``OligosetGeneratorIndependentSet`` class is used to generate ranked, non-overlapping probe sets where each probe and probe set is scored according to a protocol dependent scoring function, i.e. by weighted GC content and melting temperature score, of the probes in the set. 

--- a/oligo_designer_toolsuite/_constants.py
+++ b/oligo_designer_toolsuite/_constants.py
@@ -8,7 +8,7 @@ from typing import Literal
 # types
 ############################################
 
-_TYPES_SEQ = Literal["target", "oligo", "sequence_encoding_probe"]
+_TYPES_SEQ = Literal["target", "target_short", "oligo", "oligo_short", "sequence_encoding_probe"]
 _TYPES_FILE = Literal["gff", "gtf", "fasta"]
 _TYPES_FILE_SEQ = Literal["dna", "ncrna"]
 

--- a/oligo_designer_toolsuite/database/_oligo_database.py
+++ b/oligo_designer_toolsuite/database/_oligo_database.py
@@ -120,9 +120,8 @@ class OligoDatabase:
         Loads oligonucleotide data from one or more FASTA files into the database, optionally overwriting the existing database.
 
         This function reads sequences from FASTA file(s) and adds them to the OligoDatabase, either as 'oligo' or
-        'target' sequence and computes the reverse compliment sequence for the other sequence type. It parses the
-        headers of the FASTA entries to extract oligo ttribute information, and assigns unique IDs to the oligos within
-        each region.
+        'target' sequence. It parses the headers of the FASTA entries to extract oligo attribute information,
+        and assigns unique IDs to the oligos within each region.
 
         The header of each sequence must start with '>' and contain the following information:
         region_id, additional_information (optional) and coordinates (chrom, start, end, strand),
@@ -181,11 +180,7 @@ class OligoDatabase:
                     i = 1
                     for oligo_sequence, oligo_attributes in sequences_region.items():
                         oligo_id = f"{region}{SEPARATOR_OLIGO_ID}{i}"
-                        oligo_sequence_reverse_complement = str(Seq(oligo_sequence).reverse_complement())
-                        oligo_seq_info = {
-                            sequence_type: oligo_sequence,
-                            sequence_type_reverse_complement: oligo_sequence_reverse_complement,
-                        } | oligo_attributes
+                        oligo_seq_info = {sequence_type: oligo_sequence} | oligo_attributes
                         database_region[region][oligo_id] = oligo_seq_info
                         i += 1
 
@@ -210,8 +205,6 @@ class OligoDatabase:
         assert (
             sequence_type in options
         ), f"Sequence type not supported! '{sequence_type}' is not in {options}."
-
-        sequence_type_reverse_complement = options[0] if options[0] != sequence_type else options[1]
 
         # Clear database if it should be overwritten
         if database_overwrite:

--- a/oligo_designer_toolsuite/database/_oligo_database.py
+++ b/oligo_designer_toolsuite/database/_oligo_database.py
@@ -685,6 +685,18 @@ class OligoDatabase:
     # Getter Functions
     ############################################
 
+    def get_attribute_list(self) -> list[str]:
+        """Retrieves a list of attribute names stored in the database.
+
+        :return: A list of attribute names stored in the database.
+        :rtype: list[str]
+        """
+        region_id = next(iter(self.database.values()))
+        oligo_id = next(iter(region_id.values()))
+        attributes = list(oligo_id.keys())
+
+        return attributes
+
     def get_regionid_list(self) -> list[str]:
         """
         Retrieves a list of all region IDs present in the database.

--- a/oligo_designer_toolsuite/database/_oligo_database_attributes.py
+++ b/oligo_designer_toolsuite/database/_oligo_database_attributes.py
@@ -948,3 +948,25 @@ class OligoAttributes:
         oligo_database.update_oligo_attributes(new_oligo_attribute)
 
         return oligo_database
+
+    def calculate_shortened_sequence(
+        self,
+        oligo_database: OligoDatabase,
+        sequence_length: int,
+        sequence_type: _TYPES_SEQ = "oligo",
+        region_ids: Union[str, List[str]] = None,
+    ) -> OligoDatabase:
+        region_ids = check_if_list(region_ids) if region_ids else oligo_database.database.keys()
+        new_oligo_attribute = {}
+
+        for region_id in region_ids:
+            for oligo_id in oligo_database.database[region_id].keys():
+                sequence = oligo_database.get_oligo_attribute_value(
+                    attribute=sequence_type, region_id=region_id, oligo_id=oligo_id, flatten=True
+                )
+
+                sequence_short = sequence[:sequence_length]
+                new_oligo_attribute[oligo_id] = {f"{sequence_type}_short": sequence_short}
+        oligo_database.update_oligo_attributes(new_oligo_attribute)
+
+        return oligo_database

--- a/oligo_designer_toolsuite/database/_oligo_database_attributes.py
+++ b/oligo_designer_toolsuite/database/_oligo_database_attributes.py
@@ -4,8 +4,8 @@
 
 from typing import List, Union, Tuple
 
-from Bio.SeqUtils import MeltingTemp as mt
-from Bio.SeqUtils import Seq, gc_fraction
+from Bio.Seq import Seq
+from Bio.SeqUtils import MeltingTemp, gc_fraction
 from seqfold import dg
 
 from oligo_designer_toolsuite._constants import _TYPES_SEQ
@@ -65,6 +65,102 @@ class OligoAttributes:
                 new_oligo_attribute[oligo_id] = {
                     "length": length,
                 }
+        oligo_database.update_oligo_attributes(new_oligo_attribute)
+
+        return oligo_database
+
+    @staticmethod
+    def _calculate_shortened_sequence(sequence: str, sequence_length: int) -> int:
+        """Calculate the shortened sequence of an oligonucleotide sequence.
+
+        :param sequence: The nucleotide sequence.
+        :type sequence: str
+        :param sequence_length: The desired length for the shortened sequence.
+        :type sequence_length: int
+        :return: The shortened sequence.
+        :rtype: str
+        """
+        return sequence[:sequence_length]
+
+    def calculate_shortened_sequence(
+        self,
+        oligo_database: OligoDatabase,
+        sequence_length: int,
+        sequence_type: _TYPES_SEQ = "oligo",
+        region_ids: Union[str, List[str]] = None,
+    ) -> OligoDatabase:
+        """Calculate and update the shortened oligonucleotide sequences for the specified regions of the OligoDatabase.
+
+        :param oligo_database: The OligoDatabase containing the oligonucleotides and their associated attributes.
+        :type oligo_database: OligoDatabase
+        :param sequence_length: The desired length for the shortened sequence.
+        :type sequence_length: int
+        :param sequence_type: The type of sequence to be used for attribute calculation, defaults to "oligo".
+        :type sequence_type: _TYPES_SEQ["oligo", "target"], optional
+        :param region_ids: List of region IDs to process. If None, all regions in the database are processed, defaults to None.
+        :type region_ids: Union[str, List[str]], optional
+        :return: The updated OligoDatabase with the calculated attribute.
+        :rtype: OligoDatabase
+        """
+        region_ids = check_if_list(region_ids) if region_ids else oligo_database.database.keys()
+        new_oligo_attribute = {}
+
+        for region_id in region_ids:
+            for oligo_id in oligo_database.database[region_id].keys():
+                sequence = oligo_database.get_oligo_attribute_value(
+                    attribute=sequence_type, region_id=region_id, oligo_id=oligo_id, flatten=True
+                )
+
+                sequence_short = self._calculate_shortened_sequence(
+                    sequence=sequence, sequence_length=sequence_length
+                )
+                new_oligo_attribute[oligo_id] = {f"{sequence_type}_short": sequence_short}
+        oligo_database.update_oligo_attributes(new_oligo_attribute)
+
+        return oligo_database
+
+    @staticmethod
+    def _calculate_reverse_complement_sequence(sequence: str) -> int:
+        """Calculate the reverse complemented sequence of an oligonucleotide sequence.
+
+        :param sequence: The nucleotide sequence.
+        :type sequence: str
+        :return: The reverse complemented sequence.
+        :rtype: str
+        """
+        return str(Seq(sequence).reverse_complement())
+
+    def calculate_reverse_complement_sequence(
+        self,
+        oligo_database: OligoDatabase,
+        sequence_type: _TYPES_SEQ,
+        sequence_type_reverse_complement: _TYPES_SEQ,
+        region_ids: Union[str, List[str]] = None,
+    ) -> OligoDatabase:
+        """Calculate and update the reverse complement of oligonucleotide sequences for the specified regions of the OligoDatabase.
+
+        :param oligo_database: The OligoDatabase containing the oligonucleotides and their associated attributes.
+        :type oligo_database: OligoDatabase
+        :param sequence_type: The type of sequence to be used for attribute calculation.
+        :type sequence_type: _TYPES_SEQ["oligo", "target"]
+        :param sequence_type_reverse_complement: The type of sequence of the reverse complement.
+        :type sequence_type_reverse_complement: int
+        :param region_ids: List of region IDs to process. If None, all regions in the database are processed, defaults to None.
+        :type region_ids: Union[str, List[str]], optional
+        :return: The updated OligoDatabase with the calculated attribute.
+        :rtype: OligoDatabase
+        """
+        region_ids = check_if_list(region_ids) if region_ids else oligo_database.database.keys()
+        new_oligo_attribute = {}
+
+        for region_id in region_ids:
+            for oligo_id in oligo_database.database[region_id].keys():
+                sequence = oligo_database.get_oligo_attribute_value(
+                    attribute=sequence_type, region_id=region_id, oligo_id=oligo_id, flatten=True
+                )
+
+                sequence_rc = self._calculate_reverse_complement_sequence(sequence=sequence)
+                new_oligo_attribute[oligo_id] = {sequence_type_reverse_complement: sequence_rc}
         oligo_database.update_oligo_attributes(new_oligo_attribute)
 
         return oligo_database
@@ -410,11 +506,11 @@ class OligoAttributes:
         :return: The calculated melting temperature (Tm) in degrees Celsius, rounded to two decimal places.
         :rtype: float
         """
-        TmNN = mt.Tm_NN(sequence, **Tm_parameters)
+        TmNN = MeltingTemp.Tm_NN(sequence, **Tm_parameters)
         if Tm_salt_correction_parameters is not None:
-            TmNN += mt.salt_correction(**Tm_salt_correction_parameters, seq=sequence)
+            TmNN += MeltingTemp.salt_correction(**Tm_salt_correction_parameters, seq=sequence)
         if Tm_chem_correction_parameters is not None:
-            TmNN = mt.chem_correction(TmNN, **Tm_chem_correction_parameters)
+            TmNN = MeltingTemp.chem_correction(TmNN, **Tm_chem_correction_parameters)
         TmNN = round(TmNN, 2)
         return TmNN
 
@@ -945,28 +1041,6 @@ class OligoAttributes:
                     "detect_oligo_long_left": detect_oligo_long_left,
                     "detect_oligo_long_right": detect_oligo_long_right,
                 }
-        oligo_database.update_oligo_attributes(new_oligo_attribute)
-
-        return oligo_database
-
-    def calculate_shortened_sequence(
-        self,
-        oligo_database: OligoDatabase,
-        sequence_length: int,
-        sequence_type: _TYPES_SEQ = "oligo",
-        region_ids: Union[str, List[str]] = None,
-    ) -> OligoDatabase:
-        region_ids = check_if_list(region_ids) if region_ids else oligo_database.database.keys()
-        new_oligo_attribute = {}
-
-        for region_id in region_ids:
-            for oligo_id in oligo_database.database[region_id].keys():
-                sequence = oligo_database.get_oligo_attribute_value(
-                    attribute=sequence_type, region_id=region_id, oligo_id=oligo_id, flatten=True
-                )
-
-                sequence_short = sequence[:sequence_length]
-                new_oligo_attribute[oligo_id] = {f"{sequence_type}_short": sequence_short}
         oligo_database.update_oligo_attributes(new_oligo_attribute)
 
         return oligo_database

--- a/oligo_designer_toolsuite/oligo_efficiency_filter/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/oligo_efficiency_filter/_oligo_scoring.py
@@ -74,7 +74,7 @@ class GCOligoScoring(OligoScoringBase):
     """
     A class for scoring oligonucleotides based on their GC content.
 
-        :math:`score = |GC_opt} - GC_{oligo}|`
+        :math:`score = |GC_{opt} - GC_{oligo}|`
 
     The `GCOligoScoring` class calculates the score for an oligo by evaluating the difference between
     its actual GC content and a predefined optimal GC content. The smaller the difference,

--- a/oligo_designer_toolsuite/oligo_efficiency_filter/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/oligo_efficiency_filter/_oligo_scoring.py
@@ -189,7 +189,8 @@ class WeightedTmGCOligoScoring(OligoScoringBase):
     """
     A class used to score oligonucleotides based on their melting temperature (Tm) and GC content.
 
-        :math:`score = w_{Tm}\\left[I_{Tm_{oligo} \\ge Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{max} - Tm_{opt}}\\right) + I_{Tm_{oligo} < Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{opt} - Tm_{min}}\\right)\\right] + w_{GC}\\left[I_{GC_{oligo} \\ge GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{max} - GC_{opt}} + I_{GC_{oligo} < GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{opt} - GC_{min}}\\right]`
+        :math:`score = w_{Tm}\\left[I_{Tm_{oligo} \\ge Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{max} - Tm_{opt}}\\right) + I_{Tm_{oligo} < Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{opt} - Tm_{min}}\\right)\\right]`
+        :math:`+ w_{GC}\\left[I_{GC_{oligo} \\ge GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{max} - GC_{opt}} + I_{GC_{oligo} < GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{opt} - GC_{min}}\\right]`
 
     The `WeightedTmGCOligoScoring` class evaluates nucleotides by calculating a weighted score that considers both
     the deviation of the oligo's melting temperature from an optimal value and the deviation of its GC content from a desired
@@ -332,7 +333,8 @@ class WeightedIsoformTmGCOligoScoring(WeightedTmGCOligoScoring):
     """
     A class for scoring oligonucleotides based on melting temperature (Tm), GC content, and isoform consensus.
 
-        :math:`score = w_{Tm}\\left[I_{Tm_{oligo} \\ge Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{max} - Tm_{opt}}\\right) + I_{Tm_{oligo} < Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{opt} - Tm_{min}}\\right)\\right] + w_{GC}\\left[I_{GC_{oligo} \\ge GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{max} - GC_{opt}} + I_{GC_{oligo} < GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{opt} - GC_{min}}\\right] + w_{IC} IC`
+        :math:`score = w_{Tm}\\left[I_{Tm_{oligo} \\ge Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{max} - Tm_{opt}}\\right) + I_{Tm_{oligo} < Tm_{opt}}\\left(\\frac{|Tm_{oligo} - Tm_{opt}|}{Tm_{opt} - Tm_{min}}\\right)\\right]`
+        :math:`+ w_{GC}\\left[I_{GC_{oligo} \\ge GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{max} - GC_{opt}} + I_{GC_{oligo} < GC_{opt}}\\frac{|GC_{oligo} - GC_{opt}|}{GC_{opt} - GC_{min}}\\right] + w_{IC} IC`
 
     This class extends `WeightedTmGCOligoScoring` by incorporating isoform targeting efficiency into the scoring criteria.
     It calculates a composite score using weights assigned to Tm, GC content, and isoform consensus, helping in the selection

--- a/oligo_designer_toolsuite/pipelines/__init__.py
+++ b/oligo_designer_toolsuite/pipelines/__init__.py
@@ -5,10 +5,14 @@ The module provides a collection of comprehensive oligonucleotide design pipelin
 from ._genomic_region_generator import GenomicRegionGenerator
 from ._oligo_seq_probe_designer import OligoSeqProbeDesigner
 from ._scrinshot_probe_designer import ScrinshotProbeDesigner
+from ._seqfish_plus_probe_designer import SeqFishPlusProbeDesigner
+from ._merfish_probe_designer import MerfishProbeDesigner
 
 
 __all__ = [
     "GenomicRegionGenerator",
     "OligoSeqProbeDesigner",
     "ScrinshotProbeDesigner",
+    "SeqFishPlusProbeDesigner",
+    "MerfishProbeDesigner",
 ]

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -1136,6 +1136,9 @@ class TargetProbeDesigner:
             sequence_type="target",
             region_ids=gene_ids,
         )
+        oligo_database = self.oligo_attributes_calculator.calculate_reverse_complement_sequence(
+            oligo_database=oligo_database, sequence_type="target", sequence_type_reverse_complement="oligo"
+        )
 
         ##### pre-filter oligo database for certain attributes #####
         oligo_database = self.oligo_attributes_calculator.calculate_isoform_consensus(

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -801,6 +801,9 @@ class TargetProbeDesigner:
             sequence_type="target",
             region_ids=gene_ids,
         )
+        oligo_database = self.oligo_attributes_calculator.calculate_reverse_complement_sequence(
+            oligo_database=oligo_database, sequence_type="target", sequence_type_reverse_complement="oligo"
+        )
 
         ##### pre-filter oligo database for certain attributes #####
         oligo_database = self.oligo_attributes_calculator.calculate_isoform_consensus(

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -1021,6 +1021,9 @@ class TargetProbeDesigner:
             sequence_type="target",
             region_ids=gene_ids,
         )
+        oligo_database = self.oligo_attributes_calculator.calculate_reverse_complement_sequence(
+            oligo_database=oligo_database, sequence_type="target", sequence_type_reverse_complement="oligo"
+        )
 
         ##### pre-filter oligo database for certain attributes #####
         oligo_database = self.oligo_attributes_calculator.calculate_isoform_consensus(

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -141,7 +141,9 @@ class CustomGenomicRegionGenerator:
         Generates gene sequences based on gene annotations. These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id}::{chromosome}:{start}-{end}({strand})
+        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id}
+        ::{chromosome}:{start}-{end}({strand})
 
         sequence
 
@@ -193,7 +195,8 @@ class CustomGenomicRegionGenerator:
         These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{intergenic_region_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype}::{chromosome}:{start}-{end}({strand})
+        >{intergenic_region_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype}::{chromosome}:{start}-{end}({strand})
 
         sequence
 
@@ -383,7 +386,10 @@ class CustomGenomicRegionGenerator:
         These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+        exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
+        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
         sequence
 
         :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
@@ -452,7 +458,10 @@ class CustomGenomicRegionGenerator:
         These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},intron_number={intron_number_x};transcript_id={transcript_id_b},intron_number={intron_number_y};number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+        intron_number={intron_number_x};transcript_id={transcript_id_b},intron_number={intron_number_y};
+        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
         sequence
 
         :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
@@ -586,7 +595,10 @@ class CustomGenomicRegionGenerator:
         These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+        exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
+        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
         sequence
 
         :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
@@ -661,7 +673,10 @@ class CustomGenomicRegionGenerator:
         These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+        exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
+        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
         sequence
 
         :param five_prime: Boolean flag indicating whether to include 5' UTR sequences. Defaults to True.
@@ -794,7 +809,10 @@ class CustomGenomicRegionGenerator:
         These sequences are then saved in a FASTA file.
 
         Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},exon_number={exon_number_x__JUNC__exon_number_y};transcript_id={transcript_id_b},exon_number={exon_number_y__JUNC__exon_number_z};number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+        exon_number={exon_number_x__JUNC__exon_number_y};transcript_id={transcript_id_b},
+        exon_number={exon_number_y__JUNC__exon_number_z};number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
         sequence
 
         :param block_size: The size of the sequence block used to generate junctions between exons. This parameter determines the length of the sequence blocks flanking the junctions.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -288,6 +288,18 @@ class TestOligoDatabase(unittest.TestCase):
             len(REGION_IDS) - 1 + 1  # one region removed but one added from random seqs
         ), "error: wrong number of regions in database"
 
+    def test_get_attribute_list(self):
+        self.oligo_database.load_database_from_table(
+            file_database=FILE_DATABASE_OLIGO_ATTRIBUTES,
+            region_ids=None,
+            database_overwrite=True,
+        )
+
+        list_attributes = self.oligo_database.get_attribute_list()
+        print(list_attributes)
+        assert len(list_attributes) == 13, "error: wrong number of attributes in database"
+        assert "oligo" in list_attributes, "error: missing attribute"
+
     def test_get_oligoid_list(self):
         self.oligo_database.load_database_from_table(
             file_database=FILE_DATABASE_OLIGO_ATTRIBUTES,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -625,3 +625,33 @@ class TestOligoAttributes(unittest.TestCase):
         assert detect_oligo_even == "AGGGAATCGAAT", "error: wrong detection oligo even calculated"
         assert detect_oligo_long_left == None, "error: wrong detection oligo left calculated"
         assert detect_oligo_long_right == None, "error: wrong detection oligo right calculated"
+
+    def test_calculate_shortened_sequence(self):
+        # check if it works for oligos
+        sequence_type = "oligo"
+
+        oligo_database = self.oligo_attributes.calculate_shortened_sequence(
+            self.oligo_database,
+            sequence_length=10,
+            sequence_type=sequence_type,
+        )
+
+        sequence_short_oligo = oligo_database.get_oligo_attribute_value(
+            attribute=f"{sequence_type}_short", flatten=True, region_id="region_1", oligo_id="region_1::2"
+        )
+
+        # check if it works for targets
+        sequence_type = "target"
+
+        oligo_database = self.oligo_attributes.calculate_shortened_sequence(
+            self.oligo_database,
+            sequence_length=5,
+            sequence_type=sequence_type,
+        )
+
+        sequence_short_target = oligo_database.get_oligo_attribute_value(
+            attribute=f"{sequence_type}_short", flatten=True, region_id="region_1", oligo_id="region_1::2"
+        )
+
+        assert sequence_short_oligo == "GGCTAGGGAA", "error: wrong short sequence calculated"
+        assert sequence_short_target == "CTCTA", "error: wrong short sequence calculated"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -476,6 +476,53 @@ class TestOligoAttributes(unittest.TestCase):
         assert length1 == 20, "error: wrong oligo length"
         assert length2 == 29, "error: wrong oligo length"
 
+    def test_calculate_reverse_complement_sequence(self):
+        oligo_database = self.oligo_attributes.calculate_reverse_complement_sequence(
+            oligo_database=self.oligo_database,
+            sequence_type="target",
+            sequence_type_reverse_complement="oligo",
+        )
+
+        target = oligo_database.get_oligo_attribute_value(
+            attribute="target", flatten=True, region_id="region_1", oligo_id="region_1::1"
+        )
+        oligo = oligo_database.get_oligo_attribute_value(
+            attribute="oligo", flatten=True, region_id="region_1", oligo_id="region_1::1"
+        )
+
+        assert target == "ATCGTCATCCATTGGGGCAT", "error: wrong target sequence"
+        assert oligo == "ATGCCCCAATGGATGACGAT", "error: wrong oligo sequence"
+
+    def test_calculate_shortened_sequence(self):
+        # check if it works for oligos
+        sequence_type = "oligo"
+
+        oligo_database = self.oligo_attributes.calculate_shortened_sequence(
+            self.oligo_database,
+            sequence_length=10,
+            sequence_type=sequence_type,
+        )
+
+        sequence_short_oligo = oligo_database.get_oligo_attribute_value(
+            attribute=f"{sequence_type}_short", flatten=True, region_id="region_1", oligo_id="region_1::2"
+        )
+
+        # check if it works for targets
+        sequence_type = "target"
+
+        oligo_database = self.oligo_attributes.calculate_shortened_sequence(
+            self.oligo_database,
+            sequence_length=5,
+            sequence_type=sequence_type,
+        )
+
+        sequence_short_target = oligo_database.get_oligo_attribute_value(
+            attribute=f"{sequence_type}_short", flatten=True, region_id="region_1", oligo_id="region_1::2"
+        )
+
+        assert sequence_short_oligo == "GGCTAGGGAA", "error: wrong short sequence calculated"
+        assert sequence_short_target == "CTCTA", "error: wrong short sequence calculated"
+
     def test_calculate_num_targeted_transcripts(self):
         oligo_database = self.oligo_attributes.calculate_num_targeted_transcripts(self.oligo_database)
 
@@ -625,33 +672,3 @@ class TestOligoAttributes(unittest.TestCase):
         assert detect_oligo_even == "AGGGAATCGAAT", "error: wrong detection oligo even calculated"
         assert detect_oligo_long_left == None, "error: wrong detection oligo left calculated"
         assert detect_oligo_long_right == None, "error: wrong detection oligo right calculated"
-
-    def test_calculate_shortened_sequence(self):
-        # check if it works for oligos
-        sequence_type = "oligo"
-
-        oligo_database = self.oligo_attributes.calculate_shortened_sequence(
-            self.oligo_database,
-            sequence_length=10,
-            sequence_type=sequence_type,
-        )
-
-        sequence_short_oligo = oligo_database.get_oligo_attribute_value(
-            attribute=f"{sequence_type}_short", flatten=True, region_id="region_1", oligo_id="region_1::2"
-        )
-
-        # check if it works for targets
-        sequence_type = "target"
-
-        oligo_database = self.oligo_attributes.calculate_shortened_sequence(
-            self.oligo_database,
-            sequence_length=5,
-            sequence_type=sequence_type,
-        )
-
-        sequence_short_target = oligo_database.get_oligo_attribute_value(
-            attribute=f"{sequence_type}_short", flatten=True, region_id="region_1", oligo_id="region_1::2"
-        )
-
-        assert sequence_short_oligo == "GGCTAGGGAA", "error: wrong short sequence calculated"
-        assert sequence_short_target == "CTCTA", "error: wrong short sequence calculated"


### PR DESCRIPTION
Changes include:
- add filter for read length biases, where we remove oligos that match within the first x bases
- use exact match filter on shortened oligo sequences to remove read length bias sequences
- add oligo attribute calculator for shortened sequences
- add new sequence type to _TYPES_SEQ
- add oligo attribute calculator for reverse complement of sequences and remove automatic rc computation when reading in a fasta file into the oligo database
- add tests for new functions
- adapt existing pipeline to new loading of fasta files into oligo databases
- adjust documentation for oligo-seq pipeline
- corrent Exact Match filter for all pipelines, as it should use RemoveAll policy because matching oligos will have off-targets anyways