### PR TITLE
109 general database content checks

### DIFF
--- a/oligo_designer_toolsuite/oligo_property_filter/_property_filter.py
+++ b/oligo_designer_toolsuite/oligo_property_filter/_property_filter.py
@@ -64,7 +64,6 @@ class PropertyFilter:
                 for region_id in region_ids
             )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         return oligo_database
 
     def _filter_region(

--- a/oligo_designer_toolsuite/oligo_selection/_generate_oligosets.py
+++ b/oligo_designer_toolsuite/oligo_selection/_generate_oligosets.py
@@ -107,7 +107,6 @@ class OligosetGeneratorIndependentSet:
                 for region_id in region_ids
             )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="oligoset generation")
         return oligo_database
 
     def _get_oligo_set_for_region(
@@ -302,7 +301,6 @@ class HomogeneousPropertyOligoSetGenerator:
                 for region_id in region_ids
             )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="oligoset generation")
         return oligo_database
 
     def _get_oligo_sets_for_region(

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_specificity_filter.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_specificity_filter.py
@@ -65,6 +65,5 @@ class SpecificityFilter:
                 sequence_type=sequence_type,
                 n_jobs=n_jobs,
             )
-            oligo_database.remove_regions_with_insufficient_oligos("Specificity Filters")
 
         return oligo_database

--- a/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
@@ -316,7 +316,6 @@ class CycleHCRProbeDesigner:
             min_oligos_per_gene=set_size_min,
             isoform_consensus=target_probe_isoform_consensus,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
@@ -335,7 +334,6 @@ class CycleHCRProbeDesigner:
             Tm_chem_correction_parameters=self.target_probe_Tm_chem_correction_parameters,
             Tm_salt_correction_parameters=self.target_probe_Tm_salt_correction_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
@@ -351,7 +349,6 @@ class CycleHCRProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.target_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.target_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
@@ -374,7 +371,6 @@ class CycleHCRProbeDesigner:
             heuristic=self.heuristic,
             heuristic_n_attempts=self.heuristic_n_attempts,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
@@ -858,10 +854,12 @@ class TargetProbeDesigner:
             property_thr=isoform_consensus,
             remove_if_smaller_threshold=True,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
 
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -950,6 +948,8 @@ class TargetProbeDesigner:
             sequence_type="oligo_pair_R",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1084,6 +1084,9 @@ class TargetProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1229,6 +1232,9 @@ class TargetProbeDesigner:
             n_sets=n_sets,
             n_jobs=self.n_jobs,
         )
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -520,7 +520,6 @@ class MerfishProbeDesigner:
             min_oligos_per_gene=set_size_min,
             isoform_consensus=target_probe_isoform_consensus,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
@@ -539,7 +538,6 @@ class MerfishProbeDesigner:
             Tm_chem_correction_parameters=self.target_probe_Tm_chem_correction_parameters,
             Tm_salt_correction_parameters=self.target_probe_Tm_salt_correction_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
@@ -553,7 +551,6 @@ class MerfishProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.target_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.target_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
@@ -582,7 +579,6 @@ class MerfishProbeDesigner:
             heuristic=self.heuristic,
             heuristic_n_attempts=self.heuristic_n_attempts,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
@@ -650,7 +646,6 @@ class MerfishProbeDesigner:
             oligo_base_probabilities=readout_probe_base_probabilities,
             initial_num_sequences=self.readout_probe_initial_num_sequences,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_readout_probes_initial")
@@ -662,7 +657,6 @@ class MerfishProbeDesigner:
             GC_content_max=readout_probe_GC_content_max,
             homopolymeric_base_n=readout_probe_homopolymeric_base_n,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_readout_probes_property_filter")
@@ -676,7 +670,6 @@ class MerfishProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.readout_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.readout_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_readout_probes_specificty_filter")
@@ -693,7 +686,6 @@ class MerfishProbeDesigner:
             Tm_chem_correction_parameters=self.readout_probe_Tm_chem_correction_parameters,
             Tm_salt_correction_parameters=self.readout_probe_Tm_salt_correction_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_readout_probes_set_selection")
@@ -855,7 +847,6 @@ class MerfishProbeDesigner:
             oligo_base_probabilities=primer_base_probabilities,
             initial_num_sequences=self.primer_initial_num_sequences,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_primers_initial")
