### PR TITLE
Avoid relabeling graph in set selection and fix use of multiprocessing

### DIFF
--- a/oligo_designer_toolsuite/oligo_selection/_oligo_selection_independent_sets.py
+++ b/oligo_designer_toolsuite/oligo_selection/_oligo_selection_independent_sets.py
@@ -383,7 +383,7 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
 
         return oligosets
 
-    def _greedy_max_clique(self, G: nx.Graph) -> list[str]:
+    def _greedy_max_clique(self, G: nx.Graph) -> list[int]:
         """
         Finds a maximal clique in the graph using a greedy degree-based heuristic.
 
@@ -391,13 +391,13 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
         if it is adjacent to all nodes currently in the clique. The result is guaranteed
         to be a valid maximal clique but not necessarily a maximum-size clique.
 
-        :param G: The compatibility graph (nodes = oligo IDs, edges = compatible pairs).
+        :param G: The compatibility graph (nodes = indices, edges = compatible pairs).
         :type G: nx.Graph
-        :return: List of node IDs (oligo IDs) in the computed clique.
-        :rtype: list[str]
+        :return: List of node indices in the computed clique.
+        :rtype: list[int]
         """
         nodes = sorted(G.nodes(), key=lambda n: G.degree(n), reverse=True)
-        clique: list[str] = []
+        clique: list[int] = []
         for n in nodes:
             if all(G.has_edge(n, c) for c in clique):
                 clique.append(n)

--- a/oligo_designer_toolsuite/oligo_selection/_oligo_selection_independent_sets.py
+++ b/oligo_designer_toolsuite/oligo_selection/_oligo_selection_independent_sets.py
@@ -296,15 +296,16 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
         :rtype: dict[tuple[str, ...], dict[str, float]]
         """
 
-        def _add_clique_to_oligosets(clique: list[str], oligoset_size: int) -> None:
+        def _add_clique_to_oligosets(clique: list[int], oligoset_size: int) -> None:
+            oligo_ids = [non_overlap_matrix_ids[v] for v in clique]
             oligos_scores = self.oligos_scoring.apply(
                 oligo_database=oligo_database,
                 region_id=region_id,
-                oligo_ids=clique,
+                oligo_ids=oligo_ids,
                 sequence_type=sequence_type,
                 non_overlap_matrix=non_overlap_matrix,
                 non_overlap_matrix_ids=non_overlap_matrix_ids,
-                set_oligo_ids=clique,
+                set_oligo_ids=oligo_ids,
                 oligoset_size=oligoset_size,
             )
             oligoset, oligoset_scores = self.set_scoring.apply(oligos_scores, oligoset_size)
@@ -318,13 +319,12 @@ class IndependentSetsOligoSelection(BaseOligoSelection):
 
         # --- Build full graph once ---
         G_full = nx.from_scipy_sparse_array(non_overlap_matrix)
-        G_full = nx.relabel_nodes(G_full, dict(enumerate(non_overlap_matrix_ids)))
         all_nodes = np.array(list(G_full.nodes))
 
         oligos_scores = self.oligos_scoring.apply(
             oligo_database=oligo_database,
             region_id=region_id,
-            oligo_ids=all_nodes.tolist(),
+            oligo_ids=non_overlap_matrix_ids,
             sequence_type=sequence_type,
             non_overlap_matrix=non_overlap_matrix,
             non_overlap_matrix_ids=non_overlap_matrix_ids,

--- a/oligo_designer_toolsuite/sequence_generator/_oligo_sequence_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_oligo_sequence_generator.py
@@ -288,7 +288,7 @@ class OligoSequenceGenerator:
         for file_fasta in files_fasta_in:
             self.fasta_parser.check_fasta_format(file_fasta)
             fasta_sequences = self.fasta_parser.read_fasta_sequences(file_fasta, region_ids)
-            files_fasta_oligos = Parallel(n_jobs=n_jobs)(
+            files_fasta_oligos = Parallel(n_jobs=n_jobs, prefer="threads", require="sharedmem")(
                 delayed(get_sliding_window_sequence)(entry, length_interval_sequences, split_region, stride)
                 for entry in fasta_sequences
             )


### PR DESCRIPTION
### Summary

This PR picks off two low hanging fruit for reducing memory usage, cutting it in half for some scenarios.

Changes:

- map indices to oligo ids when adding cliques instead of relabeling the graph
- use multithreading instead of multiprocessing in `get_sliding_window_sequence`

### Avoiding relabeling

Memory profiling revealed that the relabeling operation makes a copy of the graph, apparently without properly freeing/collecting the old graph. While there is the option to pass `copy=False` to `nx.relabel_nodes`, this significantly increases runtime. So instead, this PR only keeps indices in the graph and maps these to the respective oligo ids when adding a clique. The logic should be equivalent and all related tests pass.

### Avoiding multiprocessing

As a second change, the last use of multiprocessing is being replaced with multithreading. Previously, ODT would spawn additional processes during the sliding window operation which remained idle afterwards but kept blocking memory.

Due to the global interpreter lock, the change might negatively impact runtime for users who were using a high `n_jobs` setting. But since this was the only use of multiprocessing, it seemed unintentional and the benefit of reduced memory usage is worth the trade-off in my view. I have not tested the change in runtime for different `n_jobs` settings.

### Results

For the default Scrinshot pipeline config, these are the results for me:
|                                             |  **dev**  | **this PR** |  change  |
|:-------------------------------------------:|:---------:|:-----------:|:--------:|
|              **Total Runtime**              |  **317s** |    **288s** |  **-9%** |
|            **Total Memory Usage**           | **7.7GB** |   **3.3GB** | **-57%** |
|             Actively Used Memory            |     5.1GB |       3.3GB |     -35% |
| Additional Reserved Memory |     2.6GB |         0GB |    -100% |

The last row refers to the memory that was blocked by the 4 processes that were spawned, reserving ~600MB each.
Actively used memory was measured with [memray](https://bloomberg.github.io/memray/) whereas the additional memory reserved by the spawned processes was observed using [btop](https://github.com/aristocratos/btop). The runtime was analyzed with [py-spy](https://github.com/benfred/py-spy).