### PR TITLE
Add dedicated library-wide logger

### DIFF
--- a/oligo_designer_toolsuite/database/_oligo_database.py
+++ b/oligo_designer_toolsuite/database/_oligo_database.py
@@ -4,7 +4,6 @@
 
 import os
 import pickle
-import warnings
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +29,7 @@ from oligo_designer_toolsuite.utils import (
     collapse_properties_for_duplicated_sequences,
     flatten_property_list,
     format_oligo_properties,
+    logger,
     merge_databases,
 )
 from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
@@ -565,7 +565,7 @@ class OligoDatabase:
         property_table = property_table[~mask]
 
         if mask.sum() > 0:
-            warnings.warn(f"Removing {mask.sum()} row(s) containing None/NaN values.", UserWarning)
+            logger.warning(f"Removing {mask.sum()} row(s) containing None/NaN values.")
 
         # expand rows which contain lists for chr, start, end, strand columns into seperate rows
         property_table_extended = property_table.explode(
@@ -785,15 +785,13 @@ class OligoDatabase:
                             sheet_name = sheet_name.replace(char, "_")
                         region_data.to_excel(writer, sheet_name=sheet_name, index=False)
         except ImportError:
-            warnings.warn(
+            logger.warning(
                 "openpyxl is not installed. Excel file generation skipped. "
                 "Install openpyxl to enable Excel export: pip install openpyxl",
-                UserWarning,
             )
         except Exception as e:
-            warnings.warn(
+            logger.warning(
                 f"Failed to write Excel file: {e}. TSV file was written successfully.",
-                UserWarning,
             )
 
     def write_ready_to_order_yaml(

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -4,7 +4,6 @@
 
 import os
 import subprocess
-import warnings
 from abc import abstractmethod
 
 import numpy as np
@@ -20,6 +19,7 @@ from oligo_designer_toolsuite.oligo_property_calculator import (
     SeedregionSiteProperty,
 )
 from oligo_designer_toolsuite.oligo_specificity_filter import AlignmentSpecificityFilter
+from oligo_designer_toolsuite.utils import logger
 from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 from ..utils._sequence_processor import get_sequence_from_annotation
@@ -217,7 +217,7 @@ class BlastNFilter(AlignmentSpecificityFilter):
         """
         if "min_alignment_length" in self.hit_parameters.keys():
             if "coverage" in self.hit_parameters.keys():
-                warnings.warn(
+                logger.warning(
                     "Both, 'min_alignment_length' and 'coverage' parameters were provided. Using 'min_alignment_length' parameter."
                 )
             min_alignment_length = self.hit_parameters["min_alignment_length"]
@@ -590,7 +590,7 @@ class BlastNSeedregionFilterBase(BlastNFilter):
         """
         if "min_alignment_length" in self.hit_parameters.keys():
             if "coverage" in self.hit_parameters.keys():
-                warnings.warn(
+                logger.warning(
                     "Both, 'min_alignment_length' and 'coverage' parameters were provided. Using 'min_alignment_length' parameter."
                 )
             min_alignment_length = self.hit_parameters["min_alignment_length"]

--- a/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
@@ -3,10 +3,8 @@
 ############################################
 
 import itertools
-import logging
 import os
 import shutil
-import warnings
 from pathlib import Path
 
 import numpy as np
@@ -60,9 +58,9 @@ from oligo_designer_toolsuite.pipelines._utils import (
     format_sequence,
     pipeline_step_basic,
     preprocess_tm_parameters,
-    setup_logging,
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
+from oligo_designer_toolsuite.utils import configure_root_logger, logger
 
 ############################################
 # CycleHCR Probe Designer
@@ -169,12 +167,6 @@ class CycleHCRProbeDesigner:
         self.dir_output = os.path.abspath(dir_output)
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
 
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="cyclehcr_probe_designer",
-            log_start_message=True,
-        )
         self.write_intermediate_steps = write_intermediate_steps
         self.n_jobs = n_jobs
 
@@ -386,7 +378,7 @@ class CycleHCRProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 1 (Create Database) in directory {dir_database}"
             )
 
@@ -406,7 +398,7 @@ class CycleHCRProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 2 (Property Filters) in directory {dir_database}"
             )
 
@@ -423,7 +415,7 @@ class CycleHCRProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 3 (Specificity Filters) in directory {dir_database}"
             )
 
@@ -463,7 +455,7 @@ class CycleHCRProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 4 (Specificity Filters) in directory {dir_database}."
             )
 
@@ -520,7 +512,7 @@ class CycleHCRProbeDesigner:
                     file_readout_probe_table=file_readout_probe_table
                 )
             )
-            logging.info(
+            logger.info(
                 f"Loaded readout probes table from file and retrieved {n_channels} channels and {n_readout_probes_LR} L and R readout probes."
             )
         else:
@@ -1886,7 +1878,7 @@ def main() -> None:
     Command-line arguments are parsed using `base_parser()`, which expects:
     - `config`: Path to the YAML configuration file containing all pipeline parameters
     """
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
 
     args = base_parser()
 
@@ -1896,7 +1888,7 @@ def main() -> None:
 
     ##### read the genes file #####
     if config["file_regions"] is None:
-        warnings.warn(
+        logger.warning(
             "No gene list file was provided! All genes from fasta file are used to generate the probes. This chioce can use a lot of resources."
         )
         region_ids = None
@@ -1911,6 +1903,12 @@ def main() -> None:
         dir_output=config["dir_output"],
         write_intermediate_steps=config["write_intermediate_steps"],
         n_jobs=config["n_jobs"],
+    )
+
+    # setup logger
+    configure_root_logger(
+        dir_output=pipeline.dir_output,
+        pipeline_name="cyclehcr_probe_designer",
     )
 
     ##### design probes #####
@@ -1996,7 +1994,7 @@ def main() -> None:
         readout_probe_table=readout_probe_table,
     )
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
@@ -3,19 +3,19 @@
 ############################################
 
 import inspect
-import logging
 import os
 from pathlib import Path
 
 import yaml
 
 from oligo_designer_toolsuite._exceptions import ConfigurationError
-from oligo_designer_toolsuite.pipelines._utils import base_log_parameters, base_parser, setup_logging
+from oligo_designer_toolsuite.pipelines._utils import base_log_parameters, base_parser
 from oligo_designer_toolsuite.sequence_generator import (
     CustomGenomicRegionGenerator,
     EnsemblGenomicRegionGenerator,
     NcbiGenomicRegionGenerator,
 )
+from oligo_designer_toolsuite.utils import configure_root_logger, logger
 
 ############################################
 # Genomic Region Generator Functions
@@ -36,13 +36,6 @@ class GenomicRegionGenerator:
         # create the output folder
         self.dir_output = os.path.abspath(dir_output)
         Path(dir_output).mkdir(parents=True, exist_ok=True)
-
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="genomic_region_generation",
-            include_console=True,
-        )
 
     def load_annotations(
         self,
@@ -67,7 +60,7 @@ class GenomicRegionGenerator:
         :rtype: CustomGenomicRegionGenerator
         """
         ##### log parameters #####
-        logging.info("Parameters Load Annotations:")
+        logger.info("Parameters Load Annotations:")
         frame = inspect.currentframe()
         if frame is not None:
             args, _, _, values = inspect.getargvalues(frame)
@@ -119,10 +112,10 @@ class GenomicRegionGenerator:
             )
 
         ##### save annotation information #####
