### PR TITLE
Suppress stdout for subprocess calls in BlastN, Bowtie, and sequence …

### DIFF
--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -121,7 +121,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
         ## Create blast index
         args = ["makeblastdb", "-dbtype", "nucl", "-out", file_reference, "-in", file_reference]
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         return file_reference
 
@@ -174,7 +174,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
             if str(value) != "":
                 args.append(str(value))
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         # read the reuslts of the blast seatch
         blast_results = self._read_search_output(

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_bowtie.py
@@ -118,7 +118,7 @@ class BowtieFilter(AlignmentSpecificityFilter):
             file_reference,
         ]
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         return file_reference
 
@@ -173,7 +173,7 @@ class BowtieFilter(AlignmentSpecificityFilter):
         args.append(file_oligo_database)
         args.append(file_bowtie_results)
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         # read the reuslts of the bowtie search
         bowtie_results = self._read_search_output(
@@ -401,7 +401,7 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
             file_reference,
         ]
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         return file_reference
 
@@ -458,7 +458,7 @@ class Bowtie2Filter(AlignmentSpecificityFilter):
 
         args.extend(["-U", file_oligo_database, "-S", file_bowtie_results])
 
-        subprocess.run(args, cwd=self.dir_output, check=True)
+        subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)
 
         # read the reuslts of the bowtie seatch
         bowtie_results = self._read_search_output(

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -2,11 +2,11 @@
 # imports
 ############################################
 
-import subprocess
 import gzip
 import os
 import pickle
 import re
+import subprocess
 from typing import Any
 
 import pandas as pd
@@ -634,19 +634,19 @@ class VCFParser:
                 compressed_files_to_cleanup.append(file_vcf_compressed)
 
                 args_compress = ["bcftools", "view", "-O", "z", "-o", file_vcf_compressed, file_vcf]
-                subprocess.run(args_compress, check=True)
+                subprocess.run(args_compress, check=True, stdout=subprocess.DEVNULL)
 
                 file_vcf = file_vcf_compressed
 
             args_sort = ["bcftools", "sort", file_vcf, "-Oz", "-o", file_vcf]
-            subprocess.run(args_sort, check=True)
+            subprocess.run(args_sort, check=True, stdout=subprocess.DEVNULL)
 
             args_index = ["bcftools", "index", "-f", file_vcf]
-            subprocess.run(args_index, check=True)
+            subprocess.run(args_index, check=True, stdout=subprocess.DEVNULL)
 
             args.append(file_vcf)
 
-        subprocess.run(args, check=True)
+        subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
 
         # Clean up compressed files and their index files
         for file_vcf_compressed in compressed_files_to_cleanup:

--- a/oligo_designer_toolsuite/utils/_sequence_processor.py
+++ b/oligo_designer_toolsuite/utils/_sequence_processor.py
@@ -2,8 +2,8 @@
 # imports
 ############################################
 
-import subprocess
 import os
+import subprocess
 from collections import Counter
 
 from Bio import SeqIO
@@ -53,7 +53,7 @@ def get_sequence_from_annotation(
     if name:
         args.append("-name")
 
-    subprocess.run(args, check=True)
+    subprocess.run(args, check=True, stdout=subprocess.DEVNULL)
 
 
 def get_complement_regions(file_bed_in: str, file_chromosome_length: str, file_bed_out: str) -> None:
@@ -88,7 +88,7 @@ def get_intersection(file_A: str, file_B: list[str] | str, file_bed_out: str) ->
     :param file_bed_out: Path to the output BED file where the intersection results will be saved.
     :type file_bed_out: str
     """
-    file_B: list[str] = cast_to_list(file_B)
+    file_B_list: list[str] = cast_to_list(file_B)
 
     args = [
         "bedtools",
@@ -99,7 +99,7 @@ def get_intersection(file_A: str, file_B: list[str] | str, file_bed_out: str) ->
         "-a",
         file_A,
         "-b",
-        *file_B,
+        *file_B_list,
     ]
 
     # redirect stdout to output file


### PR DESCRIPTION
## Summary

On top of `173-fix-failing-tests`, this PR sends **standard output** from selected external subprocesses to **`subprocess.DEVNULL`** so interactive runs stay readable next to structured progress UI. **`check=True`** is unchanged, so failures still raise **`CalledProcessError`**.

## Changes

| Area | Commands | Change |
|------|----------|--------|
| **`_filter_blastn.py`** | `makeblastdb`, `blastn` | `stdout=subprocess.DEVNULL` |
| **`_filter_bowtie.py`** | Bowtie / Bowtie2 index and align | `stdout=subprocess.DEVNULL` |
| **`_sequence_parser.py`** | `bcftools` (`view`, `sort`, `index`, `merge`) in `VCFParser.merge_vcf_files` | `stdout=subprocess.DEVNULL` |
| **`_sequence_processor.py`** | `bedtools getfasta` | `stdout=subprocess.DEVNULL` |
| **`_sequence_processor.py`** | `get_intersection` | Rename inner **`file_B`** → **`file_B_list`** to avoid shadowing the **`file_B`** parameter (no intended behavior change) |

## Note on stderr

Messages printed to **standard error** (for example some **bcftools** progress lines) are **not** suppressed by this change.


## Verify

- Run **`pytest`** (at least **`tests/test_oligo_specificity_filter.py`**, **`tests/test_utils.py`**, and any tests that exercise VCF merge / bedtools paths).
