### PR TITLE
Prevent unexpected path resolution using safe_append_filename helper

### DIFF
--- a/oligo_designer_toolsuite/database/_oligo_database.py
+++ b/oligo_designer_toolsuite/database/_oligo_database.py
@@ -32,6 +32,7 @@ from oligo_designer_toolsuite.utils import (
     format_oligo_properties,
     merge_databases,
 )
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 CustomYamlDumper.add_representer(list, CustomYamlDumper.represent_list)
 CustomYamlDumper.add_representer(dict, CustomYamlDumper.represent_dict)
@@ -82,10 +83,10 @@ class OligoDatabase:
         self.n_jobs = n_jobs
 
         self.database_name = database_name
-        self.dir_output = os.path.abspath(os.path.join(dir_output, database_name))
+        self.dir_output = os.path.abspath(safe_append_filename(dir_output, database_name))
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
 
-        self._dir_cache_files = os.path.join(self.dir_output, "cache_files")
+        self._dir_cache_files = safe_append_filename(self.dir_output, "cache_files")
 
         self.fasta_parser = FastaParser()
 
@@ -104,7 +105,7 @@ class OligoDatabase:
 
         # Initialize the file for regions with insufficient oligos
         if self.write_regions_with_insufficient_oligos:
-            self.file_removed_regions = os.path.join(
+            self.file_removed_regions = safe_append_filename(
                 self.dir_output,
                 f"regions_with_insufficient_oligos_for_{self.database_name}.txt",
             )
@@ -449,9 +450,9 @@ class OligoDatabase:
         region_ids = cast_to_list(region_ids) if region_ids else self.database.keys()
 
         if dir_output:
-            dir_database = os.path.join(dir_output, name_database)
+            dir_database = safe_append_filename(dir_output, name_database)
         else:
-            dir_database = os.path.join(self.dir_output, name_database)
+            dir_database = safe_append_filename(self.dir_output, name_database)
         Path(dir_database).mkdir(parents=True, exist_ok=True)
 
         for region_id in region_ids:
@@ -460,7 +461,7 @@ class OligoDatabase:
                 oligoset_region = self.oligosets[region_id]
             else:
                 oligoset_region = None
-            file_output = os.path.join(dir_database, region_id)
+            file_output = safe_append_filename(dir_database, region_id)
             with open(file_output, "wb") as file:
                 pickle.dump(
                     {
@@ -506,7 +507,7 @@ class OligoDatabase:
         region_ids = cast_to_list(region_ids) if region_ids else self.database.keys()
 
         dir_output = dir_output if dir_output else self.dir_output
-        file_fasta = os.path.join(dir_output, f"{filename}.fna")
+        file_fasta = safe_append_filename(dir_output, f"{filename}.fna")
         output_fasta = []
 
         with open(file_fasta, "w") as handle_fasta:
@@ -552,7 +553,7 @@ class OligoDatabase:
         region_ids = cast_to_list(region_ids) if region_ids else self.database.keys()
 
         dir_output = dir_output if dir_output else self.dir_output
-        file_bed = os.path.join(dir_output, f"{filename}.bed")
+        file_bed = safe_append_filename(dir_output, f"{filename}.bed")
 
         # retrieve relevant information from database
         property_table = self.get_oligo_property_table(
@@ -610,7 +611,7 @@ class OligoDatabase:
         properties = cast_to_list(properties)
 
         dir_output = dir_output if dir_output else self.dir_output
-        file_table = os.path.join(os.path.dirname(dir_output), f"{filename}.tsv")
+        file_table = safe_append_filename(os.path.dirname(dir_output), f"{filename}.tsv")
 
         first_entry = True
         for region_id in region_ids:
@@ -704,7 +705,7 @@ class OligoDatabase:
                     yaml_dict[region_id][oligoset_id][oligo_id_yaml] = yaml_dict_oligo_entry
 
         dir_output = dir_output if dir_output else self.dir_output
-        file_yaml = os.path.join(os.path.dirname(dir_output), f"{filename}.yml")
+        file_yaml = safe_append_filename(os.path.dirname(dir_output), f"{filename}.yml")
 
         with open(file_yaml, "w") as handle:
             yaml.dump(yaml_dict, handle, Dumper=CustomYamlDumper, default_flow_style=False, sort_keys=False)
@@ -761,13 +762,13 @@ class OligoDatabase:
                     csv_table.append(entry)
 
         dir_output = dir_output if dir_output else self.dir_output
-        file_table = os.path.join(os.path.dirname(dir_output), f"{filename}.tsv")
+        file_table = safe_append_filename(os.path.dirname(dir_output), f"{filename}.tsv")
 
         csv_table_df = pd.DataFrame(csv_table)
         csv_table_df.to_csv(file_table, sep="\t", index=False)
 
         # Also write Excel file with one sheet per region_id
-        file_excel = os.path.join(os.path.dirname(dir_output), f"{filename}.xlsx")
+        file_excel = safe_append_filename(os.path.dirname(dir_output), f"{filename}.xlsx")
         try:
             with pd.ExcelWriter(file_excel, engine="openpyxl") as writer:
                 for region_id in region_ids:
@@ -849,7 +850,7 @@ class OligoDatabase:
                     yaml_dict[region_id][oligoset_id][oligo_id] = entry
 
         dir_output = dir_output if dir_output else self.dir_output
-        file_yaml = os.path.join(os.path.dirname(dir_output), f"{filename}.yml")
+        file_yaml = safe_append_filename(os.path.dirname(dir_output), f"{filename}.yml")
 
         with open(file_yaml, "w") as outfile:
             yaml.dump(yaml_dict, outfile, Dumper=CustomYamlDumper, default_flow_style=False, sort_keys=False)

--- a/oligo_designer_toolsuite/database/_reference_database.py
+++ b/oligo_designer_toolsuite/database/_reference_database.py
@@ -10,6 +10,7 @@ from typing import Any, get_args
 from oligo_designer_toolsuite._constants import _TYPES_REF
 from oligo_designer_toolsuite._exceptions import DatabaseError
 from oligo_designer_toolsuite.utils import FastaParser, VCFParser, cast_to_list, remove_index_files
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 ############################################
 # Reference Database Class
@@ -107,13 +108,13 @@ class ReferenceDatabase:
         if self.database_type == "fasta":
             for file in files_in:
                 self.fasta_parser.check_fasta_format(file)
-            self.database_file = os.path.join(self.dir_output, f"tmp_{self.database_name}.fna")
+            self.database_file = safe_append_filename(self.dir_output, f"tmp_{self.database_name}.fna")
             self.fasta_parser.merge_fasta_files(
                 files_in=files_in, file_out=self.database_file, overwrite=True
             )
         elif self.database_type == "vcf":
             self.database_type = file_type
-            self.database_file = os.path.join(self.dir_output, f"tmp_{self.database_name}.vcf.gz")
+            self.database_file = safe_append_filename(self.dir_output, f"tmp_{self.database_name}.vcf.gz")
             self.vcf_parser.merge_vcf_files(files_in=files_in, file_out=self.database_file)
         else:
             raise DatabaseError(f"Database type {self.database_type} not supported.")
@@ -137,7 +138,7 @@ class ReferenceDatabase:
 
         if self.database_file:
             file_ending = "fna" if self.database_type == "fasta" else "vcf.gz"
-            file_database = os.path.join(dir_output, f"{filename}.{file_ending}")
+            file_database = safe_append_filename(dir_output, f"{filename}.{file_ending}")
             shutil.copy2(self.database_file, file_database)
             if self.database_type == "fasta":
                 self.fasta_parser.index_fasta_file(file_fasta=file_database)
@@ -242,7 +243,7 @@ class ReferenceDatabase:
             file_fasta_in=file, region_ids=regions_to_keep
         )
 
-        file_database_filtered = os.path.join(self.dir_output, f"{self.database_name}_filtered.fna")
+        file_database_filtered = safe_append_filename(self.dir_output, f"{self.database_name}_filtered.fna")
         self.fasta_parser.write_fasta_sequences(
             fasta_sequences=fasta_sequences_filtered, file_out=file_database_filtered
         )
@@ -288,7 +289,7 @@ class ReferenceDatabase:
                 ):
                     fasta_sequences_filtered.append(entry)
 
-        file_database_filtered = os.path.join(self.dir_output, f"{self.database_name}_filtered.fna")
+        file_database_filtered = safe_append_filename(self.dir_output, f"{self.database_name}_filtered.fna")
         self.fasta_parser.write_fasta_sequences(
             fasta_sequences=fasta_sequences_filtered, file_out=file_database_filtered
         )

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_base.py
@@ -14,6 +14,7 @@ from oligo_designer_toolsuite._constants import SEPARATOR_FASTA_HEADER_FIELDS, S
 from oligo_designer_toolsuite._exceptions import ConfigurationError
 from oligo_designer_toolsuite.database import OligoDatabase, ReferenceDatabase
 from oligo_designer_toolsuite.utils import cast_to_list, remove_index_files
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 ############################################
 # Oligo Specificity Filter Classes
@@ -39,7 +40,7 @@ class BaseSpecificityFilter(ABC):
         """Constructor for the BaseSpecificityFilter class."""
         # folder where we write the intermediate files
         self.filter_name = filter_name
-        self.dir_output = os.path.abspath(os.path.join(dir_output, self.filter_name))
+        self.dir_output = os.path.abspath(safe_append_filename(dir_output, self.filter_name))
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
 
         self.sequence_type: str | None = None
@@ -155,7 +156,7 @@ class ReferenceSpecificityFilter(BaseSpecificityFilter):
         """Constructor for the ReferenceSpecificityFilter class."""
         # folder where we write the intermediate files
         self.filter_name = filter_name
-        self.dir_output = os.path.abspath(os.path.join(dir_output, self.filter_name))
+        self.dir_output = os.path.abspath(safe_append_filename(dir_output, self.filter_name))
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
 
         self.remove_hits = remove_hits
@@ -269,7 +270,7 @@ class AlignmentSpecificityFilter(ReferenceSpecificityFilter):
 
         # folder where we write the intermediate files
         self.filter_name = filter_name
-        self.dir_output = os.path.abspath(os.path.join(dir_output, self.filter_name))
+        self.dir_output = os.path.abspath(safe_append_filename(dir_output, self.filter_name))
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
 
         self.remove_hits = remove_hits

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -167,7 +167,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
             "-out",
             file_blast_results,
             "-db",
-            safe_append_filename(self.dir_output, file_reference),
+            file_reference,
         ]
 
         for parameter, value in self.search_parameters.items():

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -20,6 +20,7 @@ from oligo_designer_toolsuite.oligo_property_calculator import (
     SeedregionSiteProperty,
 )
 from oligo_designer_toolsuite.oligo_specificity_filter import AlignmentSpecificityFilter
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 from ..utils._sequence_processor import get_sequence_from_annotation
 
@@ -157,7 +158,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
             save_description=False,
             region_ids=region_id,
         )