-        logging.info(
+        logger.info(
             f"The following annotation files are used for GTF annotation of regions: {region_generator.annotation_file} and for fasta sequence file: {region_generator.sequence_file} ."
         )
-        logging.info(
+        logger.info(
             f"The annotations are from {region_generator.files_source} source, for the species: {region_generator.species}, release number: {region_generator.annotation_release} and genome assembly: {region_generator.genome_assembly}"
         )
         return region_generator
@@ -172,7 +165,7 @@ class GenomicRegionGenerator:
                     )
 
                 files_fasta.append(file_fasta)
-                logging.info(f"The genomic region '{genomic_region}' was stored in :{file_fasta}.")
+                logger.info(f"The genomic region '{genomic_region}' was stored in :{file_fasta}.")
 
         return files_fasta
 
@@ -193,7 +186,7 @@ def main() -> None:
         - config: Path to the configuration YAML file containing parameters for the pipeline.
     :type args: dict
     """
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
     args = base_parser()
 
     # read the config file
@@ -201,6 +194,13 @@ def main() -> None:
         config = yaml.safe_load(handle)
 
     pipeline = GenomicRegionGenerator(dir_output=config["dir_output"])
+
+    # setup logger
+    configure_root_logger(
+        dir_output=pipeline.dir_output,
+        pipeline_name="genomic_region_generation",
+        include_console=True,
+    )
 
     # generate the genomic regions
     region_generator = pipeline.load_annotations(
@@ -214,7 +214,7 @@ def main() -> None:
         block_size=config["exon_exon_junction_block_size"],
     )
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
@@ -2,10 +2,8 @@
 # imports
 ############################################
 
-import logging
 import os
 import shutil
-import warnings
 from pathlib import Path
 
 import pandas as pd
@@ -55,9 +53,9 @@ from oligo_designer_toolsuite.pipelines._utils import (
     check_content_oligo_database,
     format_sequence,
     pipeline_step_basic,
-    setup_logging,
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
+from oligo_designer_toolsuite.utils import configure_root_logger, logger
 
 ############################################
 # HCR Probe Designer
@@ -76,13 +74,6 @@ class HcrProbeDesigner:
         # create the output folder
         self.dir_output = os.path.abspath(dir_output)
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
-
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="hcr_probe_designer",
-            log_start_message=True,
-        )
 
         ##### set class parameters #####
         self.write_intermediate_steps = write_intermediate_steps
@@ -138,7 +129,7 @@ class HcrProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 1 (Create Database) in directory {dir_database}"
             )
 
@@ -158,7 +149,7 @@ class HcrProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 2 (Property Filters) in directory {dir_database}"
             )
 
@@ -175,7 +166,7 @@ class HcrProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 3 (Specificity Filters) in directory {dir_database}"
             )
 
@@ -209,7 +200,7 @@ class HcrProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 4 (Specificity Filters) in directory {dir_database}."
             )
 
@@ -230,7 +221,7 @@ class HcrProbeDesigner:
             initiator_table = initiator_designer.load_initiator_table(
                 file_initiator_table=file_initiator_table
             )
-            logging.info(f"Loaded initiator table from file and retrieved {len(initiator_table)} initiators.")
+            logger.info(f"Loaded initiator table from file and retrieved {len(initiator_table)} initiators.")
         else:
             raise FeatureNotImplementedError(
                 "Generation of initiator table is not yet implemented. "
@@ -808,7 +799,7 @@ class InitiatorDesigner:
 
 def main() -> None:
 
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
 
     args = base_parser()
 
@@ -818,7 +809,7 @@ def main() -> None:
 
     ##### read the genes file #####
     if config["file_regions"] is None:
-        warnings.warn(
+        print(
             "No gene list file was provided! All genes from fasta file are used to generate the probes. This choice can use a lot of resources."
         )
         gene_ids = None
@@ -840,6 +831,12 @@ def main() -> None:
         write_intermediate_steps=config["write_intermediate_steps"],
         dir_output=config["dir_output"],
         n_jobs=config["n_jobs"],
+    )
+
+    # setup logger
+    configure_root_logger(
+        dir_output=pipeline.dir_output,
+        pipeline_name="hcr_probe_designer",
     )
 
     ##### design probes #####
@@ -907,7 +904,7 @@ def main() -> None:
         initiator_table=initiator_table,
     )
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -2,10 +2,8 @@
 # imports
 ############################################
 
-import logging
 import os
 import shutil
-import warnings
 from itertools import combinations
 from pathlib import Path
 
@@ -64,10 +62,9 @@ from oligo_designer_toolsuite.pipelines._utils import (
     format_sequence,
     pipeline_step_basic,
     preprocess_tm_parameters,
-    setup_logging,
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
-from oligo_designer_toolsuite.utils import append_nucleotide_to_sequences
+from oligo_designer_toolsuite.utils import append_nucleotide_to_sequences, configure_root_logger, logger
 
 ############################################
 # Merfish Probe Designer
@@ -180,13 +177,6 @@ class MerfishProbeDesigner:
         # create the output folder
         self.dir_output = os.path.abspath(dir_output)
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
-
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="Merfish_probe_designer",
-            log_start_message=True,
-        )
 
         self.write_intermediate_steps = write_intermediate_steps
         self.n_jobs = n_jobs
@@ -387,7 +377,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 1 (Create Database) in directory {dir_database}"
             )
 
@@ -407,7 +397,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 2 (Property Filters) in directory {dir_database}"
             )
 
@@ -422,7 +412,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 3 (Specificity Filters) in directory {dir_database}"
             )
 
@@ -453,7 +443,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 4 (Specificity Filters) in directory {dir_database}."
             )
 
@@ -623,7 +613,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_readout_probes_initial")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 1 (Create Database) in directory {dir_database}"
             )
 
@@ -636,7 +626,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_readout_probes_property_filter")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 2 (Property Filters) in directory {dir_database}"
             )
 
@@ -651,7 +641,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_readout_probes_specificty_filter")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 3 (Specificity Filters) in directory {dir_database}"
             )
 
@@ -667,7 +657,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_readout_probes_set_selection")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 4 (Set Selection) in directory {dir_database}"
             )
 
@@ -941,7 +931,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_primers_initial")
-            logging.info(f"Saved primer database for step 1 (Create Database) in directory {dir_database}")
+            logger.info(f"Saved primer database for step 1 (Create Database) in directory {dir_database}")
 
         oligo_database = primer_designer.filter_by_property(
             oligo_database=oligo_database,
@@ -964,7 +954,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_primer_property_filter")
-            logging.info(f"Saved primer database for step 2 (Property Filters) in directory {dir_database}")
+            logger.info(f"Saved primer database for step 2 (Property Filters) in directory {dir_database}")
 
         oligo_database = primer_designer.filter_by_specificity(
             oligo_database=oligo_database,
@@ -978,9 +968,7 @@ class MerfishProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_primer_specificty_filter")
-            logging.info(
-                f"Saved primer database for step 3 (Specificity Filters) in directory {dir_database}"
-            )
+            logger.info(f"Saved primer database for step 3 (Specificity Filters) in directory {dir_database}")
 
         # calculate Tm for the reverse primer
         Tm_reverse_primer = calc_tm_nn(
@@ -2657,7 +2645,7 @@ def main() -> None:
     Command-line arguments are parsed using `base_parser()`, which expects:
     - `config`: Path to the YAML configuration file containing all pipeline parameters
     """
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
 
     args = base_parser()
 
@@ -2667,7 +2655,7 @@ def main() -> None:
 
     ##### read the genes file #####
     if config["file_regions"] is None:
-        warnings.warn(
+        print(
             "No gene list file was provided! All genes from fasta file are used to generate the probes. This chioce can use a lot of resources."
         )
         region_ids = None
@@ -2682,6 +2670,12 @@ def main() -> None:
         write_intermediate_steps=config["write_intermediate_steps"],
         dir_output=config["dir_output"],
         n_jobs=config["n_jobs"],
+    )
+
+    # setup logger
+    configure_root_logger(
+        dir_output=pipeline.dir_output,
+        pipeline_name="Merfish_probe_designer",
     )
 
     ##### design probes #####
@@ -2830,7 +2824,7 @@ def main() -> None:
         readout_probe_table=readout_probe_table,
     )
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -2,10 +2,8 @@
 # imports
 ############################################
 
