### PR TITLE
Unify blast and bowtie `search_parameters`

### DIFF
--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -3,13 +3,13 @@
 ############################################
 
 import os
-import warnings
 import subprocess
+import warnings
+from abc import abstractmethod
+from typing import List, Tuple, Union
+
 import numpy as np
 import pandas as pd
-
-from abc import abstractmethod
-from typing import List, Union, Tuple
 from Bio import SeqIO
 
 from oligo_designer_toolsuite._constants import _TYPES_SEQ
@@ -85,8 +85,8 @@ class BlastNFilter(AlignmentSpecificityFilter):
 
         # Define default output format for blast search filter. The fields are:
         # query, reference, alignment_length, query_start, query_end, query_length
-        if "outfmt" not in self.search_parameters.keys():
-            self.search_parameters["outfmt"] = "6 qseqid sseqid length qstart qend qlen"
+        if "-outfmt" not in self.search_parameters.keys():
+            self.search_parameters["-outfmt"] = "6 qseqid sseqid length qstart qend qlen"
 
     def _create_index(
         self,
@@ -163,7 +163,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
         for parameter, value in self.search_parameters.items():
             # add quotes if list of strings seperated by whitespace
             value = f'"{value}"' if " " in str(value) else value
-            cmd_parameters += f" -{parameter} {value}"
+            cmd_parameters += f" {parameter} {value}"
 
         cmd = (
             "blastn"

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -4,7 +4,7 @@
 
 import os
 import subprocess
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
 import pandas as pd
 from Bio import SeqIO
@@ -153,20 +153,13 @@ class BowtieFilter(AlignmentSpecificityFilter):
 
         cmd_parameters = ""
         for parameter, value in self.search_parameters.items():
-            cmd_parameters += f" {parameter} {value}"
+            cmd_parameters += f" -{parameter} {value}"
 
-        cmd = (
-            "bowtie"
-            + " -x "
-            + file_index
-            + " -f"  # fasta file is input
-            + " -a"  # report all alignments -> TODO: does this make sense or set e.g. -k 100
-            + cmd_parameters
-            + " "
-            + file_oligo_database
-            + " "
-            + file_bowtie_results
-        )
+        cmd = "bowtie" + " -x " + file_index + " -f"  # fasta file is input
+        # return all alignments only if the number of alignments is not specified
+        if "k" not in self.search_parameters.keys():
+            cmd += " -a"
+        cmd += cmd_parameters + " " + file_oligo_database + " " + file_bowtie_results
         process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output, stdout=subprocess.DEVNULL).wait()
 
         # read the reuslts of the bowtie search
@@ -433,21 +426,13 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
 
         cmd_parameters = ""
         for parameter, value in self.search_parameters.items():
-            cmd_parameters += f" {parameter} {value}"
+            cmd_parameters += f" -{parameter} {value}"
 
-        cmd = (
-            "bowtie2 --quiet"
-            + " --no-hd --no-unal"
-            + " -x "
-            + file_index
-            + " -f"  # fast file is input
-            + " -a"  # report all alignments -> TODO: does this make sense or set e.g. -k 100
-            + cmd_parameters
-            + " -U "
-            + file_oligo_database
-            + " -S "
-            + file_bowtie_results
-        )
+        cmd = "bowtie2 --quiet" + " --no-hd --no-unal" + " -x " + file_index + " -f"  # fast file is input
+        # return all alignments only if the number of alignments is not specified
+        if "k" not in self.search_parameters.keys():
+            cmd += " -a"
+        cmd += cmd_parameters + " -U " + file_oligo_database + " -S " + file_bowtie_results
         process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output).wait()
 
         # read the reuslts of the bowtie seatch

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -153,11 +153,11 @@ class BowtieFilter(AlignmentSpecificityFilter):
 
         cmd_parameters = ""
         for parameter, value in self.search_parameters.items():
-            cmd_parameters += f" -{parameter} {value}"
+            cmd_parameters += f" {parameter} {value}"
 
         cmd = "bowtie" + " -x " + file_index + " -f"  # fasta file is input
         # return all alignments only if the number of alignments is not specified
-        if "k" not in self.search_parameters.keys():
+        if "-k" not in self.search_parameters.keys():
             cmd += " -a"
         cmd += cmd_parameters + " " + file_oligo_database + " " + file_bowtie_results
         process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output, stdout=subprocess.DEVNULL).wait()
@@ -426,11 +426,11 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
 
         cmd_parameters = ""
         for parameter, value in self.search_parameters.items():
-            cmd_parameters += f" -{parameter} {value}"
+            cmd_parameters += f" {parameter} {value}"
 
         cmd = "bowtie2 --quiet" + " --no-hd --no-unal" + " -x " + file_index + " -f"  # fast file is input
         # return all alignments only if the number of alignments is not specified
-        if "k" not in self.search_parameters.keys():
+        if "-k" not in self.search_parameters.keys():
             cmd += " -a"
         cmd += cmd_parameters + " -U " + file_oligo_database + " -S " + file_bowtie_results
         process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output).wait()