-        file_blast_results = os.path.join(self.dir_output, f"blast_results_{region_id}.txt")
+        file_blast_results = safe_append_filename(self.dir_output, f"blast_results_{region_id}.txt")
 
         args = [
             "blastn",
@@ -166,7 +167,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
             "-out",
             file_blast_results,
             "-db",
-            os.path.join(self.dir_output, file_reference),
+            safe_append_filename(self.dir_output, file_reference),
         ]
 
         for parameter, value in self.search_parameters.items():
@@ -297,7 +298,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
         # adjust for possible overflows (e.g. new coordinates are not included in the gene boundaries)
         # additionally we store how muchpadding we have to do to have two seqeunces of the same length
         bed = self._remove_overflows(bed, file_reference)
-        file_bed = os.path.join(self.dir_output, f"references_{region_id}.bed")
+        file_bed = safe_append_filename(self.dir_output, f"references_{region_id}.bed")
         bed.to_csv(
             file_bed,
             sep="\t",
@@ -306,7 +307,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
             columns=["chr", "start", "end", "name", "score", "strand"],
         )
         # generate the fasta file
-        references_fasta_file = os.path.join(self.dir_output, f"references_{region_id}.fasta")
+        references_fasta_file = safe_append_filename(self.dir_output, f"references_{region_id}.fasta")
         get_sequence_from_annotation(
             file_bed, file_reference, references_fasta_file, strand=True, nameOnly=True
         )

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -16,6 +16,7 @@ from oligo_designer_toolsuite._exceptions import (
 )
 from oligo_designer_toolsuite.database import OligoDatabase
 from oligo_designer_toolsuite.oligo_specificity_filter import AlignmentSpecificityFilter
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 from ..utils._sequence_processor import get_sequence_from_annotation
 