-import logging
 import os
 import shutil
-import warnings
 from pathlib import Path
 from typing import Any
 
@@ -64,9 +62,9 @@ from oligo_designer_toolsuite.pipelines._utils import (
     get_highly_abundant_kmer_sequences,
     pipeline_step_basic,
     preprocess_tm_parameters,
-    setup_logging,
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
+from oligo_designer_toolsuite.utils import configure_root_logger, logger
 
 ############################################
 # Oligo-Seq Probe Designer
@@ -117,13 +115,6 @@ class OligoSeqProbeDesigner:
         # create the output folder
         self.dir_output = os.path.abspath(dir_output)
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
-
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="oligoseq_probe_designer",
-            log_start_message=True,
-        )
 
         ##### set class parameters #####
         self.write_intermediate_steps = write_intermediate_steps
@@ -209,7 +200,7 @@ class OligoSeqProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_probes_initial")
-            logging.info(f"Saved probe database for step 1 (Create Database) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 1 (Create Database) in directory {dir_database}")
 
         # Add highly abundant k-mers to prohibited sequences
         if property_filters_parameters["prohibited_sequences_filter"]["enabled"]:
@@ -245,7 +236,7 @@ class OligoSeqProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_probes_property_filter")
-            logging.info(f"Saved probe database for step 2 (Property Filters) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 2 (Property Filters) in directory {dir_database}")
 
         oligo_database = target_probe_designer.filter_by_specificity(
             oligo_database=oligo_database,
@@ -259,7 +250,7 @@ class OligoSeqProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_probes_specificity_filter")
-            logging.info(f"Saved probe database for step 3 (Specificity Filters) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 3 (Specificity Filters) in directory {dir_database}")
 
         oligo_database = target_probe_designer.create_oligo_sets(
             oligo_database=oligo_database,
@@ -299,7 +290,7 @@ class OligoSeqProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_probes_probesets")
-            logging.info(f"Saved probe database for step 4 (Specificity Filters) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 4 (Specificity Filters) in directory {dir_database}")
 
         return oligo_database
 
@@ -1068,7 +1059,7 @@ def _preprocess_config(config_validated: OligoSeqProbeDesignerConfig) -> dict[st
     ##### read the genes file #####
     file_region_ids = config["target_probe"]["oligo_generation"]["file_region_ids"]
     if file_region_ids is None:
-        warnings.warn(
+        logger.warning(
             "No gene list file was provided! All genes from fasta file are used to generate the probes. This choice can use a lot of resources."
         )
         config["target_probe"]["oligo_generation"]["region_ids"] = None
@@ -1138,7 +1129,7 @@ def main() -> None:
     Command-line arguments are parsed using `base_parser()`, which expects:
     - `config`: Path to the YAML configuration file containing all pipeline parameters
     """
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
 
     args = base_parser()
 
@@ -1149,12 +1140,18 @@ def main() -> None:
     try:
         config_validated = OligoSeqProbeDesignerConfig.model_validate(config_raw)
     except ValidationError as e:
-        logging.error("Invalid configuration file:\n%s", e)
+        print("Invalid configuration file:\n%s", e)
         raise
+
+    # setup logger
+    configure_root_logger(
+        dir_output=config_validated.general.dir_output,
+        pipeline_name="oligoseq_probe_designer",
+    )
 
     oligo_seq_probe_designer(config_validated)
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -3,11 +3,9 @@
 ############################################
 
 import itertools
-import logging
 import os
 import random
 import shutil
-import warnings
 from pathlib import Path
 
 import yaml
@@ -61,9 +59,9 @@ from oligo_designer_toolsuite.pipelines._utils import (
     check_content_oligo_database,
     pipeline_step_basic,
     preprocess_tm_parameters,
-    setup_logging,
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
+from oligo_designer_toolsuite.utils import configure_root_logger, logger
 
 ############################################
 # SCRINSHOT Probe Designer
@@ -135,13 +133,6 @@ class ScrinshotProbeDesigner:
         # create the output folder
         self.dir_output = os.path.abspath(dir_output)
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
-
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="scrinshot_probe_designer",
-            log_start_message=True,
-        )
 
         ##### set class parameters #####
         self.write_intermediate_steps = write_intermediate_steps
@@ -365,7 +356,7 @@ class ScrinshotProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_probes_initial")
-            logging.info(f"Saved probe database for step 1 (Create Database) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 1 (Create Database) in directory {dir_database}")
 
         oligo_database = target_probe_designer.filter_by_property(
             oligo_database=oligo_database,
@@ -388,7 +379,7 @@ class ScrinshotProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_probes_property_filter")
-            logging.info(f"Saved probe database for step 2 (Property Filters) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 2 (Property Filters) in directory {dir_database}")
 
         oligo_database = target_probe_designer.filter_by_specificity(
             oligo_database=oligo_database,
@@ -409,7 +400,7 @@ class ScrinshotProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_probes_specificity_filter")
-            logging.info(f"Saved probe database for step 3 (Specificity Filters) in directory {dir_database}")
+            logger.info(f"Saved probe database for step 3 (Specificity Filters) in directory {dir_database}")
 
         oligo_database = target_probe_designer.create_oligo_sets(
             oligo_database=oligo_database,
@@ -455,9 +446,7 @@ class ScrinshotProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_probes_probesets")
-            logging.info(
-                f"Saved probe database for step 4 (Specificity Filters) in directory {dir_database}."
-            )
+            logger.info(f"Saved probe database for step 4 (Specificity Filters) in directory {dir_database}.")
 
         return oligo_database
 
@@ -1924,7 +1913,7 @@ def main() -> None:
     Command-line arguments are parsed using `base_parser()`, which expects:
     - `config`: Path to the YAML configuration file containing all pipeline parameters
     """
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
 
     args = base_parser()
 
@@ -1934,7 +1923,7 @@ def main() -> None:
 
     ##### read the genes file #####
     if config["file_regions"] is None:
-        warnings.warn(
+        print(
             "No gene list file was provided! All genes from fasta file are used to generate the probes. This chioce can use a lot of resources."
         )
         region_ids = None
@@ -1952,6 +1941,12 @@ def main() -> None:
         write_intermediate_steps=config["write_intermediate_steps"],
         dir_output=config["dir_output"],
         n_jobs=config["n_jobs"],
+    )
+
+    # setup logger
+    configure_root_logger(
+        dir_output=pipeline.dir_output,
+        pipeline_name="scrinshot_probe_designer",
     )
 
     ##### design probes #####
@@ -2031,7 +2026,7 @@ def main() -> None:
 
     pipeline.generate_output(probe_database=probe_database)
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -2,10 +2,8 @@
 # imports
 ############################################
 
-import logging
 import os
 import shutil
-import warnings
 from itertools import product
 from pathlib import Path
 
@@ -57,10 +55,9 @@ from oligo_designer_toolsuite.pipelines._utils import (
     format_sequence,
     pipeline_step_basic,
     preprocess_tm_parameters,
-    setup_logging,
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
-from oligo_designer_toolsuite.utils import append_nucleotide_to_sequences
+from oligo_designer_toolsuite.utils import append_nucleotide_to_sequences, configure_root_logger, logger
 
 ############################################
 # SeqFISH Plus Probe Designer
@@ -170,13 +167,6 @@ class SeqFishPlusProbeDesigner:
         # create the output folder
         self.dir_output = os.path.abspath(dir_output)
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
-
-        # setup logger
-        setup_logging(
-            dir_output=self.dir_output,
-            pipeline_name="seqfishplus_probe_designer",
-            log_start_message=True,
-        )
 
         ##### set class parameters #####
         self.write_intermediate_steps = write_intermediate_steps
@@ -342,7 +332,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_target_probes_initial")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 1 (Create Database) in directory {dir_database}"
             )
 
@@ -357,7 +347,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_target_probes_property_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 2 (Property Filters) in directory {dir_database}"
             )
 
@@ -372,7 +362,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_target_probes_specificity_filter")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 3 (Specificity Filters) in directory {dir_database}"
             )
 
@@ -396,7 +386,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="4_db_target_probes_sets")
-            logging.info(
+            logger.info(
                 f"Saved target probe database for step 4 (Specificity Filters) in directory {dir_database}."
             )
 
@@ -521,7 +511,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_readout_probes_initial")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 1 (Create Database) in directory {dir_database}"
             )
 
@@ -534,7 +524,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_readout_probes_property_filter")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 2 (Property Filters) in directory {dir_database}"
             )
 
