### PR TITLE
bug fix genomic regions generator correcting new mode parameter level

### DIFF
--- a/data/configs/genomic_region_generator_ncbi.yaml
+++ b/data/configs/genomic_region_generator_ncbi.yaml
@@ -7,19 +7,20 @@ dir_output: output_genomic_region_generator_ncbi # name of the directory where t
 
 ### Parameters for genome and gene annotation
 source: ncbi # required: indicate that ncbi annotation should be used
-mode: species # required: How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'.
-# For 'species', source_params needs the arguments 'taxon', 'species', 'assembly_source' and 'annotation_release'.
-# For 'assembly', source_params needs the arguments 'refseq_assembly_accession' and 'assembly_name'.
 source_params:
+  mode: species # required: How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'.
+  # For 'species', source_params needs the arguments 'taxon', 'species', 'assembly_source' and 'annotation_release'.
+  # For 'assembly', source_params needs the arguments 'refseq_assembly_accession' and 'assembly_name'.
+
   # Mode 'species': set taxon/species/assembly_source/annotation_release
   taxon: vertebrate_mammalian # required in Mode 'species'; supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral
   species: Homo_sapiens # required in Mode 'species'; species name in NCBI download format
+  annotation_release: 110 # required in Mode 'species'; use release number only with assembly_source=annotation_releases; otherwise set to 'current'
   assembly_source: auto # optional in Mode 'species': auto, annotation_releases, latest_assembly_versions, reference. Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory.
   # 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'.
   # 'latest_assembly_version' directory is available for all species and contains the latest assembly.
   # 'reference' directory contains the reference genome. This is only available for a subset of species.
   # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'
-  annotation_release: 110 # required in Mode 'species'; use release number only with assembly_source=annotation_releases; otherwise set to 'current'
 
   # Mode 'assembly': set both fields below
   # refseq_assembly_accession: GCF_000001405.38

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -121,7 +121,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
         ## Create blast index
         args = ["makeblastdb", "-dbtype", "nucl", "-out", file_reference, "-in", file_reference]
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         return file_reference
 
@@ -174,7 +174,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
             if str(value) != "":
                 args.append(str(value))
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         # read the reuslts of the blast seatch
         blast_results = self._read_search_output(

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -118,7 +118,7 @@ class BowtieFilter(AlignmentSpecificityFilter):
             file_reference,
         ]
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         return file_reference
 
@@ -173,7 +173,7 @@ class BowtieFilter(AlignmentSpecificityFilter):
         args.append(file_oligo_database)
         args.append(file_bowtie_results)
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         # read the reuslts of the bowtie search
         bowtie_results = self._read_search_output(
@@ -401,7 +401,7 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
             file_reference,
         ]
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         return file_reference
 