@@ -879,7 +870,6 @@ class MerfishProbeDesigner:
             T_secondary_structure=primer_T_secondary_structure,
             secondary_structures_threshold_deltaG=primer_secondary_structures_threshold_deltaG,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_primer_property_filter")
@@ -894,7 +884,6 @@ class MerfishProbeDesigner:
             specificity_encoding_probes_blastn_search_parameters=self.primer_specificity_encoding_probes_blastn_search_parameters,
             specificity_encoding_probes_blastn_hit_parameters=self.primer_specificity_encoding_probes_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_primer_specificty_filter")
@@ -1150,10 +1139,12 @@ class TargetProbeDesigner:
             property_thr=isoform_consensus,
             remove_if_smaller_threshold=True,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
 
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1238,6 +1229,9 @@ class TargetProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
     @pipeline_step_basic(step_name="Target Probe Generation - Specificity Filters")
@@ -1320,6 +1314,9 @@ class TargetProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1490,6 +1487,9 @@ class TargetProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
 
@@ -1618,6 +1618,9 @@ class ReadoutProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
     @pipeline_step_basic(step_name="Readout Probe Generation - Specificity Filters")
@@ -1704,6 +1707,9 @@ class ReadoutProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
     @pipeline_step_basic(step_name="Readout Probe Generation - Set Selection")
@@ -1757,6 +1763,9 @@ class ReadoutProbeDesigner:
         oligo_database = set_generator.apply(
             oligo_database, n_sets=1, n_combinations=n_combinations, n_jobs=self.n_jobs
         )
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -2044,6 +2053,9 @@ class PrimerDesigner:
             n_jobs=self.n_jobs,
         )
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
     @pipeline_step_basic(step_name="Primer Generation - Specificity Filters")
@@ -2124,6 +2136,9 @@ class PrimerDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -391,7 +391,6 @@ class OligoSeqProbeDesigner:
             min_oligos_per_gene=set_size_min,
             isoform_consensus=target_probe_isoform_consensus,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_probes_initial")
@@ -411,7 +410,6 @@ class OligoSeqProbeDesigner:
             Tm_chem_correction_parameters=self.target_probe_Tm_chem_correction_parameters,
             Tm_salt_correction_parameters=self.target_probe_Tm_salt_correction_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_probes_property_filter")
@@ -430,7 +428,6 @@ class OligoSeqProbeDesigner:
             hybridization_probability_threshold=target_probe_hybridization_probability_threshold,
             target_probe_read_length_bias=target_probe_read_length_bias,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_probes_specificity_filter")
@@ -461,7 +458,6 @@ class OligoSeqProbeDesigner:
             heuristic=self.heuristic,
             heuristic_n_attempts=self.heuristic_n_attempts,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_probes_probesets")
@@ -646,10 +642,11 @@ class TargetProbeDesigner:
             remove_if_smaller_threshold=True,
         )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
-
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -741,6 +738,8 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -912,6 +911,9 @@ class TargetProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
+        oligo_database.remove_regions_with_insufficient_oligos("Specificity Filters")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
     @pipeline_step_basic(step_name="Oligo Selection")
@@ -1015,7 +1017,6 @@ class TargetProbeDesigner:
         )
 
         oligos_scoring = OligoScoring(scorers=[exon_scorer, isoform_scorer, Tm_scorer, GC_scorer])
-
         set_scoring = AverageSetScoring(ascending=True)
 
         # We change the processing dependent on the required number of probes in the probe sets
@@ -1090,6 +1091,8 @@ class TargetProbeDesigner:
             n_sets=n_sets,
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -395,7 +395,6 @@ class ScrinshotProbeDesigner:
             min_oligos_per_gene=set_size_min,
             isoform_consensus=target_probe_isoform_consensus,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_probes_initial")
@@ -419,7 +418,6 @@ class ScrinshotProbeDesigner:
             Tm_chem_correction_parameters=self.target_probe_Tm_chem_correction_parameters,
             Tm_salt_correction_parameters=self.target_probe_Tm_salt_correction_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_probes_property_filter")