@@ -152,7 +153,7 @@ class BowtieFilter(AlignmentSpecificityFilter):
             save_description=False,
             region_ids=region_id,
         )
-        file_bowtie_results = os.path.join(self.dir_output, f"bowtie_results_{region_id}.txt")
+        file_bowtie_results = safe_append_filename(self.dir_output, f"bowtie_results_{region_id}.txt")
 
         args = [
             "bowtie",
@@ -263,10 +264,10 @@ class BowtieFilter(AlignmentSpecificityFilter):
                 "strand": table_hits["strand"],
             }
         )
-        file_bed = os.path.join(self.dir_output, f"references_{region_id}.bed")
+        file_bed = safe_append_filename(self.dir_output, f"references_{region_id}.bed")
         bed.to_csv(file_bed, sep="\t", index=False, header=False)
 
-        references_fasta_file = os.path.join(self.dir_output, f"references_{region_id}.fasta")
+        references_fasta_file = safe_append_filename(self.dir_output, f"references_{region_id}.fasta")
 
         get_sequence_from_annotation(
             file_bed, file_reference, references_fasta_file, strand=True, nameOnly=True
@@ -435,7 +436,7 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
             save_description=False,
             region_ids=region_id,
         )
-        file_bowtie_results = os.path.join(self.dir_output, f"bowtie2_results_{region_id}.txt")
+        file_bowtie_results = safe_append_filename(self.dir_output, f"bowtie2_results_{region_id}.txt")
 
         args = [
             "bowtie2",

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_variants.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_variants.py
@@ -11,6 +11,7 @@ from oligo_designer_toolsuite._exceptions import ConfigurationError, DatabaseErr
 from oligo_designer_toolsuite.database import OligoDatabase
 from oligo_designer_toolsuite.oligo_specificity_filter import ReferenceSpecificityFilter
 from oligo_designer_toolsuite.utils import get_intersection
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 ############################################
 # Oligo Variants Filter Class
@@ -143,7 +144,7 @@ class VariantsFilter(ReferenceSpecificityFilter):
         file_oligo_database = oligo_database.write_database_to_bed(
             filename=f"{region_id}.bed", dir_output=self.dir_output, region_ids=region_id
         )
-        file_bed_results = os.path.join(self.dir_output, f"bed_results_{region_id}.txt")
+        file_bed_results = safe_append_filename(self.dir_output, f"bed_results_{region_id}.txt")
 
         get_intersection(file_A=file_oligo_database, file_B=file_reference, file_bed_out=file_bed_results)
 

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -11,6 +11,8 @@ from typing import Callable, Iterable
 import numpy as np
 import pandas as pd
 
+from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
+
 pd.options.mode.chained_assignment = None
 
 from pathlib import Path
@@ -101,7 +103,7 @@ class CustomGenomicRegionGenerator:
         self.annotation_release = annotation_release
         self.genome_assembly = genome_assembly
         self.annotation_file = annotation_file
-        self.parsed_annotation_file = os.path.join(
+        self.parsed_annotation_file = safe_append_filename(
             self.dir_output,
             os.path.basename(f"{'.'.join(annotation_file.split('.')[:-1])}.pckl"),
         )
@@ -177,7 +179,7 @@ class CustomGenomicRegionGenerator:
         annotation = annotation[self.BED_HEADER]
 
         # get sequence from bed file
-        file_fasta = os.path.join(self.dir_output, f"{self.FILE_INFO}__annotation_type__gene.fna")
+        file_fasta = safe_append_filename(self.dir_output, f"{self.FILE_INFO}__annotation_type__gene.fna")
         self._get_sequence_from_annotation(annotation, file_fasta, split=False)
 
         del annotation
@@ -374,7 +376,9 @@ class CustomGenomicRegionGenerator:
         annotation = annotation[self.BED_HEADER]
 
         # get sequence from bed file
-        file_fasta = os.path.join(self.dir_output, f"{self.FILE_INFO}__annotation_type__intergenic.fna")
+        file_fasta = safe_append_filename(
+            self.dir_output, f"{self.FILE_INFO}__annotation_type__intergenic.fna"
+        )
         self._get_sequence_from_annotation(annotation, file_fasta, split=False)
 
         os.remove(file_chromosome_length)
@@ -445,7 +449,7 @@ class CustomGenomicRegionGenerator:
         )
         annotation = annotation[self.BED_HEADER]
 
-        file_fasta = os.path.join(self.dir_output, f"{self.FILE_INFO}__annotation_type__exon.fna")
+        file_fasta = safe_append_filename(self.dir_output, f"{self.FILE_INFO}__annotation_type__exon.fna")
         self._get_sequence_from_annotation(annotation, file_fasta, split=False)
 
         del annotation
@@ -585,7 +589,7 @@ class CustomGenomicRegionGenerator:
         annotation = annotation[self.BED_HEADER]
 
         # get sequence from bed file
-        file_fasta = os.path.join(self.dir_output, f"{self.FILE_INFO}__annotation_type__intron.fna")
+        file_fasta = safe_append_filename(self.dir_output, f"{self.FILE_INFO}__annotation_type__intron.fna")
         self._get_sequence_from_annotation(annotation, file_fasta, split=False)
 
         del annotation
@@ -654,7 +658,7 @@ class CustomGenomicRegionGenerator:
         )
         annotation = annotation[self.BED_HEADER]
 