@@ -458,7 +458,7 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
 
         args.extend(["-U", file_oligo_database, "-S", file_bowtie_results])
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         # read the reuslts of the bowtie seatch
         bowtie_results = self._read_search_output(

--- a/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
@@ -47,7 +47,6 @@ class GenomicRegionGenerator:
     def load_annotations(
         self,
         source: str,
-        mode: str | None,
         source_params: dict,
     ) -> CustomGenomicRegionGenerator:
         """
@@ -55,10 +54,8 @@ class GenomicRegionGenerator:
 
         :param source: The source of the annotations. Options: 'ncbi', 'ensembl', 'custom'.
         :type source: str
-        :param mode: How should be specified which genome to use? Options: 'species', 'assembly'
-        :type mode: str
         :param source_params: Parameters required for loading the annotations depending on the source.
-            If source is 'ncbi', it should contain 'taxon', 'species', 'annotation_release' and can optionally
+            If source is 'ncbi', it should contain 'mode', 'taxon', 'species', 'annotation_release' and can optionally
             contain 'assembly_source', 'refseq_assembly_accession', and 'assembly_name'.
             If source is 'ensembl', it should contain 'species' and 'annotation_release'.
             If source is 'custom', it should contain 'file_annotation', 'file_sequence', 'files_source',
@@ -81,13 +78,13 @@ class GenomicRegionGenerator:
 
         ##### loading annotations from different sources #####
         if source == "ncbi":
-            if mode is None:
+            if source_params["mode"] is None:
                 raise ConfigurationError(
-                    "For source='ncbi', top-level config parameter 'mode' must be provided."
+                    "For source='ncbi', source_params parameter 'mode' must be provided."
                 )
             # dowload the fasta files formthe NCBI server
             region_generator = NcbiGenomicRegionGenerator(
-                mode=mode,
+                mode=source_params["mode"],
                 taxon=source_params["taxon"],
                 species=source_params["species"],
                 annotation_release=source_params["annotation_release"],
@@ -206,7 +203,6 @@ def main() -> None:
     # generate the genomic regions
     region_generator = pipeline.load_annotations(
         source=config["source"],
-        mode=config["mode"],
         source_params=config["source_params"],
     )
 

--- a/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
@@ -55,8 +55,10 @@ class GenomicRegionGenerator:
         :param source: The source of the annotations. Options: 'ncbi', 'ensembl', 'custom'.
         :type source: str
         :param source_params: Parameters required for loading the annotations depending on the source.
-            If source is 'ncbi', it should contain 'mode', 'taxon', 'species', 'annotation_release' and can optionally
-            contain 'assembly_source', 'refseq_assembly_accession', and 'assembly_name'.
+            If source is 'ncbi', it must contain 'mode'. The remaining required keys depend on that mode:
+            for taxonomy/species-based modes, provide 'taxon', 'species', and 'annotation_release';
+            for 'assembly' mode, provide the assembly identifier via 'refseq_assembly_accession' and/or
+            'assembly_name'. 'assembly_source' may also be provided when applicable.
             If source is 'ensembl', it should contain 'species' and 'annotation_release'.
             If source is 'custom', it should contain 'file_annotation', 'file_sequence', 'files_source',
             'species', 'annotation_release', and 'genome_assembly'.

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -2,11 +2,11 @@
 # imports
 ############################################
 
-import subprocess
 import gzip
 import os
 import pickle
 import re
+import subprocess
 from typing import Any
 
 import pandas as pd
@@ -634,19 +634,19 @@ class VCFParser:
                 compressed_files_to_cleanup.append(file_vcf_compressed)
 
                 args_compress = ["bcftools", "view", "-O", "z", "-o", file_vcf_compressed, file_vcf]
-                subprocess.run(args_compress, check=True)
+                subprocess.run(args_compress, check=True, stdout=subprocess.DEVNULL)
 
                 file_vcf = file_vcf_compressed
 
             args_sort = ["bcftools", "sort", file_vcf, "-Oz", "-o", file_vcf]
-            subprocess.run(args_sort, check=True)
+            subprocess.run(args_sort, check=True, stdout=subprocess.DEVNULL)
 
             args_index = ["bcftools", "index", "-f", file_vcf]
-            subprocess.run(args_index, check=True)
+            subprocess.run(args_index, check=True, stdout=subprocess.DEVNULL)
 
             args.append(file_vcf)
 
-        subprocess.run(args, check=True)
+        subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
 
         # Clean up compressed files and their index files
         for file_vcf_compressed in compressed_files_to_cleanup:

--- a/oligo_designer_toolsuite/utils/_sequence_processor.py
+++ b/oligo_designer_toolsuite/utils/_sequence_processor.py
@@ -2,8 +2,8 @@
 # imports
 ############################################
 
-import subprocess
 import os
+import subprocess
 from collections import Counter
 
 from Bio import SeqIO
@@ -53,7 +53,7 @@ def get_sequence_from_annotation(
     if name:
         args.append("-name")
 
-    subprocess.run(args, check=True)
+    subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
 
 
 def get_complement_regions(file_bed_in: str, file_chromosome_length: str, file_bed_out: str) -> None:
@@ -88,7 +88,7 @@ def get_intersection(file_A: str, file_B: list[str] | str, file_bed_out: str) ->
     :param file_bed_out: Path to the output BED file where the intersection results will be saved.
     :type file_bed_out: str
     """
-    file_B: list[str] = cast_to_list(file_B)
+    file_B_list: list[str] = cast_to_list(file_B)
 
     args = [
         "bedtools",
@@ -99,7 +99,7 @@ def get_intersection(file_A: str, file_B: list[str] | str, file_bed_out: str) ->
         "-a",
         file_A,
         "-b",
-        *file_B,
+        *file_B_list,
     ]
 
     # redirect stdout to output file


### PR DESCRIPTION
## Summary

On top of `172-general-bug-fixed-on-dev`, this branch fixes how the NCBI genome selection **`mode`** is configured and passed into the genomic region generator: it lives under **`source_params`** (not as a top-level YAML key), and **`load_annotations`** no longer takes a separate **`mode`** argument.

## Changes

- **`GenomicRegionGenerator.load_annotations`:** Remove the **`mode`** parameter; for **`source == "ncbi"`**, read **`source_params["mode"]`**, validate it, and pass it to **`NcbiGenomicRegionGenerator`**.
- **`main()` in `_genomic_region_generator.py`:** Call **`load_annotations(source=..., source_params=...)`** only (no **`mode=config["mode"]`**).
- **`data/configs/genomic_region_generator_ncbi.yaml`:** Move **`mode`** and its comments into **`source_params`**; reorder **`annotation_release`** next to other species-mode fields (behavior unchanged).

## User-facing migration

Existing configs that set **`mode`** at the top level next to **`source`** should move **`mode`** inside **`source_params`** for NCBI runs.

## Verify

- **`pytest tests/test_pipelines.py::TestGenomicRegionGenerator`** (and any other genomic region tests you rely on).