@@ -441,7 +439,6 @@ class ScrinshotProbeDesigner:
             Tm_chem_correction_parameters=self.target_probe_Tm_chem_correction_parameters,
             Tm_salt_correction_parameters=self.target_probe_Tm_salt_correction_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_probes_specificity_filter")
@@ -470,7 +467,6 @@ class ScrinshotProbeDesigner:
             heuristic=self.heuristic,
             heuristic_n_attempts=self.heuristic_n_attempts,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_probes_probesets")
@@ -826,10 +822,12 @@ class TargetProbeDesigner:
             property_thr=isoform_consensus,
             remove_if_smaller_threshold=True,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
 
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -937,6 +935,8 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1079,6 +1079,9 @@ class TargetProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1248,6 +1251,9 @@ class TargetProbeDesigner:
             n_sets=n_sets,
             n_jobs=self.n_jobs,
         )
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -416,7 +416,6 @@ class SeqFishPlusProbeDesigner:
             min_oligos_per_gene=set_size_min,
             isoform_consensus=target_probe_isoform_consensus,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
@@ -430,7 +429,6 @@ class SeqFishPlusProbeDesigner:
             T_secondary_structure=target_probe_T_secondary_structure,
             secondary_structures_threshold_deltaG=target_probe_secondary_structures_threshold_deltaG,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
@@ -444,7 +442,6 @@ class SeqFishPlusProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.target_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.target_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
@@ -464,7 +461,6 @@ class SeqFishPlusProbeDesigner:
             heuristic_n_attempts=self.heuristic_n_attempts,
             distance_between_oligos=distance_between_target_probes,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
@@ -523,7 +519,6 @@ class SeqFishPlusProbeDesigner:
             oligo_base_probabilities=readout_probe_base_probabilities,
             initial_num_sequences=self.readout_probe_initial_num_sequences,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_readout_probes_initial")
@@ -535,7 +530,6 @@ class SeqFishPlusProbeDesigner:
             GC_content_max=readout_probe_GC_content_max,
             homopolymeric_base_n=readout_probe_homopolymeric_base_n,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_readout_probes_property_filter")
@@ -549,7 +543,6 @@ class SeqFishPlusProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.readout_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.readout_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_readout_probes_specificty_filter")
@@ -721,7 +714,6 @@ class SeqFishPlusProbeDesigner:
             oligo_base_probabilities=primer_base_probabilities,
             initial_num_sequences=self.primer_initial_num_sequences,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_primers_initial")
@@ -745,7 +737,6 @@ class SeqFishPlusProbeDesigner:
             T_secondary_structure=primer_T_secondary_structure,
             secondary_structures_threshold_deltaG=primer_secondary_structures_threshold_deltaG,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_primer_property_filter")
@@ -760,7 +751,6 @@ class SeqFishPlusProbeDesigner:
             specificity_encoding_probes_blastn_search_parameters=self.primer_specificity_encoding_probes_blastn_search_parameters,
             specificity_encoding_probes_blastn_hit_parameters=self.primer_specificity_encoding_probes_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_primer_specificty_filter")
@@ -1039,10 +1029,12 @@ class TargetProbeDesigner:
             property_thr=isoform_consensus,
             remove_if_smaller_threshold=True,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
 
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1103,6 +1095,8 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1186,6 +1180,9 @@ class TargetProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1318,6 +1315,9 @@ class TargetProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
 