-        file_fasta = os.path.join(self.dir_output, f"{self.FILE_INFO}__annotation_type__cds.fna")
+        file_fasta = safe_append_filename(self.dir_output, f"{self.FILE_INFO}__annotation_type__cds.fna")
         self._get_sequence_from_annotation(annotation, file_fasta, split=False)
 
         del annotation
@@ -800,7 +804,9 @@ class CustomGenomicRegionGenerator:
             ["utr"] + (["five_prime"] if five_prime else []) + (["three_prime"] if three_prime else [])
         )
 
-        file_fasta = os.path.join(self.dir_output, f"{self.FILE_INFO}__annotation_type__{utr_suffix}.fna")
+        file_fasta = safe_append_filename(
+            self.dir_output, f"{self.FILE_INFO}__annotation_type__{utr_suffix}.fna"
+        )
         self._get_sequence_from_annotation(annotation, file_fasta, split=False)
 
         del annotation
@@ -1018,7 +1024,7 @@ class CustomGenomicRegionGenerator:
         )
         annotation = annotation[self.BED12_HEADER]
 
-        file_fasta = os.path.join(
+        file_fasta = safe_append_filename(
             self.dir_output,
             f"{self.FILE_INFO}__annotation_type__exon_exon_junction__block_size__{block_size}.fna",
         )
@@ -1175,7 +1181,7 @@ class CustomGenomicRegionGenerator:
 
         # save the annotation as bed file
         id = random.randint(0, 10000000)
-        file_bed = os.path.join(self.dir_output, f"annotation_{id}.bed")
+        file_bed = safe_append_filename(self.dir_output, f"annotation_{id}.bed")
         annotation.to_csv(file_bed, sep="\t", header=False, index=False)
 
         # create the fasta file

--- a/oligo_designer_toolsuite/sequence_generator/_oligo_sequence_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_oligo_sequence_generator.py
@@ -13,7 +13,7 @@ from joblib import Parallel, delayed
 from oligo_designer_toolsuite.utils import FastaParser
 
 from .._constants import SEPARATOR_FASTA_HEADER_FIELDS, SEPARATOR_FASTA_HEADER_FIELDS_LIST
-from ..utils._checkers_and_helpers import cast_to_list, generate_unique_filename
+from ..utils._checkers_and_helpers import cast_to_list, generate_unique_filename, safe_append_filename
 
 ############################################
 # Oligo Database Class
@@ -104,7 +104,7 @@ class OligoSequenceGenerator:
             }
             sequences_set.update(new_sequences)
 
