### PR TITLE
Mitigate code injection vulnerabilities via subprocess calls

### DIFF
--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -117,9 +117,11 @@ class BlastNFilter(AlignmentSpecificityFilter):
             filename=f"db_reference_{self.filter_name}",
             dir_output=self.dir_output,
         )
+
         ## Create blast index
-        cmd = "makeblastdb -dbtype nucl" + " -out " + file_reference + " -in " + file_reference
-        process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output, stdout=subprocess.DEVNULL).wait()
+        args = ["makeblastdb", "-dbtype", "nucl", "-out", file_reference, "-in", file_reference]
+
+        subprocess.run(args, cwd=self.dir_output, check=True)
 
         return file_reference
 
@@ -157,24 +159,22 @@ class BlastNFilter(AlignmentSpecificityFilter):
         )
         file_blast_results = os.path.join(self.dir_output, f"blast_results_{region_id}.txt")
 
-        cmd_parameters = ""
-        for parameter, value in self.search_parameters.items():
-            # add quotes if list of strings seperated by whitespace
-            value = f'"{value}"' if " " in str(value) else value
-            cmd_parameters += f" {parameter} {value}"
+        args = [
+            "blastn",
+            "-query",
+            file_oligo_database,
+            "-out",
+            file_blast_results,
+            "-db",
+            os.path.join(self.dir_output, file_reference),
+        ]
 
-        cmd = (
-            "blastn"
-            + " -query "
-            + file_oligo_database
-            + " -out "
-            + file_blast_results
-            + " -db "
-            + os.path.join(self.dir_output, file_reference)
-            + " "
-            + cmd_parameters
-        )
-        process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output, stdout=subprocess.DEVNULL).wait()
+        for parameter, value in self.search_parameters.items():
+            args.append(parameter)
+            if str(value) != "":
+                args.append(str(value))
+
+        subprocess.run(args, cwd=self.dir_output, check=True)
 
         # read the reuslts of the blast seatch
         blast_results = self._read_search_output(

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -107,16 +107,18 @@ class BowtieFilter(AlignmentSpecificityFilter):
         )
 
         ## Create bowtie index
-        cmd = (
-            "bowtie-build --offrate 4"
-            + " --threads "
-            + str(n_jobs)
-            + " -f "
-            + file_reference
-            + " "
-            + file_reference
-        )
-        process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output, stdout=subprocess.DEVNULL).wait()
+        args = [
+            "bowtie-build",
+            "--offrate",
+            "4",
+            "--threads",
+            str(n_jobs),
+            "-f",
+            file_reference,
+            file_reference,
+        ]
+
+        subprocess.run(args, cwd=self.dir_output, check=True)
 
         return file_reference
 
@@ -152,16 +154,26 @@ class BowtieFilter(AlignmentSpecificityFilter):
         )
         file_bowtie_results = os.path.join(self.dir_output, f"bowtie_results_{region_id}.txt")
 
-        cmd_parameters = ""
-        for parameter, value in self.search_parameters.items():
-            cmd_parameters += f" {parameter} {value}"
+        args = [
+            "bowtie",
+            "-x",
+            file_reference,  # fasta file is input
+            "-f",
+        ]
 
-        cmd = "bowtie" + " -x " + file_reference + " -f"  # fasta file is input
         # return all alignments only if the number of alignments is not specified
         if "-k" not in self.search_parameters.keys():
-            cmd += " -a"
-        cmd += cmd_parameters + " " + file_oligo_database + " " + file_bowtie_results
-        process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output, stdout=subprocess.DEVNULL).wait()
+            args.append("-a")
+
+        for parameter, value in self.search_parameters.items():
+            args.append(parameter)
+            if str(value) != "":
+                args.append(str(value))
+
+        args.append(file_oligo_database)
+        args.append(file_bowtie_results)
+
+        subprocess.run(args, cwd=self.dir_output, check=True)
 
         # read the reuslts of the bowtie search
         bowtie_results = self._read_search_output(
@@ -376,16 +388,20 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
             filename=f"db_reference_{self.filter_name}",
             dir_output=self.dir_output,
         )
-        cmd = (
-            "bowtie2-build --quiet --offrate 4"
-            + " --threads "
-            + str(n_jobs)
-            + " -f "
-            + file_reference
-            + " "
-            + file_reference
-        )
-        process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output).wait()
+
+        args = [
+            "bowtie2-build",
+            "--quiet",
+            "--offrate",
+            "4",
+            "--threads",
+            str(n_jobs),
+            "-f",
+            file_reference,
+            file_reference,
+        ]
+
+        subprocess.run(args, cwd=self.dir_output, check=True)
 
         return file_reference
 
