### PR TITLE
Refactor IndependentSetsOligoSelection to optimize graph handling: Bu…

### DIFF
--- a/oligo_designer_toolsuite/oligo_selection/_oligo_selection_independent_sets.py
+++ b/oligo_designer_toolsuite/oligo_selection/_oligo_selection_independent_sets.py
@@ -316,11 +316,23 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
         rng = np.random.default_rng(seed)
         n_nodes_removed = int(self.diversification_fraction * len(non_overlap_matrix_ids))
 
-        for attempt in range(self.n_attempts_graph):
+        # --- Build full graph once ---
+        G_full = nx.from_scipy_sparse_array(non_overlap_matrix)
+        G_full = nx.relabel_nodes(G_full, dict(enumerate(non_overlap_matrix_ids)))
+        all_nodes = np.array(list(G_full.nodes))
 
-            # --- Build full graph ---
-            G = nx.from_scipy_sparse_array(non_overlap_matrix)
-            G = nx.relabel_nodes(G, dict(enumerate(non_overlap_matrix_ids)))
+        oligos_scores = self.oligos_scoring.apply(
+            oligo_database=oligo_database,
+            region_id=region_id,
+            oligo_ids=all_nodes.tolist(),
+            sequence_type=sequence_type,
+            non_overlap_matrix=non_overlap_matrix,
+            non_overlap_matrix_ids=non_overlap_matrix_ids,
+            set_oligo_ids=None,
+            oligoset_size=None,
+        )
+
+        for attempt in range(self.n_attempts_graph):
 
             # --- Diversification: remove nodes (except first attempt) ---
             if attempt > 0 and n_nodes_removed > 0:
@@ -330,29 +342,23 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
                 #   alpha → 1 : increasingly biased by oligo scores
                 alpha = attempt / self.n_attempts_graph
 
-                oligos_scores = self.oligos_scoring.apply(
-                    oligo_database=oligo_database,
-                    region_id=region_id,
-                    oligo_ids=list(G.nodes),
-                    sequence_type=sequence_type,
-                    non_overlap_matrix=non_overlap_matrix,
-                    non_overlap_matrix_ids=non_overlap_matrix_ids,
-                    set_oligo_ids=None,
-                    oligoset_size=None,
-                )
-
                 weights = oligos_scores**alpha
                 total = weights.sum()
                 weights = np.ones_like(weights) / len(weights) if total == 0 else weights / total
 
                 nodes_to_remove = rng.choice(
-                    list(G.nodes),
+                    all_nodes,
                     size=n_nodes_removed,
                     replace=False,
                     p=weights,
                 )
 
-                G.remove_nodes_from(list(nodes_to_remove))
+                nodes_remaining = set(all_nodes) - set(nodes_to_remove)
+
+                # Create lightweight view (no data duplication)
+                G = G_full.subgraph(nodes_remaining)
+            else:
+                G = G_full
 
             # --- Check feasibility via greedy clique ---
             greedy_max_clique = self._greedy_max_clique(G)
@@ -374,9 +380,6 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
                     continue
 
                 _add_clique_to_oligosets(clique, oligoset_size)
-
-            del G
-            gc.collect()
 
         return oligosets
 


### PR DESCRIPTION
## PR Title

Optimize candidate set generation by reusing full graph and precomputing oligo scores

---

## Summary

This PR refactors `_generate_candidate_sets()` to remove repeated graph reconstruction and redundant oligo scoring inside the diversification loop. The full compatibility graph is now built once and reused across attempts, and node diversification is implemented using lightweight subgraph views instead of destructive node removal. Additionally, per-oligo scores used for weighted diversification are computed once before the loop and reused.

---

## Key Changes

### 1. Build full graph once

The full NetworkX graph is now constructed a single time:

```python
G_full = nx.from_scipy_sparse_array(non_overlap_matrix)
G_full = nx.relabel_nodes(G_full, dict(enumerate(non_overlap_matrix_ids)))
```

Previously, this conversion was performed on every attempt.

---

### 2. Use subgraph views for diversification

Instead of mutating the graph with `remove_nodes_from()`, diversification now creates a lightweight subgraph view:

```python
G = G_full.subgraph(nodes_remaining)
```

This:

* Avoids destructive graph modifications
* Prevents repeated adjacency restructuring
* Reduces memory churn
* Lowers garbage collection pressure

---

### 3. Precompute oligo scores once

The per-oligo scores used to weight node removal are now computed once before the loop:

```python
oligos_scores = self.oligos_scoring.apply(...)
```

Previously, scoring was recomputed for each attempt.

---

## Expected Impact

* Reduced runtime of candidate set generation
* Lower memory allocation overhead
* Improved scalability when processing multiple regions in parallel
* More predictable performance across hardware

---

## Functional Impact

No changes to algorithmic behavior or selection logic.
The diversification and clique enumeration strategy remain unchanged.

---

This refactor strictly improves efficiency without altering results.

Close #155 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor is localized to candidate-set generation and is intended to be behavior-preserving; main risk is subtle changes in diversification sampling or clique enumeration due to using graph views and precomputed score ordering.
> 
> **Overview**
> Optimizes `_generate_candidate_sets()` in `IndependentSetsOligoSelection` by **building the NetworkX compatibility graph once** and reusing it across diversification attempts.
> 
> Diversification now uses **lightweight `subgraph()` views** instead of mutating/removing nodes, and the per-oligo scores used to weight node removal are **computed once outside the loop** (removing repeated scoring + explicit `gc.collect()` cleanup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa730419facc1a1edc3fb435368ab09b3f6df72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->