### PR TITLE
Fix FTP download of ENSEMBL with current release

### DIFF
--- a/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
+++ b/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
@@ -196,6 +196,7 @@ class FtpLoaderEnsembl(BaseFtpLoader):
             file_readme = self._download(self.ftp_link, "pub/", "current_README")
             with open(file_readme, "r") as handle:
                 for line in handle:
+                    # assumes that a line in the format 'Ensembl Release 114 Databases.' is present
                     if line.startswith("Ensembl Release"):
                         self.annotation_release = line.strip().split(" ")[2]
             os.remove(file_readme)

--- a/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
+++ b/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
@@ -196,8 +196,8 @@ class FtpLoaderEnsembl(BaseFtpLoader):
             file_readme = self._download(self.ftp_link, "pub/", "current_README")
             with open(file_readme, "r") as handle:
                 for line in handle:
-                    if line.startswith("The current release is"):
-                        self.annotation_release = line.strip().split("Ensembl ")[1]
+                    if line.startswith("Ensembl Release"):
+                        self.annotation_release = line.strip().split(" ")[2]
             os.remove(file_readme)
 
         if file_type.casefold() == "fasta".casefold():


### PR DESCRIPTION
The FTP download of Ensembl data was not possible anymore when using 'current' as the `annotation_release` value.

This is because the line in the 'current_README'  file from Ensembl does not have the format assumed in the `_get_params` function anymore. I could not verify when it changed, but have changed the code to the current format to extract the current Ensembl release version number.