@@ -421,16 +437,28 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
         )
         file_bowtie_results = os.path.join(self.dir_output, f"bowtie2_results_{region_id}.txt")
 
-        cmd_parameters = ""
-        for parameter, value in self.search_parameters.items():
-            cmd_parameters += f" {parameter} {value}"
+        args = [
+            "bowtie2",
+            "--quiet",
+            "--no-hd",
+            "--no-unal",
+            "-x",
+            file_reference,  # fasta file is input
+            "-f",
+        ]
 
-        cmd = "bowtie2 --quiet" + " --no-hd --no-unal" + " -x " + file_reference + " -f"  # fast file is input
         # return all alignments only if the number of alignments is not specified
         if "-k" not in self.search_parameters.keys():
-            cmd += " -a"
-        cmd += cmd_parameters + " -U " + file_oligo_database + " -S " + file_bowtie_results
-        process = subprocess.Popen(cmd, shell=True, cwd=self.dir_output).wait()
+            args.append("-a")
+
+        for parameter, value in self.search_parameters.items():
+            args.append(parameter)
+            if str(value) != "":
+                args.append(str(value))
+
+        args.extend(["-U", file_oligo_database, "-S", file_bowtie_results])
+
+        subprocess.run(args, cwd=self.dir_output, check=True)
 
         # read the reuslts of the bowtie seatch
         bowtie_results = self._read_search_output(

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -2,11 +2,11 @@
 # imports
 ############################################
 
+import subprocess
 import gzip
 import os
 import pickle
 import re
-from subprocess import Popen
 from typing import Any
 
 import pandas as pd
@@ -527,9 +527,8 @@ class FastaParser:
             os.remove(index_file)
 
         # Use samtools faidx to create the index (same tool that bedtools getfasta uses)
-        cmd = ["samtools", "faidx", file_fasta]
-        process = Popen(cmd)
-        process.wait()
+        args = ["samtools", "faidx", file_fasta]
+        process = subprocess.run(args)
 
         if process.returncode != 0:
             raise FileFormatError(
@@ -627,29 +626,27 @@ class VCFParser:
         # Track compressed files that need to be cleaned up
         compressed_files_to_cleanup: list[str] = []
 
-        cmd = "bcftools merge --force-single --output-type v"
-        cmd += " -o " + file_out
+        args = ["bcftools", "merge", "--force-single", "--output-type", "v", "-o", file_out]
         for file_vcf in files_in:
             _, ext = os.path.splitext(file_vcf)
             if ext == ".vcf":
                 file_vcf_compressed = f"{file_vcf}.gz"
                 compressed_files_to_cleanup.append(file_vcf_compressed)
-                cmd_compress = "bcftools view -O z "
-                cmd_compress += "-o " + file_vcf_compressed
-                cmd_compress += " " + file_vcf
-                process = Popen(cmd_compress, shell=True).wait()
+
+                args_compress = ["bcftools", "view", "-O", "z", "-o", file_vcf_compressed, file_vcf]
+                subprocess.run(args_compress, check=True)
 
                 file_vcf = file_vcf_compressed
 
-            cmd_sort = "bcftools sort " + file_vcf + " -Oz -o " + file_vcf
-            process = Popen(cmd_sort, shell=True).wait()
+            args_sort = ["bcftools", "sort", file_vcf, "-Oz", "-o", file_vcf]
+            subprocess.run(args_sort, check=True)
 
-            cmd_index = "bcftools index " + file_vcf
-            process = Popen(cmd_index, shell=True).wait()
+            args_index = ["bcftools", "index", "-f", file_vcf]
+            subprocess.run(args_index, check=True)
 
-            cmd += " " + file_vcf
+            args.append(file_vcf)
 
-        process = Popen(cmd, shell=True).wait()
+        subprocess.run(args, check=True)
 
         # Clean up compressed files and their index files
         for file_vcf_compressed in compressed_files_to_cleanup:

--- a/oligo_designer_toolsuite/utils/_sequence_processor.py
+++ b/oligo_designer_toolsuite/utils/_sequence_processor.py
@@ -2,9 +2,9 @@
 # imports
 ############################################
 
+import subprocess
 import os
 from collections import Counter
-from subprocess import Popen
 
 from Bio import SeqIO
 
@@ -43,20 +43,17 @@ def get_sequence_from_annotation(
     :param name: Whether to use the name field and coordinates for the FASTA header, defaults to False.
     :type name: bool
     """
-    cmd = "bedtools getfasta"
-    cmd += " -fi " + file_reference_fasta
-    cmd += " -bed " + file_bed
-    cmd += " -fo " + file_fasta
+    args = ["bedtools", "getfasta", "-fi", file_reference_fasta, "-bed", file_bed, "-fo", file_fasta]
     if split:
-        cmd += " -split"
+        args.append("-split")
     if strand:
-        cmd += " -s"
+        args.append("-s")
     if nameOnly:
-        cmd += " -nameOnly"
+        args.append("-nameOnly")
     if name:
-        cmd += " -name"
+        args.append("-name")
 
-    process = Popen(cmd, shell=True).wait()
+    subprocess.run(args, check=True)
 
 
 def get_complement_regions(file_bed_in: str, file_chromosome_length: str, file_bed_out: str) -> None:
@@ -70,13 +67,11 @@ def get_complement_regions(file_bed_in: str, file_chromosome_length: str, file_b
     :param file_bed_out: Path to the output BED file where complement regions will be saved.
     :type file_bed_out: str
     """
-    cmd = "bedtools complement"
-    cmd += " -i " + file_bed_in
-    cmd += " -g " + file_chromosome_length
-    cmd += " -L "
-    cmd += " > " + file_bed_out
+    args = ["bedtools", "complement", "-i", file_bed_in, "-g", file_chromosome_length, "-L"]
 
-    process = Popen(cmd, shell=True).wait()
+    # redirect stdout to output file
+    with open(file_bed_out, "w") as f:
+        subprocess.run(args, stdout=f, check=True)
 
 
 def get_intersection(file_A: str, file_B: list[str] | str, file_bed_out: str) -> None:
@@ -93,14 +88,23 @@ def get_intersection(file_A: str, file_B: list[str] | str, file_bed_out: str) ->
     :param file_bed_out: Path to the output BED file where the intersection results will be saved.
     :type file_bed_out: str
     """
-    file_B = cast_to_list(file_B)
+    file_B: list[str] = cast_to_list(file_B)
 
-    cmd = "bedtools intersect -wa -wb -bed"
-    cmd += " -a " + file_A
-    cmd += " -b " + " ".join(file_B)
-    cmd += " > " + file_bed_out
+    args = [
+        "bedtools",
+        "intersect",
+        "-wa",
+        "-wb",
+        "-bed",
+        "-a",
+        file_A,
+        "-b",
+        *file_B,
+    ]
 
-    process = Popen(cmd, shell=True).wait()
+    # redirect stdout to output file
+    with open(file_bed_out, "w") as f:
+        subprocess.run(args, stdout=f, check=True)
 
 
 def append_nucleotide_to_sequences(input_fasta: str, nucleotide: str) -> str:


### PR DESCRIPTION
### Summary

This PR changes the implementation of subprocess calls such that commands are passed to `subprocess.run` as a list of arguments instead of a raw string. By removing `shell=True` we prevent running arbitrary shell commands as laid out in #162. See "Use shell=True with caution" in [this article](https://snyk.io/de/blog/command-injection-python-prevention-examples/) for more details.

Changes:

- call subprocesses without `shell=True` by passing list of arguments
- change usage of `subprocess.Popen` to [recommended](https://docs.python.org/3.12/library/subprocess.html#using-the-subprocess-module) `subprocess.run`
- remove custom quoting/escaping (this gets handled by `subprocess.run`)
- add `check=True` such that ODT will now raise if a subprocess fails
- add `-f` parameter to `bcftools index` in `merge_vcf_files()` as the subprocess could fail due to already existing files otherwise

I decided not to change the Jupyter notebooks that also use `subprocess.Popen` since they're not part of the library and seem to be used for local testing only. Some Python tests failed for me both on the `dev` branch as well as on this feature branch so I assume that is unrelated.

This PR will slightly conflict with #149. Since this vulnerability is currently blocking deployment of ODT Cloud and any external workarounds are more complex than this direct fix here, I'll gladly help integrate the changes if desired.

Closes #162 for now. We will create a new issue should we find another potential vulnerability.