### PR TITLE
176 remove insufficient regions at each filtering step

### DIFF
--- a/oligo_designer_toolsuite/oligo_property_calculator/_property_region.py
+++ b/oligo_designer_toolsuite/oligo_property_calculator/_property_region.py
@@ -19,8 +19,9 @@ class NumTargetedTranscriptsProperty(BaseProperty):
     A property class for calculating the number of unique transcripts targeted by an oligonucleotide.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, property_name: str = "transcript_id") -> None:
         """Constructor for the NumTargetedTranscriptsProperty class."""
+        self.property_name = property_name
         super().__init__()
 
     def apply(self, oligo_database: OligoDatabase, region_id: str, oligo_id: str, sequence_type: str) -> dict:
@@ -39,7 +40,7 @@ class NumTargetedTranscriptsProperty(BaseProperty):
         :rtype: dict
         """
         transcript_id = oligo_database.get_oligo_property_value(
-            property="transcript_id", region_id=region_id, oligo_id=oligo_id, flatten=True
+            property=self.property_name, region_id=region_id, oligo_id=oligo_id, flatten=True
         )
 
         if transcript_id:
@@ -59,9 +60,15 @@ class IsoformConsensusProperty(BaseProperty):
     A property class for calculating the isoform consensus for an oligonucleotide.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        property_name_transcript_id: str = "transcript_id",
+        property_name_number_total_transcripts: str = "number_total_transcripts",
+    ) -> None:
         """Constructor for the IsoformConsensusProperty class."""
         super().__init__()
+        self.property_name_transcript_id = property_name_transcript_id
+        self.property_name_number_total_transcripts = property_name_number_total_transcripts
 
     def apply(self, oligo_database: OligoDatabase, region_id: str, oligo_id: str, sequence_type: str) -> dict:
         """