--- a/tests/notebooks/test_oligo_specificity_filter.ipynb
+++ b/tests/notebooks/test_oligo_specificity_filter.ipynb
@@ -79,12 +79,12 @@
             },
             {
                   "cell_type": "code",
-                  "execution_count": 5,
+                  "execution_count": null,
                   "metadata": {},
                   "outputs": [],
                   "source": [
                         "# Blast parameters\n",
-                        "blast_search_parameters = {\"perc_identity\": 80, \"strand\": \"plus\", \"word_size\": 10}\n",
+                        "blast_search_parameters = {\"-perc_identity\": 80, \"-strand\": \"plus\", \"-word_size\": 10}\n",
                         " \n",
                         "\n",
                         "blast_hit_parameters = {\"coverage\": 50}\n",
@@ -98,9 +98,9 @@
                         "\n",
                         "# Parameters Cross-hybridization\n",
                         "blast_search_parameters_crosshyb = {\n",
-                        "    \"perc_identity\": 80,\n",
-                        "    \"strand\": \"minus\",\n",
-                        "    \"word_size\": 10,\n",
+                        "    \"-perc_identity\": 80,\n",
+                        "    \"-strand\": \"minus\",\n",
+                        "    \"-word_size\": 10,\n",
                         "}\n"
                   ]
             },
@@ -675,7 +675,7 @@
             },
             {
                   "cell_type": "code",
-                  "execution_count": 26,
+                  "execution_count": null,
                   "metadata": {},
                   "outputs": [
                         {
@@ -687,7 +687,7 @@
                         }
                   ],
                   "source": [
-                        "blast_search_parameters = {\"perc_identity\": 80, \"strand\": \"both\", \"word_size\": 10}\n",
+                        "blast_search_parameters = {\"-perc_identity\": 80, \"-strand\": \"both\", \"-word_size\": 10}\n",
                         "\n",
                         "# define the seqeunces\n",
                         "sequences = [\n",
@@ -852,7 +852,7 @@
             },
             {
                   "cell_type": "code",
-                  "execution_count": 32,
+                  "execution_count": null,
                   "metadata": {},
                   "outputs": [
                         {
@@ -1010,7 +1010,7 @@
                         "        return predictions\n",
                         "    \n",
                         "tmp_path = os.path.join(os.getcwd(), \"tmp_hybridization_probability_outputs\")\n",
-                        "blast_search_parameters = blast_search_parameters = {\"perc_identity\": 80, \"strand\": \"both\", \"word_size\": 10}\n",
+                        "blast_search_parameters = blast_search_parameters = {\"-perc_identity\": 80, \"-strand\": \"both\", \"-word_size\": 10}\n",
                         "blast_hit_parameters = {\"coverage\": 50}\n",
                         "alignment_filter = BlastNFilter(\n",
                         "    blast_search_parameters=blast_search_parameters, \n",

--- a/tests/test_oligo_specificity_filter.py
+++ b/tests/test_oligo_specificity_filter.py
@@ -179,9 +179,9 @@ class AlignmentFilterTestBase:
 class TestBlastFilter(AlignmentFilterTestBase, unittest.TestCase):
     def setup_filter(self):
         blastn_search_parameters = {
-            "perc_identity": 80,
-            "strand": "plus",
-            "word_size": 10,
+            "-perc_identity": 80,
+            "-strand": "plus",
+            "-word_size": 10,
         }
         hit_parameters = {"coverage": 50}
 
@@ -207,9 +207,9 @@ class TestBowtie2Filter(AlignmentFilterTestBase, unittest.TestCase):
 class TestBlastNSeedregionLigationsiteFilter(AlignmentFilterTestBase, unittest.TestCase):
     def setup_filter(self):
         blastn_search_parameters = {
-            "perc_identity": 80,
-            "strand": "plus",
-            "word_size": 10,
+            "-perc_identity": 80,
+            "-strand": "plus",
+            "-word_size": 10,
         }
         hit_parameters = {"coverage": 50}
         seedregion_size = 10
@@ -241,9 +241,9 @@ class TestCrossHybridizationFilter(unittest.TestCase):
 
         # Blast parameters
         self.blastn_search_parameters_crosshyb = {
-            "perc_identity": 80,
-            "strand": "minus",
-            "word_size": 10,
+            "-perc_identity": 80,
+            "-strand": "minus",
+            "-word_size": 10,
         }
         self.hit_parameters_crosshyb = {"coverage": 50}
 
@@ -375,9 +375,9 @@ class TestHybridizationProbabilityBalstn(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp_path = os.path.join(os.getcwd(), "tmp_output_hybridization_probability_filter_blast")
         blastn_search_parameters = {
-            "perc_identity": 80,
-            "strand": "both",
-            "word_size": 10,
+            "-perc_identity": 80,
+            "-strand": "both",
+            "-word_size": 10,
         }
         hit_parameters = {"coverage": 50}
         self.alignment_filter = BlastNFilter(


### PR DESCRIPTION
EDIT: see below comments

unify the behavior of `search_parameters` for bowtie and blast filters. Now, as for blast, the arguments in `search_parameters` don't need to be specified with a leading `-`.

Also, we check if `k` is in `search_parameters` for the bowtie filters (specify the number of reported alignments) and in this case don't use the `-a` option anymore.

closes #130 