-        file_fasta_out = os.path.join(self.dir_output, f"{filename_out}.fna")
+        file_fasta_out = safe_append_filename(self.dir_output, f"{filename_out}.fna")
 
         with open(file_fasta_out, "w") as handle_fasta:
             for i, seq in enumerate(sequences_set):
@@ -279,7 +279,7 @@ class OligoSequenceGenerator:
 
         # delete previous content
         for region_id in region_ids:
-            file_fasta_region = os.path.join(self.dir_output, f"{region_id}.fna")
+            file_fasta_region = safe_append_filename(self.dir_output, f"{region_id}.fna")
             if os.path.isfile(file_fasta_region):
                 os.remove(file_fasta_region)
 
@@ -299,7 +299,7 @@ class OligoSequenceGenerator:
                     file for file in files_fasta_oligos if os.path.basename(file).startswith(f"{region_id}_")
                 ]
                 if len(files_fasta_oligos_region) > 0:
-                    file_fasta_region = os.path.join(self.dir_output, f"{region_id}.fna")
+                    file_fasta_region = safe_append_filename(self.dir_output, f"{region_id}.fna")
                     file_fasta_out.add(file_fasta_region)
                     # merge the fasta files into one single file per region
                     self.fasta_parser.merge_fasta_files(

--- a/oligo_designer_toolsuite/utils/_checkers_and_helpers.py
+++ b/oligo_designer_toolsuite/utils/_checkers_and_helpers.py
@@ -220,11 +220,12 @@ def safe_append_filename(dir_path: str, file_name: str) -> str:
     :raises ConfigurationError: If the resulting path escapes the base directory or if the resolved file name does not match the provided file name.
     """
     base_dir = Path(dir_path)
-    resolved_path = (base_dir / file_name).resolve()
+    joined_path = base_dir / file_name
+    resolved_path = joined_path.resolve()
     if not resolved_path.parent == base_dir.resolve():
         raise ConfigurationError(
             f"Invalid file name: {file_name}. The resulting path escapes the base directory."
         )
     if not resolved_path.name == file_name:
         raise ConfigurationError(f"Invalid file name: {file_name}. The resolved file name does not match.")
-    return str(resolved_path)
+    return str(joined_path)

--- a/oligo_designer_toolsuite/utils/_checkers_and_helpers.py
+++ b/oligo_designer_toolsuite/utils/_checkers_and_helpers.py
@@ -3,9 +3,9 @@
 ############################################
 
 import csv
-import os
 import time
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable
 
 if TYPE_CHECKING:
@@ -203,5 +203,28 @@ def generate_unique_filename(dir_output: str, base_name: str, extension: str = "
     timestamp = time.strftime("%Y%m%d-%H%M%S")
     unique_id = uuid.uuid4().hex
     filename = f"{base_name}_{timestamp}_{unique_id}.{extension}"
-    filename = os.path.join(dir_output, filename)
+    filename = safe_append_filename(dir_output, filename)
     return filename
+
+
+def safe_append_filename(dir_path: str, file_name: str) -> str:
+    """
+    Safely joins a directory path and a file name, ensuring that the resulting path does not escape the base directory or resolve to a different file name.
+
+    :param dir_path: The base directory path.
+    :type dir_path: str
+    :param file_name: The file name to join with the directory path.
+    :type file_name: str
+    :return: The safely joined path as a string.
+    :rtype: str
+    :raises ConfigurationError: If the resulting path escapes the base directory or if the resolved file name does not match the provided file name.
+    """
+    base_dir = Path(dir_path)
+    resolved_path = (base_dir / file_name).resolve()
+    if not resolved_path.parent == base_dir.resolve():
+        raise ConfigurationError(
+            f"Invalid file name: {file_name}. The resulting path escapes the base directory."
+        )
+    if not resolved_path.name == file_name:
+        raise ConfigurationError(f"Invalid file name: {file_name}. The resolved file name does not match.")
+    return str(resolved_path)

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -2,11 +2,11 @@
 # imports
 ############################################
 
-import subprocess
 import gzip
 import os
 import pickle
 import re
+import subprocess
 from typing import Any
 
 import pandas as pd

--- a/oligo_designer_toolsuite/utils/_sequence_processor.py
+++ b/oligo_designer_toolsuite/utils/_sequence_processor.py
@@ -2,13 +2,13 @@
 # imports
 ############################################
 
-import subprocess
 import os
+import subprocess
 from collections import Counter
 
 from Bio import SeqIO
 
-from ._checkers_and_helpers import cast_to_list
+from ._checkers_and_helpers import cast_to_list, safe_append_filename
 from ._sequence_parser import FastaParser
 
 ############################################
@@ -168,7 +168,7 @@ def remove_index_files(file_reference: str, dir_output: str) -> None:
             # Remove files that start with the prefix (index files)
             # but not the reference file itself
             if file.startswith(prefix):
-                file_path = os.path.join(root, file)
+                file_path = safe_append_filename(root, file)
                 os.remove(file_path)
 
 


### PR DESCRIPTION
### Summary

This PR introduces a `safe_append_filename` helper function to replace `os.path.join` calls where dynamically generated filenames are appended to a directory path for file placement or lookup. These filenames are often derived from user input, which can lead to unexpected behavior when they contain special characters or sequences like `/`, `/../`, or `\` (depending on OS).

The goal of this PR is to prevent the creation of unintended subdirectories or traversal outside the target directory by ensuring that the resolved path remains strictly within the specified directory.

### Path Traversal Mitigation

Since all existing `os.path.join` calls (outside of tests) operate on files in the `output_dir`, this PR also helps mitigate path traversal vulnerabilities when handling untrusted user input as long as the `output_dir` itself is trusted.

### What changed

1. `safe_append_filename` introduced in `_checkers_and_helpers.py`
- This function joins a directory path and a filename, then resolves the resulting path
- It raises an exception if the resolved path falls outside the specified directory or if the filename is altered during resolution
2. Replaced `os.path.join` calls where filenames are dynamically generated
3. Removed duplicate join with `output_dir` before blastn subprocess call, since `file_reference` already holds a path pointing into the `output_dir`