@@ -79,11 +86,17 @@ class IsoformConsensusProperty(BaseProperty):
         :rtype: dict
         """
         number_total_transcripts = oligo_database.get_oligo_property_value(
-            property="number_total_transcripts", region_id=region_id, oligo_id=oligo_id, flatten=True
+            property=self.property_name_number_total_transcripts,
+            region_id=region_id,
+            oligo_id=oligo_id,
+            flatten=True,
         )
 
         transcript_id = oligo_database.get_oligo_property_value(
-            property="transcript_id", region_id=region_id, oligo_id=oligo_id, flatten=True
+            property=self.property_name_transcript_id,
+            region_id=region_id,
+            oligo_id=oligo_id,
+            flatten=True,
         )
 
         if transcript_id and number_total_transcripts:

--- a/oligo_designer_toolsuite/oligo_property_filter/_property_filter.py
+++ b/oligo_designer_toolsuite/oligo_property_filter/_property_filter.py
@@ -58,6 +58,7 @@ class PropertyFilter:
                 delayed(self._filter_region)(oligo_database, region_id, sequence_type)
                 for region_id in region_ids
             )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
 
         return oligo_database
 

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_specificity_filter.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_specificity_filter.py
@@ -64,5 +64,6 @@ class SpecificityFilter:
                 sequence_type=sequence_type,
                 n_jobs=n_jobs,
             )
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step=specificity_filter.filter_name)
 
         return oligo_database

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_specificity_filter.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_specificity_filter.py
@@ -64,6 +64,8 @@ class SpecificityFilter:
                 sequence_type=sequence_type,
                 n_jobs=n_jobs,
             )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step=specificity_filter.filter_name)
+            oligo_database.remove_regions_with_insufficient_oligos(
+                pipeline_step=specificity_filter.filter_name
+            )
 
         return oligo_database

--- a/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
@@ -1245,7 +1245,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_L",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         oligo_database = property_filter.apply(
@@ -1253,7 +1252,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_R",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1371,7 +1369,6 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         ##### define cross hybridization filter #####
@@ -1413,7 +1410,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_L",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         oligo_database = specificity_filter.apply(
@@ -1421,7 +1417,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_R",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         ##### remove all directories of intermediate steps #####

--- a/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
@@ -561,7 +561,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_L",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         oligo_database = property_filter.apply(
@@ -569,7 +568,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_R",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -628,7 +626,6 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         ##### define cross hybridization filter #####
@@ -670,7 +667,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_L",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         oligo_database = specificity_filter.apply(
@@ -678,7 +674,6 @@ class TargetProbeDesigner:
             sequence_type="oligo_R",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         ##### remove all directories of intermediate steps #####

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -1439,7 +1439,6 @@ class TargetProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1552,7 +1551,6 @@ class TargetProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1890,7 +1888,6 @@ class ReadoutProbeDesigner:
             n_jobs=self.n_jobs,
         )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -2008,7 +2005,6 @@ class ReadoutProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -2513,7 +2509,6 @@ class PrimerDesigner:
             n_jobs=self.n_jobs,
         )
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -2629,7 +2624,6 @@ class PrimerDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -844,7 +844,6 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -1070,7 +1070,6 @@ class TargetProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos("Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -1071,7 +1071,6 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1272,7 +1271,6 @@ class TargetProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -1302,7 +1302,6 @@ class TargetProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1415,7 +1414,6 @@ class TargetProbeDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1695,7 +1693,6 @@ class ReadoutProbeDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -1812,7 +1809,7 @@ class ReadoutProbeDesigner:
         ]:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
+
         check_content_oligo_database(oligo_database)
         return oligo_database
 
@@ -2256,7 +2253,6 @@ class PrimerDesigner:
             sequence_type="oligo",
             n_jobs=self.n_jobs,
         )
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -2372,7 +2368,6 @@ class PrimerDesigner:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Specificity Filters")
         check_content_oligo_database(oligo_database)
 
         return oligo_database


### PR DESCRIPTION
## Summary

This PR moves `remove_regions_with_insufficient_oligos(...)` out of individual pipelines and into the shared `PropertyFilter` and `SpecificityFilter` classes so region-pruning is applied consistently after each filtering stage. It also makes transcript-related region properties configurable by adding property-name parameters to `NumTargetedTranscriptsProperty` and `IsoformConsensusProperty`.

## What changed

### 1) Centralized pruning of insufficient regions

- `PropertyFilter.apply(...)` now runs:
  - `oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Property Filters")`
  - after region-level property filtering completes.
- `SpecificityFilter.apply(...)` now runs:
  - `oligo_database.remove_regions_with_insufficient_oligos(pipeline_step=specificity_filter.filter_name)`
  - after each applied specificity filter.

### 2) Remove duplicated pruning calls from pipelines

Redundant per-pipeline calls to `remove_regions_with_insufficient_oligos(...)` were removed from:

- `pipelines/_cycle_hcr_probe_designer.py`
- `pipelines/_hcr_probe_designer.py`
- `pipelines/_merfish_probe_designer.py`
- `pipelines/_oligo_seq_probe_designer.py`
- `pipelines/_scrinshot_probe_designer.py`
- `pipelines/_seqfish_plus_probe_designer.py`

This keeps behavior centralized and avoids drift between pipelines.

### 3) Parameterized transcript property names

In `oligo_property_calculator/_property_region.py`:

- `NumTargetedTranscriptsProperty` now accepts:
  - `property_name: str = "transcript_id"`
- `IsoformConsensusProperty` now accepts:
  - `property_name_transcript_id: str = "transcript_id"`
  - `property_name_number_total_transcripts: str = "number_total_transcripts"`

Both classes now read values using these configurable property names instead of hardcoded keys.

## Why

- Ensures the same region-pruning logic is executed for every pipeline using shared filters.
- Reduces duplicate maintenance points across six pipelines.
- Improves flexibility for datasets/configs that store transcript metadata under different property keys.

## Suggested verification

- Run pipeline-focused tests, especially around filtering stages:
  - `tests/test_pipelines.py`
  - `tests/test_oligo_property_filter.py`
  - `tests/test_oligo_specificity_filter.py`
- Smoke-test one representative pipeline per family (HCR / MERFISH / Oligo-seq) to confirm no regressions in region retention behavior.
