### PR TITLE
Replace usage of `default_factory` with customized Model overrides

### DIFF
--- a/oligo_designer_toolsuite/config/overrides/oligo_seq_probe_designer_overrides.py
+++ b/oligo_designer_toolsuite/config/overrides/oligo_seq_probe_designer_overrides.py
@@ -1,0 +1,44 @@
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from oligo_designer_toolsuite.config._general_models import BlastnHitParameters, BlastnSearchParameters
+from oligo_designer_toolsuite.config._specificity_filters import (
+    SpecificityBlastnFilterDisabled,
+    SpecificityBlastnFilterEnabled,
+    VariantFilterDisabled,
+    VariantFilterEnabled,
+)
+
+
+class OligoSeqSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
+    pass
+
+
+class OligoSeqSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=80, strand="minus", word_size=10
+    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(coverage=50)
+
+
+OligoSeqSpecificityBlastnFilterConfig = Annotated[
+    OligoSeqSpecificityBlastnFilterEnabled | OligoSeqSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class OligoSeqVariantFilterDisabled(VariantFilterDisabled):
+    pass
+
+
+class OligoSeqVariantFilterEnabled(VariantFilterEnabled):
+    action: Annotated[
+        Literal["flag", "filter"],
+        Field(description="Action for variant-overlapping oligos: 'flag' (mark only) or 'filter' (exclude)."),
+    ] = "flag"
+
+
+OligoSeqVariantFilterConfig = Annotated[
+    VariantFilterEnabled | VariantFilterDisabled, Field(discriminator="enabled")
+]

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -45,16 +45,16 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     CrossHybridizationBlastnFilterEnabled,
     ReadLengthBiasFilterConfig,
     ReadLengthBiasFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
-    VariantFilterConfig,
-    VariantFilterEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     FilesFastaDatabaseT,
     LengthMaxT,
     LengthMinT,
     RegionListT,
+)
+from oligo_designer_toolsuite.config.overrides.oligo_seq_probe_designer_overrides import (
+    OligoSeqSpecificityBlastnFilterConfig,
+    OligoSeqVariantFilterConfig,
 )
 
 
@@ -113,19 +113,8 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParameters(coverage=50),
         )
     )
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default_factory=lambda: SpecificityBlastnFilterEnabled.model_construct(
-            enabled=True,
-            search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
-            hit_parameters=BlastnHitParameters(coverage=50),
-        )
-    )
-    variant_filter: VariantFilterConfig = Field(
-        default_factory=lambda: VariantFilterEnabled.model_construct(
-            enabled=True,
-            action="flag",
-        )
-    )
+    specificity_blastn_filter: OligoSeqSpecificityBlastnFilterConfig
+    variant_filter: OligoSeqVariantFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):


### PR DESCRIPTION
This PR replaces the use of `default_factory` with customized OligoSeq-specific overrides.

### Why?

The previous implementation using `default_factory` was used as a work-around to override default values (e.g. for `BlastnSearchParameters`) without setting a default for file paths. However, this allows creating incorrect instances of Pydantic models that miss the file paths as they are considered optional at one step (since Pydantic expectes them to be created by the `default_factory`) but mandatory overall.
This also makes the use of a custom schema exporter necessary.

Example:
```py
# Creating an invalid config instance by letting the default_factory create invalid defaults
config = OligoSeqProbeDesignerConfig(
    target_probe=TargetProbe(
        oligo_generation=TargetProbeOligoGeneration(
            file_region_ids="data/genes/custom_3.txt",
            files_fasta_probe_database=[
                "data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna"
            ],
        ),
        property_filters=TargetProbePropertyFilter(),
        specificity_filters=TargetProbeSpecificityFilter(),
        probe_set_selection=TargetProbeProbeSetSelection(),
        global_parameters=TargetProbeGlobal(),
    ),
)
```
This code works as `TargetProbeSpecificityFilter()` will execute each `default_factory` and Pydantic by default assumes that this will define all fields. There is no way to both use the `BlastnSearchParameters` defaults provided by the factory _and_ add the file paths in a single step.

### The Change

The new overrides work by subclassing the original config Models and changing the default values according to the needs of each pipeline. This allows us to change the default values of _some_ attributes without having to specify a value for _all_ of them (notably, file paths).

### Advantages

This change makes it clear which arguments are required, eliminating the possibility of using an invalid config like above. The example above would fail with helpful errors. The minimal config required now looks like this:

```py
# Minimum overrides necessary to create valid config
config = OligoSeqProbeDesignerConfig(
    target_probe=TargetProbe(
        oligo_generation=TargetProbeOligoGeneration(
            file_region_ids="data/genes/custom_3.txt",
            files_fasta_probe_database=[
                "data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna",
                "data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna",
            ],
        ),
        property_filters=TargetProbePropertyFilter(),
        specificity_filters=TargetProbeSpecificityFilter(
            specificity_blastn_filter=OligoSeqSpecificityBlastnFilterEnabled(
                enabled=True,
                files_fasta_reference_database=[
                    "data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna",
                    "data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna",
                ],
            ),
            variant_filter=OligoSeqVariantFilterEnabled(
                enabled=True,
                files_vcf_reference_database=[
                    "data/annotations/custom_GCF_000001405.40.chr16.vcf"
                ],
            ),
        ),
        probe_set_selection=TargetProbeProbeSetSelection(),
        global_parameters=TargetProbeGlobal(),
    ),
)
```

The JSON schema can now simply be created using just:
```py
with open("schema.json", "w") as f:
    json.dump(OligoSeqProbeDesignerConfig.model_json_schema(), f, indent=4)
```

### Disadvantages

This makes it necessary to define all pipeline-specific overrides for models that contain mandatory parameters (e.g. file paths) by subclassing the default config. There may be a nicer approach to overriding default values in Pydantic, but I wasn't able to find one.