@@ -549,7 +539,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_readout_probes_specificty_filter")
-            logging.info(
+            logger.info(
                 f"Saved readout probe database for step 3 (Specificity Filters) in directory {dir_database}"
             )
 
@@ -835,7 +825,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="1_db_primers_initial")
-            logging.info(f"Saved primer database for step 1 (Create Database) in directory {dir_database}")
+            logger.info(f"Saved primer database for step 1 (Create Database) in directory {dir_database}")
 
         oligo_database = primer_designer.filter_by_property(
             oligo_database=oligo_database,
@@ -858,7 +848,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_primer_property_filter")
-            logging.info(f"Saved primer database for step 2 (Property Filters) in directory {dir_database}")
+            logger.info(f"Saved primer database for step 2 (Property Filters) in directory {dir_database}")
 
         oligo_database = primer_designer.filter_by_specificity(
             oligo_database=oligo_database,
@@ -872,9 +862,7 @@ class SeqFishPlusProbeDesigner:
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="3_db_primer_specificty_filter")
-            logging.info(
-                f"Saved primer database for step 3 (Specificity Filters) in directory {dir_database}"
-            )
+            logger.info(f"Saved primer database for step 3 (Specificity Filters) in directory {dir_database}")
 
         # calculate Tm for the reverse primer
         Tm_reverse_primer = calc_tm_nn(
@@ -2401,7 +2389,7 @@ def main() -> None:
     Command-line arguments are parsed using `base_parser()`, which expects:
     - `config`: Path to the YAML configuration file containing all pipeline parameters
     """
-    logging.info("--------------START PIPELINE--------------")
+    print("--------------START PIPELINE--------------")
 
     args = base_parser()
 
@@ -2411,7 +2399,7 @@ def main() -> None:
 
     ##### read the genes file #####
     if config["file_regions"] is None:
-        warnings.warn(
+        print(
             "No gene list file was provided! All genes from fasta file are used to generate the probes. This chioce can use a lot of resources."
         )
         region_ids = None
@@ -2426,6 +2414,12 @@ def main() -> None:
         write_intermediate_steps=config["write_intermediate_steps"],
         dir_output=config["dir_output"],
         n_jobs=config["n_jobs"],
+    )
+
+    # setup logger
+    configure_root_logger(
+        dir_output=pipeline.dir_output,
+        pipeline_name="seqfishplus_probe_designer",
     )
 
     ##### design probes #####
@@ -2559,7 +2553,7 @@ def main() -> None:
         readout_probe_table=readout_probe_table,
     )
 
-    logging.info("--------------END PIPELINE--------------")
+    print("--------------END PIPELINE--------------")
 
 
 if __name__ == "__main__":

--- a/oligo_designer_toolsuite/pipelines/_utils.py
+++ b/oligo_designer_toolsuite/pipelines/_utils.py
@@ -3,69 +3,20 @@
 ############################################
 
 import inspect
-import logging
-import os
 import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from datetime import datetime
 from typing import Any, Callable, TypeVar, cast
 
 from Bio.SeqUtils import MeltingTemp as mt
 
 from oligo_designer_toolsuite.database import OligoDatabase
-from oligo_designer_toolsuite.utils import count_kmer_abundance
+from oligo_designer_toolsuite.utils import count_kmer_abundance, logger
 
 F = TypeVar("F", bound=Callable[..., Any])
 
 ############################################
 # Utils functions
 ############################################
-
-
-def setup_logging(
-    dir_output: str,
-    pipeline_name: str,
-    log_level: int = logging.NOTSET,
-    include_console: bool = False,
-    log_start_message: bool = False,
-) -> None:
-    """
-    Set up logging configuration for a pipeline.
-
-    This function creates a consistent logging setup across all pipelines, creating a log file
-    in the output directory and optionally writing to the console.
-
-    :param dir_output: Directory path where output files will be saved.
-    :type dir_output: str
-    :param pipeline_name: Name of the pipeline (used in log file name).
-    :type pipeline_name: str
-    :param log_level: Logging level (default: logging.NOTSET).
-    :type log_level: int
-    :param include_console: Whether to also log to console (default: False).
-    :type include_console: bool
-    :param log_start_message: Whether to log a "START PIPELINE" message (default: False).
-    :type log_start_message: bool
-    """
-    timestamp = datetime.now()
-    file_logger = os.path.join(
-        dir_output,
-        f"log_{pipeline_name}_{timestamp.year}-{timestamp.month}-{timestamp.day}-{timestamp.hour}-{timestamp.minute}.txt",
-    )
-
-    handlers: list[logging.Handler] = [logging.FileHandler(file_logger)]
-    if include_console:
-        handlers.append(logging.StreamHandler())
-
-    logging.basicConfig(
-        format="%(asctime)s [%(levelname)s] %(message)s",
-        level=log_level,
-        handlers=handlers,
-        force=True,  # Force reconfiguration if logging was already configured
-    )
-    logging.captureWarnings(True)
-
-    if log_start_message:
-        logging.info("--------------START PIPELINE--------------")
 
 
 def base_parser() -> dict[str, Any]:
@@ -96,7 +47,7 @@ def base_log_parameters(parameters: dict[str, Any]) -> None:
     """
     for key, value in parameters.items():
         if key != "self":
-            logging.info("Parameter: %s = %s", key, value)
+            logger.info("Parameter: %s = %s", key, value)
 
 
 def log_parameters_and_get_db(func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
@@ -116,10 +67,10 @@ def log_parameters_and_get_db(func: Callable[..., Any], args: tuple[Any, ...], k
     bound_args = sig.bind(*args, **kwargs)
     bound_args.apply_defaults()
 
-    logging.info("Function: %s", func.__name__)
+    logger.info("Function: %s", func.__name__)
     for name, value in bound_args.arguments.items():
         if name != "self":
-            logging.info("Parameter: %s = %s", name, value)
+            logger.info("Parameter: %s = %s", name, value)
 
     return bound_args.arguments.get("oligo_database")
 
@@ -179,13 +130,13 @@ def pipeline_step_basic(step_name: str) -> Callable[[F], F]:
 
     def decorator(function: F) -> F:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            logging.info(f"Parameters {step_name}:")
+            logger.info(f"Parameters {step_name}:")
             log_parameters_and_get_db(function, args, kwargs)
 
             oligo_database = function(*args, **kwargs)
 
             num_genes, num_oligos = get_oligo_database_info(oligo_database.database)
-            logging.info(
+            logger.info(
                 f"Step - {step_name}: database contains {num_oligos} oligos from {num_genes} regions."
             )
 
@@ -208,7 +159,7 @@ def pipeline_step_advanced(step_name: str) -> Callable[[F], F]:
 
     def decorator(function: F) -> F:
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            logging.info(f"Parameters {step_name}:")
+            logger.info(f"Parameters {step_name}:")
             oligo_database = log_parameters_and_get_db(function, args, kwargs)
 
             num_genes_before, num_oligos_before = get_oligo_database_info(oligo_database.database)
@@ -216,7 +167,7 @@ def pipeline_step_advanced(step_name: str) -> Callable[[F], F]:
             oligo_database, *returned_values = function(*args, **kwargs)
 
             num_genes_after, num_oligos_after = get_oligo_database_info(oligo_database.database)
-            logging.info(
+            logger.info(
                 f"Step - {step_name}: database contains {num_oligos_after} oligos from {num_genes_after} regions, "
                 f"{num_oligos_before - num_oligos_after} oligos and {num_genes_before - num_genes_after} regions removed."
             )
@@ -237,7 +188,7 @@ def check_content_oligo_database(oligo_database: OligoDatabase) -> None:
     :raises SystemExit: If the database is empty, exits with status code 1.
     """
     if len(oligo_database.get_regionid_list()) == 0:
-        logging.error("The oligo database is empty. Exiting program...")
+        logger.error("The oligo database is empty. Exiting program...")
         print("The oligo database is empty. Exiting program...")
         sys.exit(1)  # Exit the program with a status code of 1
 
@@ -321,7 +272,7 @@ def get_highly_abundant_kmer_sequences(
     for k, v in kmer_abundance.items():
         for kmer, abundance in v.items():
             if abundance > kmer_abundance_threshold[k]:
-                logging.info(
+                logger.info(
                     f"K-mer {kmer} has abundance {abundance} which is greater than the threshold {kmer_abundance_threshold[k]}"
                 )
                 highly_abundant_kmer_sequences.append(kmer)

--- a/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
+++ b/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
@@ -4,11 +4,9 @@
 
 import gzip
 import itertools
-import logging
 import os
 import re
 import shutil
-import warnings
 from ftplib import FTP, error_perm
 from pathlib import Path
 from typing import IO, get_args
@@ -18,6 +16,7 @@ from Bio import SeqIO
 
 from oligo_designer_toolsuite._constants import _TYPES_FILE, _TYPES_FILE_SEQ
 from oligo_designer_toolsuite._exceptions import ConfigurationError
+from oligo_designer_toolsuite.utils import logger
 
 ############################################
 # FTP Classes
@@ -581,7 +580,7 @@ class FtpLoaderNCBI(BaseFtpLoader):
                         break
             os.remove(file_readme)
         except FileNotFoundError:
-            warnings.warn("No annotation name information available from NCBI.")
+            logger.warning("No annotation name information available from NCBI.")
 
     def _resolve_assembly_directory(self, ftp_directory: str) -> str:
         assembly_dir = f"{ftp_directory}{self.assembly_accession}_{self.assembly_name}"
@@ -714,6 +713,6 @@ class FtpLoaderNCBI(BaseFtpLoader):
                     )
                     SeqIO.write(chromosome_sequnece, handle, "fasta")
                 else:
-                    logging.warning("No mapping for accession number: {}".format(accession_number))
+                    logger.warning("No mapping for accession number: {}".format(accession_number))
 
         os.replace(file_tmp, ftp_file)

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -5,7 +5,6 @@
 import copy
 import os
 import random
-import warnings
 from typing import Callable, Iterable
 
 import numpy as np
@@ -25,9 +24,12 @@ from oligo_designer_toolsuite._constants import (
 )
 from oligo_designer_toolsuite._exceptions import ConfigurationError
 from oligo_designer_toolsuite.sequence_generator import FtpLoaderEnsembl, FtpLoaderNCBI
-from oligo_designer_toolsuite.utils import GffParser
-
-from ..utils._sequence_processor import get_complement_regions, get_sequence_from_annotation
+from oligo_designer_toolsuite.utils import (
+    GffParser,
+    get_complement_regions,
+    get_sequence_from_annotation,
+    logger,
+)
 
 ############################################
 # Genomic Region Generator Classes
@@ -81,19 +83,19 @@ class CustomGenomicRegionGenerator:
         """Constructor for the CustomGenomicRegionGenerator class."""
         if files_source is None:
             files_source = "custom"
-            warnings.warn(f"No source defined. Using default source {files_source}!")
+            logger.warning(f"No source defined. Using default source {files_source}!")
 
         if species is None:
             species = "unknown"
-            warnings.warn(f"No species defined. Using default species {species}!")
+            logger.warning(f"No species defined. Using default species {species}!")
 
         if annotation_release is None:
             annotation_release = "unknown"
-            warnings.warn(f"No annotation release defined. Using default release {annotation_release}!")
+            logger.warning(f"No annotation release defined. Using default release {annotation_release}!")
 
         if genome_assembly is None:
             genome_assembly = "unknown"
-            warnings.warn(f"No genome assembly defined. Using default genome assembly {genome_assembly}!")
+            logger.warning(f"No genome assembly defined. Using default genome assembly {genome_assembly}!")
 
         self.dir_output = os.path.join(dir_output, "annotation")
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)
@@ -1215,7 +1217,7 @@ class CustomGenomicRegionGenerator:
             if not set(gene_ids).issubset(set(number_total_transcripts_df["gene_id"])):
                 raise ConfigurationError
         except ConfigurationError:
-            warnings.warn("Could not calculate the number of total transcripts.")
+            logger.warning("Could not calculate the number of total transcripts.")
             number_total_transcripts_df = None
         finally:
             return number_total_transcripts_df
@@ -1296,11 +1298,13 @@ class NcbiGenomicRegionGenerator(CustomGenomicRegionGenerator):
 
             if annotation_release is None:
                 annotation_release = "current"
-                warnings.warn(f"No annotation release defined. Using default release {annotation_release}!")
+                logger.warning(f"No annotation release defined. Using default release {annotation_release}!")
 
             if assembly_source is None:
                 assembly_source = "auto"
-                warnings.warn(f"No assembly source defined. Using default assembly source {assembly_source}!")
+                logger.warning(
+                    f"No assembly source defined. Using default assembly source {assembly_source}!"
+                )
         elif mode == "assembly":
             if assembly_source is None:
                 assembly_source = "auto"
@@ -1357,11 +1361,11 @@ class EnsemblGenomicRegionGenerator(CustomGenomicRegionGenerator):
         files_source = "Ensemble"
         if species is None:
             species = "homo_sapiens"
-            warnings.warn(f"No species defined. Using default species {species}!")
+            logger.warning(f"No species defined. Using default species {species}!")
 
         if annotation_release is None:
             annotation_release = "current"
-            warnings.warn(f"No annotation release defined. Using default release {annotation_release}!")
+            logger.warning(f"No annotation release defined. Using default release {annotation_release}!")
 
         self.dir_output = os.path.join(dir_output, "annotation")
         Path(self.dir_output).mkdir(parents=True, exist_ok=True)

--- a/oligo_designer_toolsuite/sequence_generator/_oligo_sequence_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_oligo_sequence_generator.py
@@ -4,13 +4,12 @@
 
 import os
 import random
-import warnings
 from pathlib import Path
 
 from Bio.SeqRecord import SeqRecord
 from joblib import Parallel, delayed
 
-from oligo_designer_toolsuite.utils import FastaParser
+from oligo_designer_toolsuite.utils import FastaParser, logger
 
 from .._constants import SEPARATOR_FASTA_HEADER_FIELDS, SEPARATOR_FASTA_HEADER_FIELDS_LIST
 from ..utils._checkers_and_helpers import cast_to_list, generate_unique_filename, safe_append_filename
@@ -166,12 +165,12 @@ class OligoSequenceGenerator:
             :rtype: str
             """
             if entry.seq is None:
-                warnings.warn(f"Skipping sequence {entry.seq}: SeqRecord entry has no sequence.", UserWarning)
+                logger.warning(f"Skipping sequence {entry.seq}: SeqRecord entry has no sequence.")
                 return None
 
             # Check if entry.id is None and skip with warning
             if entry.id is None:
-                warnings.warn(f"Skipping sequence {entry.seq}: SeqRecord entry has no header.", UserWarning)
+                logger.warning(f"Skipping sequence {entry.seq}: SeqRecord entry has no header.")
                 return None
 
             entry_sequence = entry.seq
@@ -316,7 +315,7 @@ class OligoSequenceGenerator:
         # Therefore, the final output files are checked
         for one_file in list(file_fasta_out):
             if os.path.getsize(one_file) == 0:
-                warnings.warn(
+                logger.warning(
                     f"No oligos were created for region {os.path.basename(one_file).replace('.fna','')}. "
                     "This can happen if the input sequences are shorter than the specified minimum oligo length."
                 )

--- a/oligo_designer_toolsuite/utils/__init__.py
+++ b/oligo_designer_toolsuite/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-This module provides utilities for processing databases, parsing sequences and checking different file or object formats.
+This module provides utilities for processing databases, parsing sequences, checking different file or object formats and logging.
 """
 
 from ._checkers_and_helpers import (
@@ -21,6 +21,7 @@ from ._database_processor import (
     format_oligo_properties,
     merge_databases,
 )
+from ._logging import configure_root_logger, logger
 from ._sequence_parser import FastaParser, GffParser, VCFParser
 from ._sequence_processor import (
     append_nucleotide_to_sequences,
@@ -56,4 +57,6 @@ __all__ = [
     "append_nucleotide_to_sequences",
     "remove_index_files",
     "count_kmer_abundance",
+    "logger",
+    "configure_root_logger",
 ]

--- a/oligo_designer_toolsuite/utils/_database_processor.py
+++ b/oligo_designer_toolsuite/utils/_database_processor.py
@@ -2,12 +2,12 @@
 # imports
 ############################################
 
-import warnings
 from typing import Any
 
 from effidict import EffiDict, LRUReplacement, PickleBackend
 
 from oligo_designer_toolsuite._constants import SEPARATOR_OLIGO_ID
+from oligo_designer_toolsuite.utils._logging import logger
 
 from ._checkers_and_helpers import cast_to_list, cast_to_list_of_lists
 
@@ -168,7 +168,7 @@ def collapse_properties_for_duplicated_sequences(
                 oligo_properties[key] = values
             else:
                 if key in database_sequence_types and oligo_properties[key] != values:
-                    warnings.warn(
+                    logger.warning(
                         f"Values for key {key} are different in the two oligo_properties dictionaries."
                     )
                 elif key not in database_sequence_types:
@@ -198,7 +198,7 @@ def check_if_region_in_database(
     keys = list(database.keys())
     for region_id in region_ids:
         if region_id not in keys:
-            warnings.warn(f"Region {region_id} not available in reference file.")
+            logger.warning(f"Region {region_id} not available in reference file.")
             if write_regions_with_insufficient_oligos:
                 with open(file_removed_regions, "a") as hanlde:
                     hanlde.write(f"{region_id}\t{'Not in Annotation'}\n")

--- a/oligo_designer_toolsuite/utils/_logging.py
+++ b/oligo_designer_toolsuite/utils/_logging.py
@@ -1,0 +1,54 @@
+############################################
+# imports
+############################################
+
+import logging
+import os
+from datetime import datetime
+
+############################################
+# Logging utils
+############################################
+
+# Library-wide logger
+logger = logging.getLogger("oligo_designer_toolsuite")
+
+
+def configure_root_logger(
+    dir_output: str,
+    pipeline_name: str,
+    log_level: int = logging.NOTSET,
+    include_console: bool = False,
+) -> None:
+    """
+    Set up logging configuration for a pipeline.
+
+    This function creates a consistent logging setup across all pipelines, creating a log file
+    in the output directory and optionally writing to the console.
+
+    :param dir_output: Directory path where output files will be saved.
+    :type dir_output: str
+    :param pipeline_name: Name of the pipeline (used in log file name).
+    :type pipeline_name: str
+    :param log_level: Logging level (default: logging.NOTSET).
+    :type log_level: int
+    :param include_console: Whether to also log to console (default: False).
+    :type include_console: bool
+    :param log_start_message: Whether to log a "START PIPELINE" message (default: False).
+    :type log_start_message: bool
+    """
+    timestamp = datetime.now()
+    file_logger = os.path.join(
+        dir_output,
+        f"log_{pipeline_name}_{timestamp.year}-{timestamp.month}-{timestamp.day}-{timestamp.hour}-{timestamp.minute}.txt",
+    )
+
+    handlers: list[logging.Handler] = [logging.FileHandler(file_logger)]
+    if include_console:
+        handlers.append(logging.StreamHandler())
+
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        level=log_level,
+        handlers=handlers,
+    )

--- a/oligo_designer_toolsuite/utils/_logging.py
+++ b/oligo_designer_toolsuite/utils/_logging.py
@@ -2,6 +2,7 @@
 # imports
 ############################################
 
+from pathlib import Path
 import logging
 import os
 from datetime import datetime
@@ -38,6 +39,11 @@ def configure_root_logger(
     :type log_start_message: bool
     """
     timestamp = datetime.now()
+
+    # ensure output directory exists
+    dir_output = os.path.abspath(dir_output)
+    Path(dir_output).mkdir(parents=True, exist_ok=True)
+
     file_logger = os.path.join(
         dir_output,
         f"log_{pipeline_name}_{timestamp.year}-{timestamp.month}-{timestamp.day}-{timestamp.hour}-{timestamp.minute}.txt",

--- a/tests/test_oligo_property_filter.py
+++ b/tests/test_oligo_property_filter.py
@@ -412,7 +412,7 @@ class TestPropertyFilter(unittest.TestCase):
         property_filter = PropertyFilter(filters=self.filters)
 
         seq_keep = Seq("TGTCGGATCTCTTCAACAAGCTGGTCATGA")
-        res = property_filter._filter_sequence(seq_keep)
+        res = property_filter._filter_sequence(str(seq_keep))
         assert res == True, f"error: A sequence ({seq_keep}) fulfilling all conditions has not been accepted!"
 
     def test_property_filter_on_database(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ from oligo_designer_toolsuite.utils import (
     flatten_property_list,
     format_oligo_properties,
     generate_unique_filename,
+    logger,
     merge_databases,
     remove_index_files,
 )
@@ -277,12 +278,12 @@ class TestDatabaseProcessor(unittest.TestCase):
         dict1 = {"oligo": "ATCGATCGATCG", "chromosome": [["10"]], "start": [[1000]]}
         dict2 = {"oligo": "GCTAGCTAGCTA", "chromosome": [["10"]], "start": [[1000]]}
 
-        with self.assertWarns(UserWarning) as warning_context:
+        with self.assertLogs(logger, level="WARNING") as log:
             collapse_properties_for_duplicated_sequences(dict1, dict2, database_sequence_types=["oligo"])
 
         self.assertIn(
-            "oligo",
-            str(warning_context.warning),
+            "key oligo",
+            "".join(log.output),
             "error: warning should mention the key with different values",
         )
 


### PR DESCRIPTION
### Summary

This PR adds a logger (named `"oligo_designer_toolsuite"`) such that ODT's pipelines don't log to the root logger anymore. It replaces all usages of `logging.warning` and `warnings.warn` with the respective `logger.warning` (same for info, error etc.). Library users can now decide

Changes:

- add library-wide logger in new `utils/_logging.py`
- rename `setup_logging()` to `configure_root_logger()` and move it to the new logging utils file
- replace usage of `logging.info` with `logger.info` (same for warning, error etc.)
- replace usage of `warnings.warn` with `logger.warning`
  - adjust one affected test to check for the log instead of the warning
- move calls to `configure_root_logger()` to `main()` functions in pipelines
  - This ensures that the logging config is only overwritten if ODT is called via CLI, not when someone uses it as a library.
- remove `force=True` from `configure_root_logger()` to avoid hijacking the root logger
- remove `logging.captureWarnings(True)` from `configure_root_logger()` since warnings are now logged directly
- remove the "START PIPELINE" line from the log in `configure_root_logger()` since it was duplicated in the `main()` functions
- replace all logging in `main()` functions with regular `print()` since logging may not be configured yet and the `main()` functions are typically called via CLI

### Context

In ODT Cloud, our logs cut off the moment ODT is called since it forces reconfiguration of the root logger and redirects even our logs to its log file. Before the Pydantic changes, the pipelines were not meant to be called from within Python so this was fine, but now library users should be able to use ODT from their own program without it redirecting its logs.

A short write-up on the issue is provided here: [Please don't hijack my Python root logger](https://rednafi.com/python/no-hijack-root-logger/)
I implemented their suggestions in this PR.

With this PR, all code except for the `main()` functions is considered library code using the library's logger. The `main()` functions however are treated like users of the library and are thus allowed to configure the root logger. This means that calling ODT via CLI will create the log file and redirect all logs to it, but calling ODT from within Python directs all logs to the logger called `"oligo_designer_toolsuite"` and allows the user of the library to decide how to process the logs. In the case of ODT Cloud, we could easily extract them and maybe provide more context to the user in the future.

### Alternatives

Just removing the `force=True` from `setup_logging()` and avoiding all logging calls before that function is called would likely be enough to mostly resolve the issue. But this PR implements a modern logging approach that is the convention for libraries and recommended in [Python's documentation](https://docs.python.org/3/howto/logging.html#logging-basic-tutorial).

Thank you for taking a look at this!