@@ -1445,6 +1445,8 @@ class ReadoutProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1531,7 +1533,8 @@ class ReadoutProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
-
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
         return oligo_database
 
     def generate_codebook(
@@ -1833,6 +1836,8 @@ class PrimerDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1914,6 +1919,9 @@ class PrimerDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -416,7 +416,6 @@ class SeqFishPlusProbeDesigner:
             min_oligos_per_gene=set_size_min,
             isoform_consensus=target_probe_isoform_consensus,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
@@ -430,7 +429,6 @@ class SeqFishPlusProbeDesigner:
             T_secondary_structure=target_probe_T_secondary_structure,
             secondary_structures_threshold_deltaG=target_probe_secondary_structures_threshold_deltaG,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
@@ -444,7 +442,6 @@ class SeqFishPlusProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.target_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.target_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
@@ -464,7 +461,6 @@ class SeqFishPlusProbeDesigner:
             heuristic_n_attempts=self.heuristic_n_attempts,
             distance_between_oligos=distance_between_target_probes,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
@@ -523,7 +519,6 @@ class SeqFishPlusProbeDesigner:
             oligo_base_probabilities=readout_probe_base_probabilities,
             initial_num_sequences=self.readout_probe_initial_num_sequences,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_readout_probes_initial")
@@ -535,7 +530,6 @@ class SeqFishPlusProbeDesigner:
             GC_content_max=readout_probe_GC_content_max,
             homopolymeric_base_n=readout_probe_homopolymeric_base_n,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_readout_probes_property_filter")
@@ -549,7 +543,6 @@ class SeqFishPlusProbeDesigner:
             cross_hybridization_blastn_search_parameters=self.readout_probe_cross_hybridization_blastn_search_parameters,
             cross_hybridization_blastn_hit_parameters=self.readout_probe_cross_hybridization_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_readout_probes_specificty_filter")
@@ -721,7 +714,6 @@ class SeqFishPlusProbeDesigner:
             oligo_base_probabilities=primer_base_probabilities,
             initial_num_sequences=self.primer_initial_num_sequences,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_primers_initial")
@@ -745,7 +737,6 @@ class SeqFishPlusProbeDesigner:
             T_secondary_structure=primer_T_secondary_structure,
             secondary_structures_threshold_deltaG=primer_secondary_structures_threshold_deltaG,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_primer_property_filter")
@@ -760,7 +751,6 @@ class SeqFishPlusProbeDesigner:
             specificity_encoding_probes_blastn_search_parameters=self.primer_specificity_encoding_probes_blastn_search_parameters,
             specificity_encoding_probes_blastn_hit_parameters=self.primer_specificity_encoding_probes_blastn_hit_parameters,
         )
-        check_content_oligo_database(oligo_database)
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_primer_specificty_filter")
@@ -1040,10 +1030,12 @@ class TargetProbeDesigner:
             property_thr=isoform_consensus,
             remove_if_smaller_threshold=True,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
 
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1104,6 +1096,8 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1187,6 +1181,9 @@ class TargetProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1319,6 +1316,9 @@ class TargetProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Oligo Selection")
+        check_content_oligo_database(oligo_database)
+
         return oligo_database
 
 
@@ -1446,6 +1446,8 @@ class ReadoutProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1532,7 +1534,8 @@ class ReadoutProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
-
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
         return oligo_database
 
     def generate_codebook(
@@ -1834,6 +1837,8 @@ class PrimerDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 
@@ -1915,6 +1920,9 @@ class PrimerDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
+
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+        check_content_oligo_database(oligo_database)
 
         return oligo_database
 


### PR DESCRIPTION
## Add database content checks after filtering steps in pipelines

### Summary
Adds database content validation after each filtering step in all pipeline files. If filtering results in an empty database, the pipeline exits gracefully after cleaning up intermediate files.

### Changes
- Added `check_content_oligo_database()` calls after filtering operations in:
  - `_oligo_seq_probe_designer.py`
  - `_scrinshot_probe_designer.py`
  - `_merfish_probe_designer.py`
  - `_cycle_hcr_probe_designer.py`
  - `_seqfish_plus_probe_designer.py`
- Moved checks to after intermediate file cleanup (so cleanup happens before abort)
- Removed checks from upper-level orchestrator functions (`design_target_probes`, `design_readout_probes`, etc.)
- Added `remove_regions_with_insufficient_oligos()` + content checks after set selection steps

### Pattern applied
Each filter step now follows: **filter → remove_regions → cleanup → check**
- Filtering operations (`filter_database_by_property_threshold`, `property_filter.apply()`, `specificity_filter.apply()`)
- Intermediate file cleanup (`shutil.rmtree()`)
- Region removal (`remove_regions_with_insufficient_oligos()`)
- Database content check (`check_content_oligo_database()`)

### Benefits
- Prevents errors when the database becomes empty after filtering
- Ensures intermediate files are cleaned up before abort
- Provides clear logging when the database is empty
- Consistent error handling across all pipelines

### Testing
- No linting errors introduced
- All pipelines follow the same pattern
- Checks are placed consistently after cleanup operations

Closes #109