### PR TITLE
120 fix intergenic parsing

### DIFF
--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -291,13 +291,19 @@ class CustomGenomicRegionGenerator:
                 chromosome_length = pd.read_csv(
                     file_chromosome_length, sep="\t", comment="t", header=0, names=["seqid", "length"]
                 )
+                if strand == "+":
+                    region_id_name = "InterRegPlus"
+                elif strand == "-":
+                    region_id_name = "InterRegMinus"
+                else:
+                    raise ValueError(f"Invalid strand value: {strand}. Expected '+' or '-'.")
                 intergenic_annotation = pd.DataFrame(
                     {
                         "seqid": seqid,
                         "start_0base": 0,
                         "end": chromosome_length.length[chromosome_length.seqid == seqid],
                         "start_1base": 1,
-                        "region_id": "InterRegPlus" + str(seqid) + "_1",
+                        "region_id": region_id_name + str(seqid) + "_0",
                         "score": ".",
                         "strand": strand,
                     }

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -97,7 +97,7 @@ class GffParser:
         )
 
         info_df = self._info_to_df(extra_info_file, chunk_size=chunk_size)
-        csv_df = pd.read_csv(csv_file, sep="\t", names=self.GFF_HEADER, header=None)
+        csv_df = pd.read_csv(csv_file, sep="\t", names=self.GFF_HEADER, header=None, dtype={"seqid": "string"})
 
         csv_df.reset_index(inplace=True, drop=True)
         info_df.reset_index(inplace=True, drop=True)

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -1,0 +1,10 @@
+# Data Resources
+
+## Folder ```annotations```
+
+The file "GCF_000001405.40_GRCh38.p14_genomic.gtf" was downloaded from NCBI via the `NcbiGenomicRegionGenerator`.
+Then, chromsomes 16 and KI270728.1 were extracted via:
+
+```
+awk '$1 ~ /^#/ {print $0;next} {if ($1 == "16" || $1 == "KI270728.1") print}' GCF_000001405.40_GRCh38.p14_genomic.gtf > custom_GCF_000001405.40_GRCh38.p14_genomic_chr16_KI270728-1.gtf
+```

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,10 +12,10 @@ from effidict import LRUPickleDict
 
 from oligo_designer_toolsuite.database import OligoDatabase
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
-from oligo_designer_toolsuite.utils import FastaParser, GffParser, VCFParser
 from oligo_designer_toolsuite.utils import (
     FastaParser,
     GffParser,
+    VCFParser,
     check_if_dna_sequence,
     check_if_key_exists,
     check_if_list,
@@ -35,6 +35,7 @@ from oligo_designer_toolsuite.utils import (
 
 FILE_GFF = "tests/data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.gff"
 FILE_GTF = "tests/data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.gtf"
+FILE_GTF_COMPLEX = "tests/data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16_KI270728-1.gtf"
 FILE_FASTA = "tests/data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.fna"
 FILE_VCF = "tests/data/annotations/custom_GCF_000001405.40.chr16.vcf"
 FILE_TSV = "tests/data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.gtf.tsv"
@@ -288,6 +289,15 @@ class TestGffParser(unittest.TestCase):
         result = self.parser.parse_annotation_from_gff(FILE_GTF, target_lines=10)
         assert result.shape[1] == 20, "error: GTF dataframe not correctly loaded"
 
+    def test_parse_annotation_from_gtf_no_duplicates(self):
+        """Test when parsing GTF annotation chromosomes are not read in as both integers and strings."""
+        result = self.parser.parse_annotation_from_gff(FILE_GTF_COMPLEX)
+        self.assertListEqual(
+            result["seqid"].unique().tolist(),
+            ["16", "KI270728.1"],
+            "error: GTF parsing does not generate unique chromosome values",
+        )
+
     def test_load_annotation_from_pickle_file(self):
         """Test loading annotation from a pickle file."""
         result = self.parser.load_annotation_from_pickle(FILE_PICKLE)
@@ -321,7 +331,7 @@ class TestFastaParser(unittest.TestCase):
             assert (
                 out == False
             ), f"error: checker: check_fasta_format did not raise an exception with file {FILE_GFF}"
-        except Exception as e:
+        except Exception:
             pass  # should go into this case
 
     def test_is_coordinate(self):
@@ -429,7 +439,7 @@ class TestVCFParser(unittest.TestCase):
             assert (
                 out == False
             ), f"error: checker: check_fasta_format did not raise an exception with file {FILE_GFF}"
-        except Exception as e:
+        except Exception:
             pass  # should go into this case
 
     def test_read_vcf_variants(self):


### PR DESCRIPTION
Closes #120 

Generating intergenic regions led to duplicated regions. This was due to 2 different bugs:
- in `parse_annotation_from_gff`, pandas reads in a csv file with information about the sequences, containing the chromosome. Because the file is so large, `pd.read_csv` reads in the file in chunks, which leads to guessing the dtype. Because besides the autosomes, also scaffold chromsomes with alphanumeric names are contained, some chunks contain only autosomes and other chunks both autosomes and scaffold chromosomes. Therefore, the same chromosome can be read in as integer and as string, e.g. as 1 and '1'.  Because `_compute_intergenic_annotation` splits the dataframe based on unique values, the entries for the autosomes get split up into two parts and duplicates are generated.
This behavior of `read_csv` only occurs with large files and therefore was not caught by small test files.
- in `_compute_intergenic_annotation_strand`, in the case if one strand of a chromosome doesn't contain any genes, the intergenic region was always described as InterRegPlus. This mainly affected scaffold chromosomes.
Additionally, I changed the naming of the only intergenic region from _1 to _0 to be in line how the first intergenic region is called when there are several intergenic regions.

For the parsing, I added a test case with a large enough file that contains an autosome and a scaffold chromosome that originally showed the wrong parsing behavior.

The changes in how the imports and exceptions are written is due to the pre-commit hook.