### PR TITLE
196 config for scrinshot pipeline

### DIFF
--- a/data/configs/scrinshot_probe_designer.yaml
+++ b/data/configs/scrinshot_probe_designer.yaml
@@ -64,7 +64,7 @@ target_probe:
       ligation_region_size: 5 # Size of the seed region around the ligation site for BLAST seed region filter; set to 0 to skip seed-region filtering.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
       hit_parameters: {"coverage": 50} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Shared between the BLASTN specificity filter and the cross-hybridization filter. Use genomic_region_generator for custom reference sets.
+      files_fasta_reference_database: # FASTA file(s) used as reference for the specificity BLASTN search. Use genomic_region_generator for custom reference sets.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 

--- a/data/configs/scrinshot_probe_designer.yaml
+++ b/data/configs/scrinshot_probe_designer.yaml
@@ -1,139 +1,153 @@
+#########################
+### HIDDEN PARAMETERS ###
+#########################
+
+schema_version: 2
+
+general:
+  n_jobs: 4 # number of cores used to run the pipeline and 2*n_jobs +1 of regions that should be stored in cache. If memory consumption of pipeline is too high reduce this number, if a lot of RAM is available increase this number to decrease runtime
+  dir_output: output_scrinshot_probe_designer # name of the directory where the output files will be written
+  write_intermediate_steps: true # if true, saves intermediate results after each step
+
 #######################
 ### USER PARAMETERS ###
 #######################
 
-### General parameters
-### -----------------------------------------------
-n_jobs: 4 # number of cores used to run the pipeline and 2*n_jobs +1 of regions that should be stored in cache. If memory consumption of pipeline is too high reduce this number, if a lot of RAM is available increase this number to decrease runtime
-dir_output: output_scrinshot_probe_designer # name of the directory where the output files will be written
-write_intermediate_steps: true # if true, writes the oligo sequences after each step of the pipeline into a csv file
+target_probe:
+  oligo_generation:
+    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+    probe_length_min: 40 # Minimum allowed oligo length (bases).
+    probe_length_max: 45 # Maximum allowed oligo length (bases).
 
-### Target Probe Parameters
-### -----------------------------------------------
-file_regions: data/genes/custom_3.txt # file with a list the genes used to generate the oligos sequences, leave empty if all the genes are used
-files_fasta_target_probe_database: # fasta file with sequences form which the probes should be generated. Hint: use the genomic_region_generator pipeline to create fasta files of genomic regions of interest
-  - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-  - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-files_fasta_reference_database_target_probe: # fasta file with sequences used as reference for the specificity filters. Hint: use the genomic_region_generator pipeline to create fasta files of genomic regions of interest
-  - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-  - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-target_probe_length_min: 40 #min length of probe
-target_probe_length_max: 45 #max length of probe
-target_probe_isoform_consensus: 50 #min isoform consesnsus for probes, i.e. how many transcripts of the total number of transcripts of a gene are covered by the probe, given in %
-target_probe_GC_content_min: 40 # minimum GC content of oligos
-target_probe_GC_content_opt: 50 # max and min values are defiend above
-target_probe_GC_content_max: 60 # maximum GC content of oligos
-target_probe_Tm_min: 65 # minimum GC content of oligos
-target_probe_Tm_opt: 70 # max and min values are defiend above
-target_probe_Tm_max: 75 # maximum GC content of oligos
-target_probe_homopolymeric_base_n: # minimum number of nucleotides to consider it a homopolymeric run per base
-  A: 5
-  T: 5
-  C: 5
-  G: 5
-target_probe_padlock_arm_Tm_dif_max: 2 # maximum melting temperature difference of both arms (difference shouldn't be higher than 5! But range is not super important, the lower the better)
-target_probe_padlock_arm_length_min: 10 # minimum length of each arm
-target_probe_padlock_arm_Tm_min: 50 # minimum melting temperature of each arm
-target_probe_padlock_arm_Tm_max: 60 # maximum melting temperature of each arm
-target_probe_ligation_region_size: 5 # size of the seed region around the ligation site for blast seed region filter; set to 0 if ligation region should not be considered for blast search
-n_sets: 3 # number of sets to generate
-set_size_min: 3 # minimum size of probe sets (in case there exist no set of the optimal size) -> genes with less oligos will be filtered out and stored in regions_with_insufficient_oligos_for_db_probes
-set_size_opt: 5 # optimal size of probe sets
-distance_between_target_probes: 0 # how much overlap should be allowed between oligos, e.g. if oligos can overlpap x bases choose -x, if oligos can be next to one another choose 0, if oligos should be x bases apart choose x
-target_probe_isoform_weight: 2 # weight of the isoform consensus of the probe in the efficiency score
-target_probe_GC_weight: 1 # weight of the GC content of the probe in the efficiency score
-target_probe_Tm_weight: 1 # weight of the Tm of the probe in the efficiency score
+  padlock_arms_properties:
+    padlock_arm_length_min: 10 # Minimum length (bases) for each padlock arm.
+    padlock_arm_Tm_dif_max: 2 # Maximum Tm difference (°C) between the two padlock arms.
+    padlock_arm_Tm_min: 50 # Minimum melting temperature (°C) for each padlock arm.
+    padlock_arm_Tm_max: 60 # Maximum melting temperature (°C) for each padlock arm.
 
-### Detection Oligo Parameters
-### -----------------------------------------------
-detection_oligo_min_thymines: 2 # minimal number of Thymines in detection oligo.
-detection_oligo_length_min: 15 # minimum length of detection probe
-detection_oligo_length_max: 40 # maximum length of detection probe
-detection_oligo_U_distance: 5 # preferred minimal distance between U(racils)
-detection_oligo_Tm_opt: 56 # optimal melting temperature of detection probe
+  property_filters:
+    isoform_consensus_filter: # Require oligos to be supported by a minimum fraction of gene transcripts.
+      enabled: true # Turn this filter on or off.
+      isoform_consensus: 50 # Minimum isoform consensus (%). Oligos must be covered by at least this fraction of a gene's transcripts.
 
+    hard_masked_sequences_filter: # Exclude oligos overlapping hard-masked (e.g. N) regions in the reference.
+      enabled: true # Turn this filter on or off.
 
-############################
-### DEVELOPER PARAMETERS ###
-############################
+    soft_masked_sequences_filter: # Exclude oligos overlapping soft-masked (lowercase) regions in the reference.
+      enabled: true # Turn this filter on or off.
 
-### Target Probe Parameters
-### -----------------------------------------------
-# Specificity filter with BlastN
-target_probe_specificity_blastn_search_parameters:
-  -perc_identity: 80
-  -strand: "minus" # this parameter is fixed, if reference is whole genome, consider using "both"
-  -word_size: 10
-  -dust: "no"
-  -soft_masking: "false"
-  -max_target_seqs: 10
-  -max_hsps: 1000
-target_probe_specificity_blastn_hit_parameters:
-  coverage: 50 # can be turned into min_alignment_length
-# Crosshybridization filter with BlastN
-target_probe_cross_hybridization_blastn_search_parameters:
-  -perc_identity: 80
-  -strand: "minus" # this parameter is fixed
-  -word_size: 10
-  -dust: "no"
-  -soft_masking: "false"
-  -max_target_seqs: 10
-target_probe_cross_hybridization_blastn_hit_parameters:
-  coverage: 80 # can be turned into min_alignment_length
-# Parameters for the Oligo set selection
-n_attempts_graph: 20 # number of randomized graph attempts (diversification)
-n_attempts_clique_enum: 70 # max cliques enumerated per graph attempt
-diversification_fraction: 0.1 # fraction of oligos to remove from the graph to create diversity in the set selection
-jaccard_opt: 0.5 # optimal maximum Jaccard overlap between selected sets
-jaccard_step: 0.1 # step size for the Jaccard overlap if not enough sets are found
-# Parameters for Melting Temperature
-# The melting temperature is used in 2 different stages (property filters and padlock detection probe design), where a few parameters are shared and the others differ.
-# parameters for melting temperature -> for more information on parameters, see: https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-target_probe_Tm_parameters:
-    nn_table: DNA_NN3 # Allawi & SantaLucia (1997)
-    tmm_table: DNA_TMM1 #default
-    imm_table: DNA_IMM1 #default
-    de_table: DNA_DE1 #default
-    dnac1: 50 #[nM]
-    dnac2: 0 #[nM]
-    saltcorr: 7 # Owczarzy et al. (2008)
-    Na: 39 #[mM]
-    K: 75 #[mM]
-    Tris: 20 #[mM]
-    Mg: 10 #[mM]
-    dNTPs: 0 #[mM] default
-target_probe_Tm_chem_correction_parameters: # if chem correction desired, please add parameters below
-    DMSO: 0 #default
-    DMSOfactor: 0.75 #default
-    fmd: 20
-    fmdfactor: 0.65 #default
-    fmdmethod: 1 #default
-    GC: null #default
-target_probe_Tm_salt_correction_parameters: null # if salt correction desired, please add parameters below
+    homopolymeric_runs_filter: # Exclude oligos containing long homopolymeric runs (e.g. AAAAAA).
+      enabled: true # Turn this filter on or off.
+      homopolymeric_base_n: {"A": 5, "T": 5, "C": 5, "G": 5} # Minimum run length per base to count as homopolymeric. Oligos with longer runs are rejected.
 
-### Detection Oligo Parameters
-### -----------------------------------------------
-# Parameters for Melting Temperature
-# The melting temperature is used in 2 different stages (property filters and padlock detection probe design), where a few parameters are shared and the others differ.
-# parameters for melting temperature -> for more information on parameters, see: https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-detection_oligo_Tm_parameters:
-    nn_table: DNA_NN3 # Allawi & SantaLucia (1997)
-    tmm_table: DNA_TMM1 #default
-    imm_table: DNA_IMM1 #default
-    de_table: DNA_DE1 #default
-    dnac1: 50 #[nM]
-    dnac2: 0 #[nM]
-    saltcorr: 7 # Owczarzy et al. (2008)
-    Na: 39 #[mM]
-    K: 0 #[mM] default
-    Tris: 0 #[mM] default
-    Mg: 0 #[mM] default
-    dNTPs: 0 #[mM] default
-detection_oligo_Tm_chem_correction_parameters: # if chem correction desired, please add parameters below
-    DMSO: 0 #default
-    DMSOfactor: 0.75 #default
-    fmd: 30
-    fmdfactor: 0.65 #default
-    fmdmethod: 1 #default
-    GC: null #default
-detection_oligo_Tm_salt_correction_parameters: null # if salt correction desired, please add parameters below
+    GC_content_filter: # Enforce GC content within a specified range.
+      enabled: true # Turn this filter on or off.
+      GC_content_min: 40 # Minimum GC content (%). Oligos below this are rejected.
+      GC_content_max: 60 # Maximum GC content (%). Oligos above this are rejected.
+
+    Tm_filter: # Enforce melting temperature (Tm) within a range (uses Tm parameters below).
+      enabled: true # Turn this filter on or off.
+      Tm_min: 65 # Minimum melting temperature (°C). Oligos below this are rejected.
+      Tm_max: 75 # Maximum melting temperature (°C). Oligos above this are rejected.
+
+  specificity_filters:
+    cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to off-target sequences (BLAST-based).
+      enabled: true # Turn this filter on or off.
+      search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
+      hit_parameters: {"coverage": 80} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+
+    specificity_blastn_filter: # Ensure oligo specificity against a reference database (BLAST-based).
+      enabled: true # Turn this filter on or off.
+      ligation_region_size: 5 # Size of the seed region around the ligation site for BLAST seed region filter; set to 0 to skip seed-region filtering.
+      search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
+      hit_parameters: {"coverage": 50} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Shared between the BLASTN specificity filter and the cross-hybridization filter. Use genomic_region_generator for custom reference sets.
+      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+  probe_set_selection: # Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification).
+    independent_set_selection:
+      n_sets: 3 # Number of probe sets to generate per gene.
+      set_size_min: 3 # Minimum set size. Genes that cannot form a set of at least this size are reported as insufficient.
+      set_size_opt: 5 # Preferred (optimal) number of oligos per set.
+      distance_between_probes: 0 # Required spacing: negative = allow overlap (bases), 0 = adjacent OK, positive = minimum gap (bases).
+      n_attempts_graph: 20 # Number of randomized graph attempts used to diversify set selection.
+      n_attempts_clique_enum: 70 # Maximum cliques enumerated per graph attempt.
+      diversification_fraction: 0.1 # Fraction of oligos removed from the graph in each attempt to increase set diversity.
+      jaccard_opt: 0.5 # Target maximum Jaccard similarity between selected sets; lower = more distinct sets.
+      jaccard_step: 0.1 # Step size for relaxing Jaccard threshold when too few sets are found.
+    isoform_consensus_score:
+      weight: 2 # Weight for isoform coverage in the set-selection scoring function.
+    GC_content_score:
+      weight: 1 # Weight for GC content in the set-selection scoring function.
+      GC_content_min: 40 # Minimum GC content (%). Used to normalize the GC score around the optimum.
+      GC_content_opt: 50 # Target (optimal) GC content (%) for scoring.
+      GC_content_max: 60 # Maximum GC content (%). Used to normalize the GC score around the optimum.
+    Tm_score:
+      weight: 1 # Weight for Tm in the set-selection scoring function.
+      Tm_min: 65 # Minimum Tm (°C). Used to normalize the Tm score around the optimum.
+      Tm_opt: 70 # Target (optimal) Tm (°C) for scoring.
+      Tm_max: 75 # Maximum Tm (°C). Used to normalize the Tm score around the optimum.
+
+  global_parameters:
+    Tm_parameters:
+      nn_table: DNA_NN3 # Allawi & SantaLucia (1997)
+      tmm_table: DNA_TMM1 #default
+      imm_table: DNA_IMM1 #default
+      de_table: DNA_DE1 #default
+      dnac1: 50 #[nM]
+      dnac2: 0 #[nM]
+      saltcorr: 7 # Owczarzy et al. (2008)
+      Na: 39 #[mM]
+      K: 75 #[mM]
+      Tris: 20 #[mM]
+      Mg: 10 #[mM]
+      dNTPs: 0 #[mM] default
+    Tm_chem_correction_parameters:
+      enabled: true
+      parameters:
+        DMSO: 0
+        DMSOfactor: 0.75
+        fmd: 20
+        fmdfactor: 0.65
+        fmdmethod: 1
+        GC: null
+    Tm_salt_correction_parameters:
+      enabled: false
+
+detection_oligo:
+  oligo_generation:
+    min_thymines: 2 # Minimal number of thymines (T) in the detection oligo (required for UNG cleavage after U-substitution).
+    oligo_length_min: 15 # Minimum length (bases) of the detection oligo.
+    oligo_length_max: 40 # Maximum length (bases) of the detection oligo.
+    U_distance: 5 # Preferred minimum distance (bases) between consecutive uracils.
+    Tm_opt: 56 # Target (optimal) melting temperature (°C) for the detection oligo.
+
+  global_parameters:
+    Tm_parameters:
+      nn_table: DNA_NN3 # Allawi & SantaLucia (1997)
+      tmm_table: DNA_TMM1 #default
+      imm_table: DNA_IMM1 #default
+      de_table: DNA_DE1 #default
+      dnac1: 50 #[nM]
+      dnac2: 0 #[nM]
+      saltcorr: 7 # Owczarzy et al. (2008)
+      Na: 39 #[mM]
+      K: 0 #[mM] default
+      Tris: 0 #[mM] default
+      Mg: 0 #[mM] default
+      dNTPs: 0 #[mM] default
+    Tm_chem_correction_parameters:
+      enabled: true
+      parameters:
+        DMSO: 0
+        DMSOfactor: 0.75
+        fmd: 30
+        fmdfactor: 0.65
+        fmdmethod: 1
+        GC: null
+    Tm_salt_correction_parameters:
+      enabled: false

--- a/data/configs/scrinshot_probe_designer.yaml
+++ b/data/configs/scrinshot_probe_designer.yaml
@@ -54,7 +54,7 @@ target_probe:
       Tm_max: 75 # Maximum melting temperature (°C). Oligos above this are rejected.
 
   specificity_filters:
-    cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to off-target sequences (BLAST-based).
+    cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize with each other (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
       hit_parameters: {"coverage": 80} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.

--- a/oligo_designer_toolsuite/pipelines/__init__.py
+++ b/oligo_designer_toolsuite/pipelines/__init__.py
@@ -7,7 +7,7 @@ from ._genomic_region_generator import GenomicRegionGenerator
 from ._hcr_probe_designer import HcrProbeDesigner
 from ._merfish_probe_designer import MerfishProbeDesigner
 from ._oligo_seq_probe_designer import OligoSeqProbeDesigner, oligo_seq_probe_designer
-from ._scrinshot_probe_designer import ScrinshotProbeDesigner
+from ._scrinshot_probe_designer import ScrinshotProbeDesigner, scrinshot_probe_designer
 from ._seqfish_plus_probe_designer import SeqFishPlusProbeDesigner
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     "OligoSeqProbeDesigner",
     "oligo_seq_probe_designer",
     "ScrinshotProbeDesigner",
+    "scrinshot_probe_designer",
     "SeqFishPlusProbeDesigner",
     "MerfishProbeDesigner",
     "CycleHCRProbeDesigner",

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -730,17 +730,13 @@ class TargetProbeDesigner:
         :type homopolymeric_runs_filter: dict
         :param GC_content_filter: Dict with ``enabled``, ``GC_content_min``, ``GC_content_max``.
         :type GC_content_filter: dict
-        :param Tm_filter: Dict with ``enabled``, ``Tm_min``, ``Tm_max``. Thermodynamic model
-            parameters come from ``global_parameters``.
+        :param Tm_filter: Dict with ``enabled``, ``Tm_min``, ``Tm_max``, plus thermodynamic model parameters
+            (``Tm_parameters``, ``Tm_chem_correction_parameters``, ``Tm_salt_correction_parameters``) injected during
+            config preprocessing.
         :type Tm_filter: dict
-        :param padlock_arm_filter: Dict with ``enabled``, ``arm_length_min``, ``arm_Tm_dif_max``,
-            ``arm_Tm_min``, ``arm_Tm_max``. The padlock-arm filter also enforces the detection-oligo
-            length/thymine constraints (via the composite ``DetectionOligoFilter``).
-        :type padlock_arm_filter: dict
-        :param detection_oligo_parameters: ``detection_oligo.oligo_generation`` block. Provides
-            ``oligo_length_min``, ``oligo_length_max``, and ``min_thymines`` to the padlock-arm / detection-oligo
-            composite filter.
-        :type detection_oligo_parameters: dict
+        :param detection_oligo_filter: Dict with detection-oligo and padlock-arm constraints required by the
+            composite ``DetectionOligoFilter``.
+        :type detection_oligo_filter: dict
         :return: A filtered `OligoDatabase` object containing only probes that pass all enabled property
             filters. Regions with insufficient oligos after filtering are removed.
         :rtype: OligoDatabase

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -183,10 +183,9 @@ class ScrinshotProbeDesigner:
             ``independent_set_selection`` scalars and the ``isoform_consensus_score`` / ``GC_content_score`` /
             ``Tm_score`` sub-dicts.
         :type probe_set_selection_parameters: dict
-        :param detection_oligo_parameters: ``detection_oligo.oligo_generation`` block. Consumed by the
-            padlock-arm / detection-oligo composite property filter (which requires the detection-oligo
-            length bounds and minimum thymines).
-        :type detection_oligo_parameters: dict
+        :param padlock_arms_parameters: ``target_probe.padlock_arms_properties`` block. Used to compute padlock-arm
+            sequences/Tm (via ``PadlockArmsProperty``) for downstream filtering and backbone assembly.
+        :type padlock_arms_parameters: dict
         :return: An `OligoDatabase` object containing the designed target probes organized into sets.
             The database includes probe sequences, properties, and set assignments for each target gene.
         :rtype: OligoDatabase

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -829,10 +829,9 @@ class TargetProbeDesigner:
         Filter the oligo database based on sequence specificity to remove probes that bind
         non-specifically or cross-hybridize.
 
-        Before applying the alignment-based filters, the method computes the ``PadlockArmsProperty``
-        for every probe (always on) — this is required by the seed-region BLASTN filter when
-        ``ligation_region_size > 0`` and by :py:meth:`ScrinshotProbeDesigner.assemble_padlock_backbone`
-        downstream.
+        This method assumes ``PadlockArmsProperty`` has already been computed for the ``oligo`` sequence
+        (e.g. in :meth:`ScrinshotProbeDesigner.design_target_probes`) so seed-region BLASTN filtering can
+        use ``ligation_site`` and downstream padlock assembly can reuse the arm sequences.
 
         The filter list is seeded with an :class:`ExactMatchFilter` (always on) and then conditionally
         extended with the BLASTN-specificity and cross-hybridization filters depending on their

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -7,6 +7,7 @@ import os
 import random
 import shutil
 from pathlib import Path
+from typing import Any
 
 import yaml
 from joblib import Parallel, delayed
@@ -34,6 +35,7 @@ from oligo_designer_toolsuite.oligo_property_calculator._property_functions impo
     calc_tm_nn,
 )
 from oligo_designer_toolsuite.oligo_property_filter import (
+    BasePropertyFilter,
     DetectionOligoFilter,
     GCContentFilter,
     HardMaskedSequenceFilter,
@@ -45,6 +47,7 @@ from oligo_designer_toolsuite.oligo_property_filter import (
 from oligo_designer_toolsuite.oligo_selection import IndependentSetsOligoSelection
 from oligo_designer_toolsuite.oligo_specificity_filter import (
     AlignmentSpecificityFilter,
+    BaseSpecificityFilter,
     BlastNFilter,
     BlastNSeedregionSiteFilter,
     CrossHybridizationFilter,
@@ -140,50 +143,11 @@ class ScrinshotProbeDesigner:
 
     def design_target_probes(
         self,
-        # Step 1: Create Database Parameters
-        region_ids: list | None,
-        files_fasta_target_probe_database: list,
-        target_probe_length_min: int,
-        target_probe_length_max: int,
-        target_probe_isoform_consensus: float,
-        # Step 2: Property Filter Parameters
-        target_probe_GC_content_min: int,
-        target_probe_GC_content_max: int,
-        target_probe_Tm_min: int,
-        target_probe_Tm_max: int,
-        target_probe_homopolymeric_base_n: dict,
-        detection_oligo_min_thymines: int,
-        detection_oligo_length_min: int,
-        detection_oligo_length_max: int,
-        target_probe_padlock_arm_length_min: int,
-        target_probe_padlock_arm_Tm_dif_max: int,
-        target_probe_padlock_arm_Tm_min: int,
-        target_probe_padlock_arm_Tm_max: int,
-        target_probe_Tm_parameters: dict,
-        target_probe_Tm_chem_correction_parameters: dict | None,
-        target_probe_Tm_salt_correction_parameters: dict | None,
-        # Step 3: Specificity Filter Parameters
-        files_fasta_reference_database_target_probe: list,
-        target_probe_specificity_blastn_search_parameters: dict,
-        target_probe_specificity_blastn_hit_parameters: dict,
-        target_probe_cross_hybridization_blastn_search_parameters: dict,
-        target_probe_cross_hybridization_blastn_hit_parameters: dict,
-        target_probe_ligation_region_size: int,
-        # Step 4: Probe Scoring and Set Selection Parameters
-        target_probe_isoform_weight: float,
-        target_probe_GC_content_opt: int,
-        target_probe_GC_weight: float,
-        target_probe_Tm_opt: int,
-        target_probe_Tm_weight: float,
-        set_size_min: int,
-        set_size_opt: int,
-        distance_between_target_probes: int,
-        n_sets: int,
-        n_attempts_graph: int,
-        n_attempts_clique_enum: int,
-        diversification_fraction: float,
-        jaccard_opt: float,
-        jaccard_step: float,
+        oligo_generation_parameters: dict,
+        property_filters_parameters: dict,
+        specificity_filters_parameters: dict,
+        probe_set_selection_parameters: dict,
+        padlock_arms_parameters: dict,
     ) -> OligoDatabase:
         """
         Design target probes for SCRINSHOT experiments through a multi-step pipeline.
@@ -201,143 +165,28 @@ class ScrinshotProbeDesigner:
         transcripts. These probes will later be split into padlock arms and combined with a backbone
         sequence to create complete padlock probes.
 
-        **Step 1: Create Database Parameters**
-
-        :param region_ids: List of gene identifiers (e.g., gene IDs) to target for probe design. If None,
-            all genes present in the input FASTA files will be used.
-        :type region_ids: list[str] | None
-        :param files_fasta_target_probe_database: List of paths to FASTA files containing sequences
-            from which target probes will be generated. These files should contain genomic regions
-            of interest (e.g., exons, exon-exon junctions).
-        :type files_fasta_target_probe_database: list[str]
-        :param target_probe_length_min: Minimum length (in nucleotides) for target probe sequences.
-        :type target_probe_length_min: int
-        :param target_probe_length_max: Maximum length (in nucleotides) for target probe sequences.
-        :type target_probe_length_max: int
-        :param target_probe_isoform_consensus: Threshold for isoform consensus filtering (typically
-            between 0.0 and 1.0). Probes with isoform consensus values below this threshold will be
-            filtered out. This ensures that selected probes target sequences that are conserved across
-            multiple transcript isoforms.
-        :type target_probe_isoform_consensus: float
-
-        **Step 2: Property Filter Parameters**
-
-        :param target_probe_GC_content_min: Minimum acceptable GC content for target probes, expressed
-            as a fraction between 0.0 and 1.0.
-        :type target_probe_GC_content_min: int
-        :param target_probe_GC_content_max: Maximum acceptable GC content for target probes, expressed
-            as a fraction between 0.0 and 1.0.
-        :type target_probe_GC_content_max: int
-        :param target_probe_Tm_min: Minimum acceptable melting temperature (Tm) for target probes in
-            degrees Celsius.
-        :type target_probe_Tm_min: int
-        :param target_probe_Tm_max: Maximum acceptable melting temperature (Tm) for target probes in
-            degrees Celsius.
-        :type target_probe_Tm_max: int
-        :param target_probe_homopolymeric_base_n: Dictionary specifying the maximum allowed length of
-            homopolymeric runs for each nucleotide base (keys: 'A', 'T', 'G', 'C').
-        :type target_probe_homopolymeric_base_n: dict[str, int]
-        :param detection_oligo_min_thymines: Minimum number of thymine (T) nucleotides required in the
-            detection oligo region. These thymines will be converted to uracils (U) for UNG cleavage.
-        :type detection_oligo_min_thymines: int
-        :param detection_oligo_length_min: Minimum length (in nucleotides) for detection oligo sequences.
-        :type detection_oligo_length_min: int
-        :param detection_oligo_length_max: Maximum length (in nucleotides) for detection oligo sequences.
-        :type detection_oligo_length_max: int
-        :param target_probe_padlock_arm_length_min: Minimum length (in nucleotides) for each padlock
-            probe arm. Each arm must meet this requirement for the probe to pass filtering.
-        :type target_probe_padlock_arm_length_min: int
-        :param target_probe_padlock_arm_Tm_dif_max: Maximum allowed difference in melting temperature
-            (in degrees Celsius) between the two padlock arms. This ensures balanced binding of both arms.
-        :type target_probe_padlock_arm_Tm_dif_max: int
-        :param target_probe_padlock_arm_Tm_min: Minimum acceptable melting temperature (Tm) for padlock
-            arms in degrees Celsius.
-        :type target_probe_padlock_arm_Tm_min: int
-        :param target_probe_padlock_arm_Tm_max: Maximum acceptable melting temperature (Tm) for padlock
-            arms in degrees Celsius.
-        :type target_probe_padlock_arm_Tm_max: int
-        :param target_probe_Tm_parameters: Dictionary of parameters for calculating melting temperature (Tm) of target
-            probes using the nearest-neighbor method. For using Bio.SeqUtils.MeltingTemp default parameters, set to ``{}``.
-            Common parameters include: 'nn_table', 'tmm_table', 'imm_table', 'de_table', 'dnac1', 'dnac2', 'Na', 'K',
-            'Tris', 'Mg', 'dNTPs', 'saltcorr', etc. For more information on parameters, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-        :type target_probe_Tm_parameters: dict
-        :param target_probe_Tm_chem_correction_parameters: Dictionary of chemical correction parameters for Tm calculation.
-            These parameters account for the effects of chemical additives (e.g., DMSO, formamide) on melting temperature.
-            Set to ``None`` to disable chemical correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters.
-            For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.chem_correction
-        :type target_probe_Tm_chem_correction_parameters: dict | None
-        :param target_probe_Tm_salt_correction_parameters: Dictionary of salt correction parameters for Tm calculation.
-            These parameters account for the effects of salt concentration on melting temperature. Set to ``None`` to disable
-            salt correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters. For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.salt_correction
-        :type target_probe_Tm_salt_correction_parameters: dict | None
-
-        **Step 3: Specificity Filter Parameters**
-
-        :param files_fasta_reference_database_target_probe: List of paths to FASTA files containing
-            reference sequences used for specificity filtering. These files are used to identify
-            off-target binding sites (e.g., whole genome or transcriptome sequences).
-        :type files_fasta_reference_database_target_probe: list[str]
-        :param target_probe_specificity_blastn_search_parameters: Dictionary of parameters for BLASTN
-            searches used in specificity filtering.
-        :type target_probe_specificity_blastn_search_parameters: dict
-        :param target_probe_specificity_blastn_hit_parameters: Dictionary of parameters for filtering
-            BLASTN hits in specificity searches.
-        :type target_probe_specificity_blastn_hit_parameters: dict
-        :param target_probe_cross_hybridization_blastn_search_parameters: Dictionary of parameters for
-            BLASTN searches used in cross-hybridization filtering.
-        :type target_probe_cross_hybridization_blastn_search_parameters: dict
-        :param target_probe_cross_hybridization_blastn_hit_parameters: Dictionary of parameters for
-            filtering BLASTN hits in cross-hybridization searches.
-        :type target_probe_cross_hybridization_blastn_hit_parameters: dict
-        :param target_probe_ligation_region_size: Size of the ligation region (in nucleotides) around
-            the ligation site. This parameter is used for seed-based specificity filtering around the
-            junction region where padlock arms meet.
-        :type target_probe_ligation_region_size: int
-
-        **Step 4: Probe Scoring and Set Selection Parameters**
-
-        :param target_probe_isoform_weight: Weight assigned to isoform consensus in the scoring function.
-        :type target_probe_isoform_weight: float
-        :param target_probe_GC_content_opt: Optimal GC content for target probes, expressed as a fraction
-            between 0.0 and 1.0. Used in scoring to prioritize probes closer to this value.
-        :type target_probe_GC_content_opt: int
-        :param target_probe_GC_weight: Weight assigned to GC content in the scoring function.
-        :type target_probe_GC_weight: float
-        :param target_probe_Tm_opt: Optimal melting temperature (Tm) for target probes in degrees Celsius.
-            Used in scoring to prioritize probes closer to this value.
-        :type target_probe_Tm_opt: int
-        :param target_probe_Tm_weight: Weight assigned to melting temperature in the scoring function.
-        :type target_probe_Tm_weight: float
-        :param set_size_min: Minimum size (number of probes) required for each oligo set. Sets with fewer probes than
-            this value will be rejected, and regions that cannot generate sets meeting this minimum will be removed.
-        :type set_size_min: int
-        :param set_size_opt: Optimal size (number of probes) for each oligo set. The set selection algorithm will
-            attempt to generate sets of this size, but may produce sets with fewer probes if constraints cannot be met.
-        :type set_size_opt: int
-        :param distance_between_target_probes: Minimum genomic distance (in nucleotides) required between probes
-            within the same set. This spacing constraint prevents probes from binding too close together, which could
-            lead to reduced hybridization efficiency.
-        :type distance_between_target_probes: int
-        :param n_sets: Number of oligo sets to generate per region. Multiple sets allow for redundancy and selection
-            of the best-performing set based on scoring criteria.
-        :type n_sets: int
-        :param n_attempts_graph: Number of randomized graph attempts. In each attempt, a fraction of nodes is randomly
-            removed from the compatibility graph to create diversity; more attempts increase diversity at the cost of runtime.
-        :type n_attempts_graph: int
-        :param n_attempts_clique_enum: Maximum number of cliques enumerated per graph attempt. Limits how many cliques
-            are explored before stopping enumeration for the current graph.
-        :type n_attempts_clique_enum: int
-        :param diversification_fraction: Fraction of oligos to remove at random per attempt to create diversity
-            between sets.
-        :type diversification_fraction: float
-        :param jaccard_opt: Optimal maximum Jaccard overlap between selected sets. Sets with overlap above this
-            value are discouraged when selecting multiple sets per region.
-        :type jaccard_opt: float
-        :param jaccard_step: Step size for relaxing Jaccard overlap when not enough sets are found.
-        :type jaccard_step: float
+        :param oligo_generation_parameters: ``target_probe.oligo_generation`` block. Must contain
+            ``region_ids`` (populated from ``file_region_ids``), ``probe_length_min``, ``probe_length_max``,
+            and ``files_fasta_probe_database``.
+        :type oligo_generation_parameters: dict
+        :param property_filters_parameters: ``target_probe.property_filters`` block. Each filter sub-dict
+            (``isoform_consensus_filter``, ``hard_masked_sequences_filter``, ``soft_masked_sequences_filter``,
+            ``homopolymeric_runs_filter``, ``GC_content_filter``, ``Tm_filter``, ``padlock_arm_filter``)
+            carries an ``enabled`` flag plus its parameters.
+        :type property_filters_parameters: dict
+        :param specificity_filters_parameters: ``target_probe.specificity_filters`` block. Contains the
+            shared ``files_fasta_reference_database`` and ``ligation_region_size`` plus the
+            ``specificity_blastn_filter`` and ``cross_hybridization_blastn_filter`` sub-dicts, each with
+            ``enabled``, ``search_parameters``, and ``hit_parameters``.
+        :type specificity_filters_parameters: dict
+        :param probe_set_selection_parameters: ``target_probe.probe_set_selection`` block. Contains the
+            ``independent_set_selection`` scalars and the ``isoform_consensus_score`` / ``GC_content_score`` /
+            ``Tm_score`` sub-dicts.
+        :type probe_set_selection_parameters: dict
+        :param detection_oligo_parameters: ``detection_oligo.oligo_generation`` block. Consumed by the
+            padlock-arm / detection-oligo composite property filter (which requires the detection-oligo
+            length bounds and minimum thymines).
+        :type detection_oligo_parameters: dict
         :return: An `OligoDatabase` object containing the designed target probes organized into sets.
             The database includes probe sequences, properties, and set assignments for each target gene.
         :rtype: OligoDatabase
@@ -346,12 +195,11 @@ class ScrinshotProbeDesigner:
         target_probe_designer = TargetProbeDesigner(self.dir_output, self.n_jobs)
 
         oligo_database: OligoDatabase = target_probe_designer.create_oligo_database(
-            region_ids=region_ids,
-            oligo_length_min=target_probe_length_min,
-            oligo_length_max=target_probe_length_max,
-            files_fasta_oligo_database=files_fasta_target_probe_database,
-            min_oligos_per_gene=set_size_min,
-            isoform_consensus=target_probe_isoform_consensus,
+            region_ids=oligo_generation_parameters["region_ids"],
+            oligo_length_min=oligo_generation_parameters["probe_length_min"],
+            oligo_length_max=oligo_generation_parameters["probe_length_max"],
+            files_fasta_oligo_database=oligo_generation_parameters["files_fasta_probe_database"],
+            min_oligos_per_gene=probe_set_selection_parameters["independent_set_selection"]["set_size_min"],
         )
 
         if self.write_intermediate_steps:
@@ -360,42 +208,41 @@ class ScrinshotProbeDesigner:
 
         oligo_database = target_probe_designer.filter_by_property(
             oligo_database=oligo_database,
-            GC_content_min=target_probe_GC_content_min,
-            GC_content_max=target_probe_GC_content_max,
-            Tm_min=target_probe_Tm_min,
-            Tm_max=target_probe_Tm_max,
-            Tm_parameters=target_probe_Tm_parameters,
-            Tm_chem_correction_parameters=target_probe_Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=target_probe_Tm_salt_correction_parameters,
-            homopolymeric_base_n=target_probe_homopolymeric_base_n,
-            detect_oligo_length_min=detection_oligo_length_min,
-            detect_oligo_length_max=detection_oligo_length_max,
-            min_thymines=detection_oligo_min_thymines,
-            arm_length_min=target_probe_padlock_arm_length_min,
-            arm_Tm_dif_max=target_probe_padlock_arm_Tm_dif_max,
-            arm_Tm_min=target_probe_padlock_arm_Tm_min,
-            arm_Tm_max=target_probe_padlock_arm_Tm_max,
+            isoform_consensus_filter=property_filters_parameters["isoform_consensus_filter"],
+            hard_masked_sequences_filter=property_filters_parameters["hard_masked_sequences_filter"],
+            soft_masked_sequences_filter=property_filters_parameters["soft_masked_sequences_filter"],
+            homopolymeric_runs_filter=property_filters_parameters["homopolymeric_runs_filter"],
+            GC_content_filter=property_filters_parameters["GC_content_filter"],
+            Tm_filter=property_filters_parameters["Tm_filter"],
+            detection_oligo_filter=property_filters_parameters["detection_oligo_filter"],
         )
 
         if self.write_intermediate_steps:
             dir_database = oligo_database.save_database(name_database="2_db_probes_property_filter")
             logger.info(f"Saved probe database for step 2 (Property Filters) in directory {dir_database}")
 
+        ##### compute padlock arm properties #####
+        # Required by assemble_padlock_backbone and by the seed-region BLASTN filter when ligation_region_size > 0.
+        padlock_arms_property = PadlockArmsProperty(
+            arm_length_min=padlock_arms_parameters["padlock_arm_length_min"],
+            arm_Tm_dif_max=padlock_arms_parameters["padlock_arm_Tm_dif_max"],
+            arm_Tm_min=padlock_arms_parameters["padlock_arm_Tm_min"],
+            arm_Tm_max=padlock_arms_parameters["padlock_arm_Tm_max"],
+            Tm_parameters=padlock_arms_parameters["Tm_parameters"],
+            Tm_chem_correction_parameters=padlock_arms_parameters["Tm_chem_correction_parameters"],
+            Tm_salt_correction_parameters=padlock_arms_parameters["Tm_salt_correction_parameters"],
+        )
+        calculator = PropertyCalculator(properties=[padlock_arms_property])
+        oligo_database = calculator.apply(
+            oligo_database=oligo_database, sequence_type="oligo", n_jobs=self.n_jobs
+        )
+
         oligo_database = target_probe_designer.filter_by_specificity(
             oligo_database=oligo_database,
-            files_fasta_reference_database=files_fasta_reference_database_target_probe,
-            specificity_blastn_search_parameters=target_probe_specificity_blastn_search_parameters,
-            specificity_blastn_hit_parameters=target_probe_specificity_blastn_hit_parameters,
-            cross_hybridization_blastn_search_parameters=target_probe_cross_hybridization_blastn_search_parameters,
-            cross_hybridization_blastn_hit_parameters=target_probe_cross_hybridization_blastn_hit_parameters,
-            ligation_region_size=target_probe_ligation_region_size,
-            arm_length_min=target_probe_padlock_arm_length_min,
-            arm_Tm_dif_max=target_probe_padlock_arm_Tm_dif_max,
-            arm_Tm_min=target_probe_padlock_arm_Tm_min,
-            arm_Tm_max=target_probe_padlock_arm_Tm_max,
-            Tm_parameters=target_probe_Tm_parameters,
-            Tm_chem_correction_parameters=target_probe_Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=target_probe_Tm_salt_correction_parameters,
+            specificity_blastn_filter=specificity_filters_parameters["specificity_blastn_filter"],
+            cross_hybridization_blastn_filter=specificity_filters_parameters[
+                "cross_hybridization_blastn_filter"
+            ],
         )
 
         if self.write_intermediate_steps:
@@ -404,40 +251,32 @@ class ScrinshotProbeDesigner:
 
         oligo_database = target_probe_designer.create_oligo_sets(
             oligo_database=oligo_database,
-            isoform_weight=target_probe_isoform_weight,
-            GC_content_min=target_probe_GC_content_min,
-            GC_content_opt=target_probe_GC_content_opt,
-            GC_content_max=target_probe_GC_content_max,
-            GC_weight=target_probe_GC_weight,
-            Tm_min=target_probe_Tm_min,
-            Tm_opt=target_probe_Tm_opt,
-            Tm_max=target_probe_Tm_max,
-            Tm_weight=target_probe_Tm_weight,
-            Tm_parameters=target_probe_Tm_parameters,
-            Tm_chem_correction_parameters=target_probe_Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=target_probe_Tm_salt_correction_parameters,
-            set_size_opt=set_size_opt,
-            set_size_min=set_size_min,
-            distance_between_oligos=distance_between_target_probes,
-            n_sets=n_sets,
-            n_attempts_graph=n_attempts_graph,
-            n_attempts_clique_enum=n_attempts_clique_enum,
-            diversification_fraction=diversification_fraction,
-            jaccard_opt=jaccard_opt,
-            jaccard_step=jaccard_step,
+            independent_set_selection=probe_set_selection_parameters["independent_set_selection"],
+            isoform_consensus_score=probe_set_selection_parameters["isoform_consensus_score"],
+            GC_content_score=probe_set_selection_parameters["GC_content_score"],
+            Tm_score=probe_set_selection_parameters["Tm_score"],
         )
 
-        # Calculate oligo length, GC content, Tm, and isoform consensus
+        # Calculate oligo length, GC content, Tm, and isoform consensus on the selected oligos.
         length_property = LengthProperty()
         gc_content_property = GCContentProperty()
         TmNN_property = TmNNProperty(
-            Tm_parameters=target_probe_Tm_parameters,
-            Tm_chem_correction_parameters=target_probe_Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=target_probe_Tm_salt_correction_parameters,
+            Tm_parameters=property_filters_parameters["Tm_filter"]["Tm_parameters"],
+            Tm_chem_correction_parameters=property_filters_parameters["Tm_filter"][
+                "Tm_chem_correction_parameters"
+            ],
+            Tm_salt_correction_parameters=property_filters_parameters["Tm_filter"][
+                "Tm_salt_correction_parameters"
+            ],
         )
         isoform_consensus_property = IsoformConsensusProperty()
         calculator = PropertyCalculator(
-            properties=[length_property, gc_content_property, TmNN_property, isoform_consensus_property]
+            properties=[
+                length_property,
+                gc_content_property,
+                TmNN_property,
+                isoform_consensus_property,
+            ]
         )
 
         oligo_database = calculator.apply(
@@ -453,14 +292,7 @@ class ScrinshotProbeDesigner:
     def design_detection_oligos(
         self,
         oligo_database: OligoDatabase,
-        detection_oligo_length_min: int,
-        detection_oligo_length_max: int,
-        detection_oligo_min_thymines: int,
-        detection_oligo_U_distance: int,
-        detection_oligo_Tm_opt: float,
-        detection_oligo_Tm_parameters: dict,
-        detection_oligo_Tm_chem_correction_parameters: dict | None,
-        detection_oligo_Tm_salt_correction_parameters: dict | None,
+        oligo_generation_parameters: dict,
     ) -> OligoDatabase:
         """
         Design detection oligonucleotides for SCRINSHOT padlock probes.
@@ -480,36 +312,9 @@ class ScrinshotProbeDesigner:
             sequences and properties. This database should contain target probes organized by region IDs,
             with each region having one or more probe sets and ligation site information.
         :type oligo_database: OligoDatabase
-        :param detection_oligo_length_min: Minimum length (in nucleotides) for detection oligo sequences.
-        :type detection_oligo_length_min: int
-        :param detection_oligo_length_max: Maximum length (in nucleotides) for detection oligo sequences.
-        :type detection_oligo_length_max: int
-        :param detection_oligo_min_thymines: Minimum number of thymine (T) nucleotides required in the
-            detection oligo sequence. These thymines will be converted to uracils (U) for UNG cleavage.
-        :type detection_oligo_min_thymines: int
-        :param detection_oligo_U_distance: Maximum distance (in nucleotides) allowed between uracil
-            substitutions in the detection oligo. Uracils must be spaced ≤ this distance apart.
-        :type detection_oligo_U_distance: int
-        :param detection_oligo_Tm_opt: Optimal melting temperature (Tm) for detection oligos in degrees
-            Celsius. The algorithm will attempt to select detection oligos with Tm closest to this value.
-        :type detection_oligo_Tm_opt: float
-        :param detection_oligo_Tm_parameters: Dictionary of parameters for calculating melting temperature (Tm) of detection
-            oligos using the nearest-neighbor method. For using Bio.SeqUtils.MeltingTemp default parameters, set to ``{}``.
-            Common parameters include: 'nn_table', 'tmm_table', 'imm_table', 'de_table', 'dnac1', 'dnac2', 'Na', 'K',
-            'Tris', 'Mg', 'dNTPs', 'saltcorr', etc. For more information on parameters, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-        :type detection_oligo_Tm_parameters: dict
-        :param detection_oligo_Tm_chem_correction_parameters: Dictionary of chemical correction parameters for Tm calculation.
-            These parameters account for the effects of chemical additives (e.g., DMSO, formamide) on melting temperature.
-            Set to ``None`` to disable chemical correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters.
-            For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.chem_correction
-        :type detection_oligo_Tm_chem_correction_parameters: dict | None
-        :param detection_oligo_Tm_salt_correction_parameters: Dictionary of salt correction parameters for Tm calculation.
-            These parameters account for the effects of salt concentration on melting temperature. Set to ``None`` to disable
-            salt correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters. For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.salt_correction
-        :type detection_oligo_Tm_salt_correction_parameters: dict | None
+        :param oligo_generation_parameters: ``detection_oligo.oligo_generation`` block. Must contain
+            ``oligo_length_min``, ``oligo_length_max``, ``min_thymines``, ``U_distance``, and ``Tm_opt``.
+        :type oligo_generation_parameters: dict
         :return: An updated `OligoDatabase` object containing the designed detection oligos. The
             database includes the following new sequence properties for each probe:
             - `sequence_detection_oligo`: The detection oligo sequence with uracil substitutions
@@ -520,14 +325,14 @@ class ScrinshotProbeDesigner:
         detection_oligo_designer = DetectionOligoDesigner(self.n_jobs)
         oligo_database = detection_oligo_designer.create_detection_oligos(
             oligo_database=oligo_database,
-            oligo_length_min=detection_oligo_length_min,
-            oligo_length_max=detection_oligo_length_max,
-            min_thymines=detection_oligo_min_thymines,
-            U_distance=detection_oligo_U_distance,
-            Tm_opt=detection_oligo_Tm_opt,
-            Tm_parameters=detection_oligo_Tm_parameters,
-            Tm_chem_correction_parameters=detection_oligo_Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=detection_oligo_Tm_salt_correction_parameters,
+            oligo_length_min=oligo_generation_parameters["oligo_length_min"],
+            oligo_length_max=oligo_generation_parameters["oligo_length_max"],
+            min_thymines=oligo_generation_parameters["min_thymines"],
+            U_distance=oligo_generation_parameters["U_distance"],
+            Tm_opt=oligo_generation_parameters["Tm_opt"],
+            Tm_parameters=oligo_generation_parameters["Tm_parameters"],
+            Tm_chem_correction_parameters=oligo_generation_parameters["Tm_chem_correction_parameters"],
+            Tm_salt_correction_parameters=oligo_generation_parameters["Tm_salt_correction_parameters"],
         )
 
         return oligo_database
@@ -535,9 +340,7 @@ class ScrinshotProbeDesigner:
     def assemble_padlock_backbone(
         self,
         oligo_database: OligoDatabase,
-        target_probe_Tm_parameters: dict,
-        target_probe_Tm_chem_correction_parameters: dict | None,
-        target_probe_Tm_salt_correction_parameters: dict | None,
+        padlock_arms_parameters: dict,
     ) -> OligoDatabase:
         """
         Assemble padlock probes by combining target probe arms with a constant backbone sequence.
@@ -558,23 +361,6 @@ class ScrinshotProbeDesigner:
             sequences, ligation sites, and properties. This database should contain target probes
             organized by region IDs, with each region having one or more probe sets.
         :type oligo_database: OligoDatabase
-        :param target_probe_Tm_parameters: Dictionary of parameters for calculating melting temperature (Tm) of padlock
-            arms using the nearest-neighbor method. For using Bio.SeqUtils.MeltingTemp default parameters, set to ``{}``.
-            Common parameters include: 'nn_table', 'tmm_table', 'imm_table', 'de_table', 'dnac1', 'dnac2', 'Na', 'K',
-            'Tris', 'Mg', 'dNTPs', 'saltcorr', etc. For more information on parameters, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-        :type target_probe_Tm_parameters: dict
-        :param target_probe_Tm_chem_correction_parameters: Dictionary of chemical correction parameters for Tm calculation.
-            These parameters account for the effects of chemical additives (e.g., DMSO, formamide) on melting temperature.
-            Set to ``None`` to disable chemical correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters.
-            For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.chem_correction
-        :type target_probe_Tm_chem_correction_parameters: dict | None
-        :param target_probe_Tm_salt_correction_parameters: Dictionary of salt correction parameters for Tm calculation.
-            These parameters account for the effects of salt concentration on melting temperature. Set to ``None`` to disable
-            salt correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters. For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.salt_correction
-        :type target_probe_Tm_salt_correction_parameters: dict | None
         :return: An updated `OligoDatabase` object containing the assembled padlock probes. The
             database includes the following new sequence properties for each probe:
             - `barcode`: The unique barcode sequence assigned to this region
@@ -604,6 +390,10 @@ class ScrinshotProbeDesigner:
             return barcodes
 
         region_ids = list(oligo_database.database.keys())
+
+        Tm_parameters = padlock_arms_parameters["Tm_parameters"]
+        Tm_chem_correction_parameters = padlock_arms_parameters["Tm_chem_correction_parameters"]
+        Tm_salt_correction_parameters = padlock_arms_parameters["Tm_salt_correction_parameters"]
 
         barcodes = _get_barcode(len(region_ids), barcode_length=4, seed=0, choices=["A", "C", "T", "G"])
 
@@ -643,15 +433,15 @@ class ScrinshotProbeDesigner:
                     )
                     Tm_arm1 = calc_tm_nn(
                         sequence=sequence_padlock_arm1,
-                        Tm_parameters=target_probe_Tm_parameters,
-                        Tm_chem_correction_parameters=target_probe_Tm_chem_correction_parameters,
-                        Tm_salt_correction_parameters=target_probe_Tm_salt_correction_parameters,
+                        Tm_parameters=Tm_parameters,
+                        Tm_chem_correction_parameters=Tm_chem_correction_parameters,
+                        Tm_salt_correction_parameters=Tm_salt_correction_parameters,
                     )
                     Tm_arm2 = calc_tm_nn(
                         sequence=sequence_padlock_arm2,
-                        Tm_parameters=target_probe_Tm_parameters,
-                        Tm_chem_correction_parameters=target_probe_Tm_chem_correction_parameters,
-                        Tm_salt_correction_parameters=target_probe_Tm_salt_correction_parameters,
+                        Tm_parameters=Tm_parameters,
+                        Tm_chem_correction_parameters=Tm_chem_correction_parameters,
+                        Tm_salt_correction_parameters=Tm_salt_correction_parameters,
                     )
 
                     new_oligo_properties[oligo_id] = {
@@ -818,19 +608,16 @@ class TargetProbeDesigner:
         oligo_length_max: int,
         files_fasta_oligo_database: list[str],
         min_oligos_per_gene: int,
-        isoform_consensus: float,
     ) -> OligoDatabase:
         """
-        Create an initial oligo database by generating sequences using a sliding window approach
-        and performing pre-filtering based on isoform consensus.
+        Create an initial oligo database by generating sequences using a sliding window approach.
 
         This is the first step of target probe design. The method:
         1. Generates candidate oligo sequences from input FASTA files using a sliding window approach
            across the specified length range
         2. Creates an `OligoDatabase` and loads the generated sequences
-        3. Calculates reverse complement sequences and isoform consensus properties
-        4. Pre-filters oligos based on isoform consensus threshold
-        5. Removes regions with insufficient oligos after filtering
+        3. Calculates the reverse complement sequence (``oligo`` sequence type) — always on
+        4. Removes regions with insufficient oligos
 
         The database stores sequences with sequence types "target" (original sequence) and
         "oligo" (reverse complement). These sequences will later be split into padlock arms
@@ -850,13 +637,9 @@ class TargetProbeDesigner:
         :param min_oligos_per_gene: Minimum number of oligos required per region (gene) after filtering.
             Regions with fewer oligos than this threshold will be removed from the database.
         :type min_oligos_per_gene: int
-        :param isoform_consensus: Threshold for isoform consensus filtering (typically between 0.0 and 1.0).
-            Probes with isoform consensus values below this threshold will be filtered out. This ensures
-            that selected probes target sequences that are conserved across multiple transcript isoforms.
-        :type isoform_consensus: float
         :return: An `OligoDatabase` object containing the generated target probe sequences with their
-            component sequences (target, oligo) and calculated properties (isoform_consensus). The database
-            is filtered to only include regions that meet the minimum oligo requirement.
+            component sequences (target, oligo). The database is filtered to only include regions that
+            meet the minimum oligo requirement.
         :rtype: OligoDatabase
         """
 
@@ -886,27 +669,17 @@ class TargetProbeDesigner:
         )
         # Set all sequence types that will be used in this pipeline
         oligo_database.set_database_sequence_types(["target", "oligo"])
-        # Calculate reverse complement and isoform consensus
-        properties = [
-            ReverseComplementSequenceProperty(sequence_type_reverse_complement="oligo"),
-            IsoformConsensusProperty(),
-        ]
-        calculator = PropertyCalculator(properties=properties)
+        # Compute the reverse complement -> "oligo" sequence type (always on).
+        rc_sequence_property = ReverseComplementSequenceProperty(sequence_type_reverse_complement="oligo")
+        calculator = PropertyCalculator(properties=[rc_sequence_property])
         oligo_database = calculator.apply(
             oligo_database=oligo_database, sequence_type="target", n_jobs=self.n_jobs
-        )
-
-        ##### pre-filter oligo database for certain properties #####
-        oligo_database.filter_database_by_property_threshold(
-            property_name="isoform_consensus",
-            property_thr=isoform_consensus,
-            remove_if_smaller_threshold=True,
         )
 
         dir = oligo_sequences.dir_output
         shutil.rmtree(dir) if os.path.exists(dir) else None
 
-        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Pre-Filters")
+        oligo_database.remove_regions_with_insufficient_oligos(pipeline_step="Database Creation")
         check_content_oligo_database(oligo_database)
 
         return oligo_database
@@ -915,146 +688,132 @@ class TargetProbeDesigner:
     def filter_by_property(
         self,
         oligo_database: OligoDatabase,
-        GC_content_min: float,
-        GC_content_max: float,
-        Tm_min: float,
-        Tm_max: float,
-        Tm_parameters: dict,
-        Tm_chem_correction_parameters: dict | None,
-        Tm_salt_correction_parameters: dict | None,
-        homopolymeric_base_n: dict[str, int],
-        detect_oligo_length_min: int,
-        detect_oligo_length_max: int,
-        min_thymines: int,
-        arm_length_min: int,
-        arm_Tm_dif_max: int,
-        arm_Tm_min: float,
-        arm_Tm_max: float,
+        isoform_consensus_filter: dict,
+        hard_masked_sequences_filter: dict,
+        soft_masked_sequences_filter: dict,
+        homopolymeric_runs_filter: dict,
+        GC_content_filter: dict,
+        Tm_filter: dict,
+        detection_oligo_filter: dict,
     ) -> OligoDatabase:
         """
         Filter the oligo database based on sequence properties to remove probes with undesirable
         characteristics.
 
-        This method applies sequential filtering using multiple property-based filters:
-        1. **Hard masked sequences**: Removes probes containing hard-masked nucleotides (N)
-        2. **Soft masked sequences**: Removes probes containing soft-masked nucleotides (lowercase)
-        3. **Homopolymeric runs**: Removes probes with homopolymeric runs exceeding specified lengths
-        4. **GC content**: Removes probes with GC content outside the specified range
-        5. **Melting temperature**: Removes probes with Tm outside the specified range
-        6. **Detection oligo requirements**: Removes probes that cannot form valid detection oligos
-           centered on the ligation site with sufficient thymines for UNG cleavage
-        7. **Padlock arm requirements**: Removes probes that cannot be split into valid padlock arms
-           with balanced melting temperatures
+        This method applies sequential filtering using multiple property-based filters, each gated on
+        its own ``enabled`` flag:
 
-        Probes that fail any filter are removed. Regions with insufficient oligos after filtering
-        are removed from the database.
+        1. **Isoform consensus** (cheap pre-filter): computes ``IsoformConsensusProperty`` on the
+           ``target`` sequence and removes regions below the configured threshold.
+        2. **Hard masked sequences**: Removes probes containing hard-masked nucleotides (N)
+        3. **Soft masked sequences**: Removes probes containing soft-masked nucleotides (lowercase)
+        4. **Homopolymeric runs**: Removes probes with homopolymeric runs exceeding specified lengths
+        5. **GC content**: Removes probes with GC content outside the specified range
+        6. **Melting temperature**: Removes probes with Tm outside the specified range
+        7. **Padlock arm / detection oligo requirements**: Removes probes that cannot form valid padlock
+           arms with balanced melting temperatures, nor valid detection oligos centered on the ligation
+           site with sufficient thymines for UNG cleavage.
+
+        Probes that fail any enabled filter are removed. Regions with insufficient oligos after
+        filtering are removed from the database.
 
         :param oligo_database: The `OligoDatabase` instance containing oligonucleotide sequences
-            and their associated properties. This database should contain target probes with their
-            component sequences already calculated.
+            and their associated properties.
         :type oligo_database: OligoDatabase
-        :param GC_content_min: Minimum acceptable GC content for oligos, expressed as a fraction
-            between 0.0 and 1.0.
-        :type GC_content_min: float
-        :param GC_content_max: Maximum acceptable GC content for oligos, expressed as a fraction
-            between 0.0 and 1.0.
-        :type GC_content_max: float
-        :param Tm_min: Minimum acceptable melting temperature (Tm) for oligos in degrees Celsius.
-            Probes with calculated Tm below this value will be filtered out.
-        :type Tm_min: float
-        :param Tm_max: Maximum acceptable melting temperature (Tm) for oligos in degrees Celsius.
-            Probes with calculated Tm above this value will be filtered out.
-        :type Tm_max: float
-        :param Tm_parameters: Dictionary of parameters for calculating melting temperature (Tm) using
-            the nearest-neighbor method. For using Bio.SeqUtils.MeltingTemp default parameters, set to ``{}``.
-            Common parameters include: 'nn_table', 'tmm_table', 'imm_table', 'de_table', 'dnac1', 'dnac2', 'Na', 'K',
-            'Tris', 'Mg', 'dNTPs', 'saltcorr', etc. For more information on parameters, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-        :type Tm_parameters: dict
-        :param Tm_chem_correction_parameters: Dictionary of chemical correction parameters for Tm
-            calculation. These parameters account for the effects of chemical additives (e.g., DMSO,
-            formamide) on melting temperature. Set to ``None`` to disable chemical correction, or set to ``{}``
-            to use Bio.SeqUtils.MeltingTemp default parameters. For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.chem_correction
-        :type Tm_chem_correction_parameters: dict | None
-        :param Tm_salt_correction_parameters: Dictionary of salt correction parameters for Tm calculation.
-            These parameters account for the effects of salt concentration on melting temperature. Set to ``None``
-            to disable salt correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters.
-            For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.salt_correction
-        :type Tm_salt_correction_parameters: dict | None
-        :param homopolymeric_base_n: Dictionary specifying the maximum allowed length of homopolymeric
-            runs for each nucleotide base. Keys should be 'A', 'T', 'G', 'C' and values are the maximum
-            run length. For example: {'A': 3, 'T': 3, 'G': 3, 'C': 3} allows up to 3 consecutive
-            identical bases.
-        :type homopolymeric_base_n: dict[str, int]
-        :param detect_oligo_length_min: Minimum length (in nucleotides) for detection oligo sequences
-            that will be extracted from the probe, centered on the ligation site.
-        :type detect_oligo_length_min: int
-        :param detect_oligo_length_max: Maximum length (in nucleotides) for detection oligo sequences
-            that will be extracted from the probe, centered on the ligation site.
-        :type detect_oligo_length_max: int
-        :param min_thymines: Minimum number of thymine (T) nucleotides required in the detection oligo
-            region. These thymines will be converted to uracils (U) for UNG cleavage in sequential
-            hybridization cycles.
-        :type min_thymines: int
-        :param arm_length_min: Minimum length (in nucleotides) for each padlock probe arm. Each arm
-            must meet this requirement for the probe to pass filtering.
-        :type arm_length_min: int
-        :param arm_Tm_dif_max: Maximum allowed difference in melting temperature (in degrees Celsius)
-            between the two padlock arms. This ensures balanced binding of both arms for efficient
-            ligation.
-        :type arm_Tm_dif_max: int
-        :param arm_Tm_min: Minimum acceptable melting temperature (Tm) for padlock arms in degrees Celsius.
-        :type arm_Tm_min: float
-        :param arm_Tm_max: Maximum acceptable melting temperature (Tm) for padlock arms in degrees Celsius.
-        :type arm_Tm_max: float
-        :return: A filtered `OligoDatabase` object containing only probes that pass all property filters.
-            Regions with insufficient oligos after filtering are removed.
+        :param isoform_consensus_filter: Dict with ``enabled``, ``isoform_consensus``.
+        :type isoform_consensus_filter: dict
+        :param hard_masked_sequences_filter: Dict with ``enabled``.
+        :type hard_masked_sequences_filter: dict
+        :param soft_masked_sequences_filter: Dict with ``enabled``.
+        :type soft_masked_sequences_filter: dict
+        :param homopolymeric_runs_filter: Dict with ``enabled``, ``homopolymeric_base_n`` (mapping
+            ``A``/``T``/``C``/``G`` to maximum allowed run lengths).
+        :type homopolymeric_runs_filter: dict
+        :param GC_content_filter: Dict with ``enabled``, ``GC_content_min``, ``GC_content_max``.
+        :type GC_content_filter: dict
+        :param Tm_filter: Dict with ``enabled``, ``Tm_min``, ``Tm_max``. Thermodynamic model
+            parameters come from ``global_parameters``.
+        :type Tm_filter: dict
+        :param padlock_arm_filter: Dict with ``enabled``, ``arm_length_min``, ``arm_Tm_dif_max``,
+            ``arm_Tm_min``, ``arm_Tm_max``. The padlock-arm filter also enforces the detection-oligo
+            length/thymine constraints (via the composite ``DetectionOligoFilter``).
+        :type padlock_arm_filter: dict
+        :param detection_oligo_parameters: ``detection_oligo.oligo_generation`` block. Provides
+            ``oligo_length_min``, ``oligo_length_max``, and ``min_thymines`` to the padlock-arm / detection-oligo
+            composite filter.
+        :type detection_oligo_parameters: dict
+        :return: A filtered `OligoDatabase` object containing only probes that pass all enabled property
+            filters. Regions with insufficient oligos after filtering are removed.
         :rtype: OligoDatabase
         """
 
-        # define the filters
-        hard_masked_sequences = HardMaskedSequenceFilter()
-        soft_masked_sequences = SoftMaskedSequenceFilter()
-        gc_content = GCContentFilter(GC_content_min=GC_content_min, GC_content_max=GC_content_max)
-        melting_temperature = MeltingTemperatureNNFilter(
-            Tm_min=Tm_min,
-            Tm_max=Tm_max,
-            Tm_parameters=Tm_parameters,
-            Tm_chem_correction_parameters=Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=Tm_salt_correction_parameters,
-        )
-        homopolymeric_runs = HomopolymericRunsFilter(
-            base_n=homopolymeric_base_n,
-        )
-        # only need detection oligo filter because it also checks for Padlock arms
-        detect_oligo_filter = DetectionOligoFilter(
-            detect_oligo_length_min=detect_oligo_length_min,
-            detect_oligo_length_max=detect_oligo_length_max,
-            min_thymines=min_thymines,
-            arm_length_min=arm_length_min,
-            arm_Tm_dif_max=arm_Tm_dif_max,
-            arm_Tm_min=arm_Tm_min,
-            arm_Tm_max=arm_Tm_max,
-            Tm_parameters=Tm_parameters,
-            Tm_chem_correction_parameters=Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=Tm_salt_correction_parameters,
-        )
+        # Pre-filter by isoform consensus (cheap property lookup before sequence filters)
+        if isoform_consensus_filter["enabled"]:
+            isoform_consensus_property = IsoformConsensusProperty()
+            calculator = PropertyCalculator(properties=[isoform_consensus_property])
+            oligo_database = calculator.apply(
+                oligo_database=oligo_database, sequence_type="target", n_jobs=self.n_jobs
+            )
+            oligo_database.filter_database_by_property_threshold(
+                property_name="isoform_consensus",
+                property_thr=isoform_consensus_filter["isoform_consensus"],
+                remove_if_smaller_threshold=True,
+            )
 
-        filters = [
-            hard_masked_sequences,
-            soft_masked_sequences,
-            homopolymeric_runs,
-            gc_content,
-            melting_temperature,
-            detect_oligo_filter,
-        ]
+        # Instantiate sequence-based property filters
+        # Masking: drop oligos with ambiguous or low-complexity bases
+        filters: list[BasePropertyFilter] = []
+        if hard_masked_sequences_filter["enabled"]:
+            hard_masked_sequences = HardMaskedSequenceFilter()
+            filters.append(hard_masked_sequences)
 
-        # initialize the preoperty filter class
+        if soft_masked_sequences_filter["enabled"]:
+            soft_masked_sequences = SoftMaskedSequenceFilter()
+            filters.append(soft_masked_sequences)
+
+        # Composition: homopolymeric runs, GC range, prohibited motifs
+        if homopolymeric_runs_filter["enabled"]:
+            homopolymeric_runs = HomopolymericRunsFilter(
+                base_n=homopolymeric_runs_filter["homopolymeric_base_n"],
+            )
+            filters.append(homopolymeric_runs)
+
+        if GC_content_filter["enabled"]:
+            gc_content = GCContentFilter(
+                GC_content_min=GC_content_filter["GC_content_min"],
+                GC_content_max=GC_content_filter["GC_content_max"],
+            )
+            filters.append(gc_content)
+
+        # Thermodynamics: self-complementarity (hairpins), Tm range, secondary structure (ΔG)
+        if Tm_filter["enabled"]:
+            melting_temperature = MeltingTemperatureNNFilter(
+                Tm_min=Tm_filter["Tm_min"],
+                Tm_max=Tm_filter["Tm_max"],
+                Tm_parameters=Tm_filter["Tm_parameters"],
+                Tm_chem_correction_parameters=Tm_filter["Tm_chem_correction_parameters"],
+                Tm_salt_correction_parameters=Tm_filter["Tm_salt_correction_parameters"],
+            )
+            filters.append(melting_temperature)
+
+        # Note: detetcion oligo filter already checks if padlock arms are feasible.
+        # No need to apply PadlockArmsFilter here.
+        detection_oligo = DetectionOligoFilter(
+            detect_oligo_length_min=detection_oligo_filter["oligo_length_min"],
+            detect_oligo_length_max=detection_oligo_filter["oligo_length_max"],
+            min_thymines=detection_oligo_filter["min_thymines"],
+            arm_length_min=detection_oligo_filter["padlock_arm_length_min"],
+            arm_Tm_dif_max=detection_oligo_filter["padlock_arm_Tm_dif_max"],
+            arm_Tm_min=detection_oligo_filter["padlock_arm_Tm_min"],
+            arm_Tm_max=detection_oligo_filter["padlock_arm_Tm_max"],
+            Tm_parameters=detection_oligo_filter["Tm_parameters"],
+            Tm_chem_correction_parameters=detection_oligo_filter["Tm_chem_correction_parameters"],
+            Tm_salt_correction_parameters=detection_oligo_filter["Tm_salt_correction_parameters"],
+        )
+        filters.append(detection_oligo)
+
+        # Apply filters in order of cost (cheapest first) so failing oligos are rejected early.
         property_filter = PropertyFilter(filters=filters)
-
-        # filter the database
         oligo_database = property_filter.apply(
             oligo_database=oligo_database,
             sequence_type="oligo",
@@ -1068,183 +827,127 @@ class TargetProbeDesigner:
     def filter_by_specificity(
         self,
         oligo_database: OligoDatabase,
-        files_fasta_reference_database: list[str],
-        specificity_blastn_search_parameters: dict,
-        specificity_blastn_hit_parameters: dict,
-        cross_hybridization_blastn_search_parameters: dict,
-        cross_hybridization_blastn_hit_parameters: dict,
-        ligation_region_size: int,
-        arm_length_min: int,
-        arm_Tm_dif_max: int,
-        arm_Tm_min: float,
-        arm_Tm_max: float,
-        Tm_parameters: dict,
-        Tm_chem_correction_parameters: dict | None,
-        Tm_salt_correction_parameters: dict | None,
+        specificity_blastn_filter: dict,
+        cross_hybridization_blastn_filter: dict,
     ) -> OligoDatabase:
         """
         Filter the oligo database based on sequence specificity to remove probes that bind
         non-specifically or cross-hybridize.
 
-        This method applies two types of specificity filters:
+        Before applying the alignment-based filters, the method computes the ``PadlockArmsProperty``
+        for every probe (always on) — this is required by the seed-region BLASTN filter when
+        ``ligation_region_size > 0`` and by :py:meth:`ScrinshotProbeDesigner.assemble_padlock_backbone`
+        downstream.
 
-        1. **Specificity filtering**: Removes probes that bind to unintended genomic regions
-           - **Exact matches**: Removes all probes with exact sequence matches to probes of other regions
-           - **BLASTN specificity**: Uses BLASTN to search for similar sequences in the reference database.
-             Probes with hits meeting the specified criteria are removed. If `ligation_region_size > 0`,
-             seed-based filtering is applied around the ligation site, removing all probes where BLASTN
-             hits cover the junction region, regardless of the coverage threshold. If `ligation_region_size == 0`,
-             full-length specificity filtering is performed.
+        The filter list is seeded with an :class:`ExactMatchFilter` (always on) and then conditionally
+        extended with the BLASTN-specificity and cross-hybridization filters depending on their
+        ``enabled`` flags. All filters are applied in a single :class:`SpecificityFilter` invocation
+        so the database is iterated once.
 
-        2. **Cross-hybridization filtering**: Removes probes that cross-hybridize with each other.
-           This is critical because if probes can bind to each other, they may form dimers instead
-           of binding to the target RNA. Probes from the larger genomic region are removed when
-           cross-hybridization is detected.
+        1. **Exact matches** (always on): Removes all probes with exact sequence matches to probes of
+           other regions.
+        2. **BLASTN specificity** (gated on ``specificity_blastn_filter['enabled']``): Uses BLASTN to
+           search for similar sequences in the reference database. Probes with hits meeting the
+           specified criteria are removed. If ``ligation_region_size > 0``, seed-based filtering is
+           applied around the ligation site, removing all probes where BLASTN hits cover the junction
+           region, regardless of the coverage threshold. If ``ligation_region_size == 0``, full-length
+           specificity filtering is performed.
+        3. **Cross-hybridization** (gated on ``cross_hybridization_blastn_filter['enabled']``): Removes
+           probes that cross-hybridize with each other. This is critical because if probes can bind to
+           each other, they may form dimers instead of binding to the target RNA. Probes from the
+           larger genomic region are removed when cross-hybridization is detected.
 
-        Before applying specificity filters, the method calculates padlock arm properties (arm sequences,
-        ligation site, and arm melting temperatures) for all probes. This information is required for
-        seed-based specificity filtering when `ligation_region_size > 0`.
-
-        The reference database is loaded from the provided FASTA files and used for all BLASTN searches.
-        Regions that do not meet the minimum oligo requirement after filtering are removed from
-        the database.
+        The reference database is loaded from the provided FASTA files and shared between the BLASTN
+        specificity and cross-hybridization filters. Regions that do not meet the minimum oligo
+        requirement after filtering are removed from the database.
 
         :param oligo_database: The `OligoDatabase` instance containing oligonucleotide sequences
-            and their associated properties. This database should contain target probes with their
-            component sequences already calculated.
+            and their associated properties.
         :type oligo_database: OligoDatabase
         :param files_fasta_reference_database: List of paths to FASTA files containing reference
             sequences against which specificity will be evaluated. These typically include the
-            entire genome or transcriptome to identify off-target binding sites.
+            entire genome or transcriptome to identify off-target binding sites. The database is
+            shared between both BLASTN-based filters.
         :type files_fasta_reference_database: list[str]
-        :param specificity_blastn_search_parameters: Dictionary of parameters for BLASTN searches
-            used in specificity filtering.
-        :type specificity_blastn_search_parameters: dict
-        :param specificity_blastn_hit_parameters: Dictionary of parameters for filtering BLASTN hits
-            in specificity searches. Probes with hits meeting these criteria are removed.
-        :type specificity_blastn_hit_parameters: dict
-        :param cross_hybridization_blastn_search_parameters: Dictionary of parameters for BLASTN
-            searches used in cross-hybridization filtering. These searches check if probes align to
-            each other.
-        :type cross_hybridization_blastn_search_parameters: dict
-        :param cross_hybridization_blastn_hit_parameters: Dictionary of parameters for filtering
-            BLASTN hits in cross-hybridization searches. Probes with cross-hybridization hits meeting these
-            criteria are removed from the larger region.
-        :type cross_hybridization_blastn_hit_parameters: dict
         :param ligation_region_size: Size of the ligation region (in nucleotides) around the ligation
             site. If > 0, seed-based specificity filtering is applied: all probes where BLASTN hits
             cover the junction region are removed, regardless of the coverage threshold. If 0,
             full-length specificity filtering is performed. Both modes perform full BLASTN searches.
         :type ligation_region_size: int
-        :param arm_length_min: Minimum length (in nucleotides) for each padlock probe arm. Used for
-            calculating padlock arm properties before specificity filtering.
-        :type arm_length_min: int
-        :param arm_Tm_dif_max: Maximum allowed difference in melting temperature (in degrees Celsius)
-            between the two padlock arms. Used for calculating padlock arm properties.
-        :type arm_Tm_dif_max: int
-        :param arm_Tm_min: Minimum acceptable melting temperature (Tm) for padlock arms in degrees Celsius.
-            Used for calculating padlock arm properties.
-        :type arm_Tm_min: float
-        :param arm_Tm_max: Maximum acceptable melting temperature (Tm) for padlock arms in degrees Celsius.
-            Used for calculating padlock arm properties.
-        :type arm_Tm_max: float
-        :param Tm_parameters: Dictionary of parameters for calculating melting temperature (Tm) using
-            the nearest-neighbor method. Used for calculating padlock arm Tm values. For using
-            Bio.SeqUtils.MeltingTemp default parameters, set to ``{}``. Common parameters include:
-            'nn_table', 'tmm_table', 'imm_table', 'de_table', 'dnac1', 'dnac2', 'Na', 'K', 'Tris', 'Mg',
-            'dNTPs', 'saltcorr', etc. For more information on parameters, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-        :type Tm_parameters: dict
-        :param Tm_chem_correction_parameters: Dictionary of chemical correction parameters for Tm
-            calculation. These parameters account for the effects of chemical additives (e.g., DMSO,
-            formamide) on melting temperature. Set to ``None`` to disable chemical correction, or set to ``{}``
-            to use Bio.SeqUtils.MeltingTemp default parameters. For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.chem_correction
-        :type Tm_chem_correction_parameters: dict | None
-        :param Tm_salt_correction_parameters: Dictionary of salt correction parameters for Tm calculation.
-            These parameters account for the effects of salt concentration on melting temperature. Set to ``None``
-            to disable salt correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters.
-            For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.salt_correction
-        :type Tm_salt_correction_parameters: dict | None
-        :return: A filtered `OligoDatabase` object containing only probes that pass all specificity
-            and cross-hybridization filters. The database includes calculated padlock arm properties
-            (ligation_site, sequence_padlock_arm1, sequence_padlock_arm2, etc.). Regions with insufficient
+        :param specificity_blastn_filter: Dict with ``enabled``, ``search_parameters``,
+            ``hit_parameters``.
+        :type specificity_blastn_filter: dict
+        :param cross_hybridization_blastn_filter: Dict with ``enabled``, ``search_parameters``,
+            ``hit_parameters``.
+        :type cross_hybridization_blastn_filter: dict
+        :param padlock_arm_filter: Dict with ``enabled``, ``arm_length_min``, ``arm_Tm_dif_max``,
+            ``arm_Tm_min``, ``arm_Tm_max``. Provides the constraints used to compute the always-on
+            ``PadlockArmsProperty``. The ``enabled`` flag here is consulted by
+            :py:meth:`filter_by_property`; the property computation in this method runs unconditionally
+            since the arm sequences are required downstream.
+        :type padlock_arm_filter: dict
+        :return: A filtered `OligoDatabase` object containing only probes that pass all enabled
+            specificity and cross-hybridization filters. The database includes calculated padlock arm
+            properties (``ligation_site``, arm sequences, arm Tm values). Regions with insufficient
             oligos after filtering are removed.
         :rtype: OligoDatabase
         """
-
-        ##### exact match filter #####
-        # removing duplicated probes from the region with the most probes
-        # exectute seperately before specificity filter to compute ligation side for less oligos
         exact_matches = ExactMatchFilter(policy=RemoveAllFilterPolicy(), filter_name="exact_match")
-        specificity_filter = SpecificityFilter(filters=[exact_matches])
-        oligo_database = specificity_filter.apply(
-            oligo_database=oligo_database,
-            sequence_type="oligo",
-            n_jobs=self.n_jobs,
-        )
+        filters: list[BaseSpecificityFilter] = [exact_matches]
+        directories = []
 
-        ##### calculate required probe properties #####
-        # Calculate padlock arms and detection oligo
-        padlock_arms_property = PadlockArmsProperty(
-            arm_length_min=arm_length_min,
-            arm_Tm_dif_max=arm_Tm_dif_max,
-            arm_Tm_min=arm_Tm_min,
-            arm_Tm_max=arm_Tm_max,
-            Tm_parameters=Tm_parameters,
-            Tm_chem_correction_parameters=Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=Tm_salt_correction_parameters,
-        )
-        calculator = PropertyCalculator(properties=[padlock_arms_property])
-        oligo_database = calculator.apply(
-            oligo_database=oligo_database, sequence_type="oligo", n_jobs=self.n_jobs
-        )
-
-        ##### define reference database #####
-        reference_database = ReferenceDatabase(
-            database_name=self.subdir_db_reference, dir_output=self.dir_output
-        )
-        reference_database.load_database_from_file(
-            files=files_fasta_reference_database, file_type="fasta", database_overwrite=True
-        )
-
-        ##### specificity filters #####
-        cross_hybridization_aligner = BlastNFilter(
-            search_parameters=cross_hybridization_blastn_search_parameters,
-            hit_parameters=cross_hybridization_blastn_hit_parameters,
-            filter_name="blastn_crosshybridization",
-            dir_output=self.dir_output,
-        )
-        cross_hybridization_aligner.set_reference_database(reference_database=reference_database)
-        cross_hybridization = CrossHybridizationFilter(
-            policy=RemoveByLargerRegionFilterPolicy(),
-            alignment_method=cross_hybridization_aligner,
-            filter_name="blastn_crosshybridization",
-            dir_output=self.dir_output,
-        )
-
-        specificity: AlignmentSpecificityFilter
-        if ligation_region_size > 0:
-            specificity = BlastNSeedregionSiteFilter(
-                seedregion_size=ligation_region_size,
-                seedregion_site_name="ligation_site",
-                search_parameters=specificity_blastn_search_parameters,
-                hit_parameters=specificity_blastn_hit_parameters,
-                filter_name="blastn_specificity",
+        if cross_hybridization_blastn_filter["enabled"]:
+            cross_hybridization_aligner = BlastNFilter(
+                remove_hits=True,
+                search_parameters=cross_hybridization_blastn_filter["search_parameters"],
+                hit_parameters=cross_hybridization_blastn_filter["hit_parameters"],
+                filter_name="cross_hybridization_blastn_filter",
                 dir_output=self.dir_output,
             )
-            specificity.set_reference_database(reference_database=reference_database)
-        else:
-            specificity = BlastNFilter(
-                search_parameters=specificity_blastn_search_parameters,
-                hit_parameters=specificity_blastn_hit_parameters,
-                filter_name="blastn_specificity",
+            cross_hybridization = CrossHybridizationFilter(
+                policy=RemoveByLargerRegionFilterPolicy(),
+                alignment_method=cross_hybridization_aligner,
+                filter_name="cross_hybridization_blastn_filter",
                 dir_output=self.dir_output,
             )
-            specificity.set_reference_database(reference_database=reference_database)
+            filters.append(cross_hybridization)
+            directories.append(cross_hybridization_aligner.dir_output)
+            directories.append(cross_hybridization.dir_output)
 
-        specificity_filter = SpecificityFilter(filters=[specificity, cross_hybridization])
+        if specificity_blastn_filter["enabled"]:
+            reference_database = ReferenceDatabase(
+                database_name=f"{self.subdir_db_reference}_sequences", dir_output=self.dir_output
+            )
+            reference_database.load_database_from_file(
+                files=specificity_blastn_filter["files_fasta_reference_database"],
+                file_type="fasta",
+                database_overwrite=True,
+            )
+            specificity: AlignmentSpecificityFilter
+            if specificity_blastn_filter["ligation_region_size"] > 0:
+                specificity = BlastNSeedregionSiteFilter(
+                    remove_hits=True,
+                    seedregion_size=specificity_blastn_filter["ligation_region_size"],
+                    seedregion_site_name="ligation_site",
+                    search_parameters=specificity_blastn_filter["search_parameters"],
+                    hit_parameters=specificity_blastn_filter["hit_parameters"],
+                    filter_name="specificity_blastn_filter",
+                    dir_output=self.dir_output,
+                )
+            else:
+                specificity = BlastNFilter(
+                    remove_hits=True,
+                    search_parameters=specificity_blastn_filter["search_parameters"],
+                    hit_parameters=specificity_blastn_filter["hit_parameters"],
+                    filter_name="specificity_blastn_filter",
+                    dir_output=self.dir_output,
+                )
+            specificity.set_reference_database(reference_database=reference_database)
+            filters.append(specificity)
+            directories.append(specificity.dir_output)
+
+        # run all filters specified above
+        specificity_filter = SpecificityFilter(filters=filters)
         oligo_database = specificity_filter.apply(
             oligo_database=oligo_database,
             sequence_type="oligo",
@@ -1252,11 +955,7 @@ class TargetProbeDesigner:
         )
 
         # remove all directories of intermediate steps
-        for directory in [
-            cross_hybridization_aligner.dir_output,
-            cross_hybridization.dir_output,
-            specificity.dir_output,
-        ]:
+        for directory in directories:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
 
@@ -1268,27 +967,10 @@ class TargetProbeDesigner:
     def create_oligo_sets(
         self,
         oligo_database: OligoDatabase,
-        isoform_weight: float,
-        GC_content_min: float,
-        GC_content_opt: float,
-        GC_content_max: float,
-        GC_weight: float,
-        Tm_min: float,
-        Tm_opt: float,
-        Tm_max: float,
-        Tm_weight: float,
-        Tm_parameters: dict,
-        Tm_chem_correction_parameters: dict | None,
-        Tm_salt_correction_parameters: dict | None,
-        set_size_opt: int,
-        set_size_min: int,
-        distance_between_oligos: int,
-        n_sets: int,
-        n_attempts_graph: int,
-        n_attempts_clique_enum: int,
-        diversification_fraction: float,
-        jaccard_opt: float,
-        jaccard_step: float,
+        independent_set_selection: dict,
+        isoform_consensus_score: dict,
+        GC_content_score: dict,
+        Tm_score: dict,
     ) -> OligoDatabase:
         """
         Create optimal oligo sets based on weighted scoring criteria, distance constraints, and set selection.
@@ -1298,112 +980,55 @@ class TargetProbeDesigner:
            GC content, melting temperature). Higher scores indicate better probes.
         2. **Set generation**: Builds a compatibility graph from distance constraints and selects sets via
            a graph-based (clique) strategy. Generates multiple diverse sets per region, controlling overlap
-           between sets using a Jaccard threshold (`jaccard_opt`) with optional relaxation (`jaccard_step`).
+           between sets using a Jaccard threshold (``jaccard_opt``) with optional relaxation (``jaccard_step``).
         3. **Set scoring**: Evaluates each generated set and selects the best sets based on the lowest
            average score (ascending order).
         4. **Region filtering**: Removes regions that cannot generate sets meeting the minimum size requirement.
 
-        The algorithm attempts to find sets with optimal size (`set_size_opt`) but may produce sets
-        as small as `set_size_min` if constraints cannot be met.
+        The algorithm attempts to find sets with optimal size (``set_size_opt``) but may produce sets
+        as small as ``set_size_min`` if constraints cannot be met.
 
         :param oligo_database: The `OligoDatabase` instance containing oligonucleotide sequences
             and their associated properties. This database should contain target probes that have
             passed all previous filtering steps, including padlock arm property calculations.
         :type oligo_database: OligoDatabase
-        :param isoform_weight: Weight assigned to isoform consensus in the scoring function.
-        :type isoform_weight: float
-        :param GC_content_min: Minimum acceptable GC content for oligos, expressed as a fraction
-            between 0.0 and 1.0. Used in scoring to penalize probes with GC content below this value.
-        :type GC_content_min: float
-        :param GC_content_opt: Optimal GC content for oligos, expressed as a fraction between 0.0
-            and 1.0. Used in scoring to prioritize probes closer to this value.
-        :type GC_content_opt: float
-        :param GC_content_max: Maximum acceptable GC content for oligos, expressed as a fraction
-            between 0.0 and 1.0. Used in scoring to penalize probes with GC content above this value.
-        :type GC_content_max: float
-        :param GC_weight: Weight assigned to GC content in the scoring function.
-        :type GC_weight: float
-        :param Tm_min: Minimum acceptable melting temperature (Tm) for oligos in degrees Celsius.
-            Used in scoring to penalize probes with Tm below this value.
-        :type Tm_min: float
-        :param Tm_opt: Optimal melting temperature (Tm) for oligos in degrees Celsius. Used in scoring
-            to prioritize probes closer to this value.
-        :type Tm_opt: float
-        :param Tm_max: Maximum acceptable melting temperature (Tm) for oligos in degrees Celsius.
-            Used in scoring to penalize probes with Tm above this value.
-        :type Tm_max: float
-        :param Tm_weight: Weight assigned to melting temperature in the scoring function.
-        :type Tm_weight: float
-        :param Tm_parameters: Dictionary of parameters for calculating melting temperature (Tm) using
-            the nearest-neighbor method. For using Bio.SeqUtils.MeltingTemp default parameters, set to ``{}``.
-            Common parameters include: 'nn_table', 'tmm_table', 'imm_table', 'de_table', 'dnac1', 'dnac2', 'Na', 'K',
-            'Tris', 'Mg', 'dNTPs', 'saltcorr', etc. For more information on parameters, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.Tm_NN
-        :type Tm_parameters: dict
-        :param Tm_chem_correction_parameters: Dictionary of chemical correction parameters for Tm
-            calculation. These parameters account for the effects of chemical additives (e.g., DMSO,
-            formamide) on melting temperature. Set to ``None`` to disable chemical correction, or set to ``{}``
-            to use Bio.SeqUtils.MeltingTemp default parameters. For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.chem_correction
-        :type Tm_chem_correction_parameters: dict | None
-        :param Tm_salt_correction_parameters: Dictionary of salt correction parameters for Tm calculation.
-            These parameters account for the effects of salt concentration on melting temperature. Set to ``None``
-            to disable salt correction, or set to ``{}`` to use Bio.SeqUtils.MeltingTemp default parameters.
-            For more information, see:
-            https://biopython.org/docs/1.75/api/Bio.SeqUtils.MeltingTemp.html#Bio.SeqUtils.MeltingTemp.salt_correction
-        :type Tm_salt_correction_parameters: dict | None
-        :param set_size_opt: Optimal size (number of probes) for each oligo set. The set selection algorithm will
-            attempt to generate sets of this size, but may produce sets with fewer probes if constraints cannot be met.
-        :type set_size_opt: int
-        :param set_size_min: Minimum size (number of probes) required for each oligo set. Sets with fewer probes than
-            this value will be rejected, and regions that cannot generate sets meeting this minimum will be removed.
-        :type set_size_min: int
-        :param distance_between_oligos: Minimum genomic distance (in nucleotides) required between probes
-            within the same set. This spacing constraint prevents probes from binding too close together, which could
-            lead to reduced hybridization efficiency.
-        :type distance_between_oligos: int
-        :param n_sets: Number of oligo sets to generate per region. Multiple sets allow for redundancy and selection
-            of the best-performing set based on scoring criteria.
-        :type n_sets: int
-        :param n_attempts_graph: Number of randomized graph attempts. In each attempt, a fraction of nodes is randomly
-            removed from the compatibility graph to create diversity.
-        :type n_attempts_graph: int
-        :param n_attempts_clique_enum: Maximum number of cliques enumerated per graph attempt.
-        :type n_attempts_clique_enum: int
-        :param diversification_fraction: Fraction of oligos to remove at random per attempt to create diversity
-            between sets.
-        :type diversification_fraction: float
-        :param jaccard_opt: Optimal maximum Jaccard overlap between selected sets. Sets with overlap above this
-            value are discouraged when selecting multiple sets per region.
-        :type jaccard_opt: float
-        :param jaccard_step: Step size for relaxing Jaccard overlap when not enough sets are found.
-        :type jaccard_step: float
+        :param independent_set_selection: Dict controlling set generation. Must contain ``n_sets``,
+            ``set_size_min``, ``set_size_opt``, ``distance_between_probes``, ``n_attempts_graph``,
+            ``n_attempts_clique_enum``, ``diversification_fraction``, ``jaccard_opt``, ``jaccard_step``.
+        :type independent_set_selection: dict
+        :param isoform_consensus_score: Dict with ``weight``.
+        :type isoform_consensus_score: dict
+        :param GC_content_score: Dict with ``weight``, ``GC_content_min``, ``GC_content_opt``,
+            ``GC_content_max``.
+        :type GC_content_score: dict
+        :param Tm_score: Dict with ``weight``, ``Tm_min``, ``Tm_opt``, ``Tm_max``.
+        :type Tm_score: dict
         :return: An updated `OligoDatabase` object containing the generated oligo sets. Each region
-            will have up to `n_sets` sets stored, with each set containing between `set_size_min` and
-            `set_size_opt` probes. Regions with insufficient oligos are removed.
+            will have up to ``n_sets`` sets stored, with each set containing between ``set_size_min`` and
+            ``set_size_opt`` probes. Regions with insufficient oligos are removed.
         :rtype: OligoDatabase
         """
 
         # Define all scorers
         isoform_consensus_scorer = IsoformConsensusScorer(
-            score_weight=isoform_weight,
+            score_weight=isoform_consensus_score["weight"],
             property_name_transcript_id="transcript_id",
             property_name_number_total_transcripts="number_total_transcripts",
         )
         Tm_scorer = NormalizedDeviationFromOptimalTmScorer(
-            Tm_min=Tm_min,
-            Tm_opt=Tm_opt,
-            Tm_max=Tm_max,
-            Tm_parameters=Tm_parameters,
-            Tm_chem_correction_parameters=Tm_chem_correction_parameters,
-            Tm_salt_correction_parameters=Tm_salt_correction_parameters,
-            score_weight=Tm_weight,
+            Tm_min=Tm_score["Tm_min"],
+            Tm_opt=Tm_score["Tm_opt"],
+            Tm_max=Tm_score["Tm_max"],
+            Tm_parameters=Tm_score["Tm_parameters"],
+            Tm_chem_correction_parameters=Tm_score["Tm_chem_correction_parameters"],
+            Tm_salt_correction_parameters=Tm_score["Tm_salt_correction_parameters"],
+            score_weight=Tm_score["weight"],
         )
         GC_scorer = NormalizedDeviationFromOptimalGCContentScorer(
-            GC_content_min=GC_content_min,
-            GC_content_opt=GC_content_opt,
-            GC_content_max=GC_content_max,
-            score_weight=GC_weight,
+            GC_content_min=GC_content_score["GC_content_min"],
+            GC_content_opt=GC_content_score["GC_content_opt"],
+            GC_content_max=GC_content_score["GC_content_max"],
+            score_weight=GC_content_score["weight"],
         )
         oligos_scoring = OligoScoring(scorers=[isoform_consensus_scorer, Tm_scorer, GC_scorer])
         set_scoring = LowestSetScoring(ascending=True)
@@ -1412,19 +1037,19 @@ class TargetProbeDesigner:
         oligoset_generator = IndependentSetsOligoSelection(
             oligos_scoring=oligos_scoring,
             set_scoring=set_scoring,
-            set_size_opt=set_size_opt,
-            set_size_min=set_size_min,
-            distance_between_oligos=distance_between_oligos,
-            n_attempts_graph=n_attempts_graph,
-            n_attempts_clique_enum=n_attempts_clique_enum,
-            diversification_fraction=diversification_fraction,
-            jaccard_opt=jaccard_opt,
-            jaccard_step=jaccard_step,
+            set_size_opt=independent_set_selection["set_size_opt"],
+            set_size_min=independent_set_selection["set_size_min"],
+            distance_between_oligos=independent_set_selection["distance_between_probes"],
+            n_attempts_graph=independent_set_selection["n_attempts_graph"],
+            n_attempts_clique_enum=independent_set_selection["n_attempts_clique_enum"],
+            diversification_fraction=independent_set_selection["diversification_fraction"],
+            jaccard_opt=independent_set_selection["jaccard_opt"],
+            jaccard_step=independent_set_selection["jaccard_step"],
         )
         oligo_database = oligoset_generator.apply(
             oligo_database=oligo_database,
             sequence_type="oligo",
-            n_sets=n_sets,
+            n_sets=independent_set_selection["n_sets"],
             n_jobs=self.n_jobs,
         )
 
@@ -1888,30 +1513,152 @@ class DetectionOligoDesigner:
 
 
 ############################################
-# SCRINSHOT Probe Designer Pipeline
+# SCRINSHOT Designer Pipeline
 ############################################
+
+
+def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
+
+    # Preprocess Tm tables and set Tm_chem/salt_correction_parameters to None if the correction is disabled
+    for section in ["target_probe", "detection_oligo"]:
+        config[section]["global_parameters"]["Tm_parameters"] = preprocess_tm_parameters(
+            config[section]["global_parameters"]["Tm_parameters"]
+        )
+        for correction in ["Tm_chem_correction_parameters", "Tm_salt_correction_parameters"]:
+            correction_cfg = config[section]["global_parameters"][correction]
+            if not correction_cfg["enabled"]:
+                correction_cfg["parameters"] = None
+
+    target_probe_Tm_parameters = config["target_probe"]["global_parameters"]["Tm_parameters"]
+    target_probe_Tm_chem_correction_parameters = config["target_probe"]["global_parameters"][
+        "Tm_chem_correction_parameters"
+    ]["parameters"]
+    target_probe_Tm_salt_correction_parameters = config["target_probe"]["global_parameters"][
+        "Tm_salt_correction_parameters"
+    ]["parameters"]
+
+    # Note: for the detection oligo filter we have to set the Tm parameters to the ones form the target
+    # probe because it is used to check if padlock arms are feasible.
+    config["target_probe"]["property_filters"]["detection_oligo_filter"] = {
+        "oligo_length_min": config["detection_oligo"]["oligo_generation"]["oligo_length_min"],
+        "oligo_length_max": config["detection_oligo"]["oligo_generation"]["oligo_length_max"],
+        "min_thymines": config["detection_oligo"]["oligo_generation"]["min_thymines"],
+        "padlock_arm_length_min": config["target_probe"]["padlock_arms_properties"]["padlock_arm_length_min"],
+        "padlock_arm_Tm_dif_max": config["target_probe"]["padlock_arms_properties"]["padlock_arm_Tm_dif_max"],
+        "padlock_arm_Tm_min": config["target_probe"]["padlock_arms_properties"]["padlock_arm_Tm_min"],
+        "padlock_arm_Tm_max": config["target_probe"]["padlock_arms_properties"]["padlock_arm_Tm_max"],
+        "Tm_parameters": target_probe_Tm_parameters,
+        "Tm_chem_correction_parameters": target_probe_Tm_chem_correction_parameters,
+        "Tm_salt_correction_parameters": target_probe_Tm_salt_correction_parameters,
+    }
+
+    config["target_probe"]["property_filters"]["Tm_filter"]["Tm_parameters"] = target_probe_Tm_parameters
+    config["target_probe"]["property_filters"]["Tm_filter"][
+        "Tm_chem_correction_parameters"
+    ] = target_probe_Tm_chem_correction_parameters
+    config["target_probe"]["property_filters"]["Tm_filter"][
+        "Tm_salt_correction_parameters"
+    ] = target_probe_Tm_salt_correction_parameters
+
+    config["target_probe"]["padlock_arms_properties"]["Tm_parameters"] = target_probe_Tm_parameters
+    config["target_probe"]["padlock_arms_properties"][
+        "Tm_chem_correction_parameters"
+    ] = target_probe_Tm_chem_correction_parameters
+    config["target_probe"]["padlock_arms_properties"][
+        "Tm_salt_correction_parameters"
+    ] = target_probe_Tm_salt_correction_parameters
+
+    config["target_probe"]["probe_set_selection"]["Tm_score"]["Tm_parameters"] = target_probe_Tm_parameters
+    config["target_probe"]["probe_set_selection"]["Tm_score"][
+        "Tm_chem_correction_parameters"
+    ] = target_probe_Tm_chem_correction_parameters
+    config["target_probe"]["probe_set_selection"]["Tm_score"][
+        "Tm_salt_correction_parameters"
+    ] = target_probe_Tm_salt_correction_parameters
+
+    detection_oligo_Tm_parameters = config["detection_oligo"]["global_parameters"]["Tm_parameters"]
+    detection_oligo_Tm_chem_correction_parameters = config["detection_oligo"]["global_parameters"][
+        "Tm_chem_correction_parameters"
+    ]["parameters"]
+    detection_oligo_Tm_salt_correction_parameters = config["detection_oligo"]["global_parameters"][
+        "Tm_salt_correction_parameters"
+    ]["parameters"]
+
+    config["detection_oligo"]["oligo_generation"]["Tm_parameters"] = detection_oligo_Tm_parameters
+    config["detection_oligo"]["oligo_generation"][
+        "Tm_chem_correction_parameters"
+    ] = detection_oligo_Tm_chem_correction_parameters
+    config["detection_oligo"]["oligo_generation"][
+        "Tm_salt_correction_parameters"
+    ] = detection_oligo_Tm_salt_correction_parameters
+
+    ##### read the genes file #####
+    file_region_ids = config["target_probe"]["oligo_generation"]["file_region_ids"]
+    if file_region_ids is None:
+        logger.warning(
+            "No gene list file was provided! All genes from fasta file are used to generate the probes. This choice can use a lot of resources."
+        )
+        config["target_probe"]["oligo_generation"]["region_ids"] = None
+    else:
+        with open(file_region_ids) as f:
+            config["target_probe"]["oligo_generation"]["region_ids"] = sorted({line.rstrip() for line in f})
+
+    return config
+
+
+def scrinshot_probe_designer(config: dict[str, Any]) -> None:
+    """
+    Execute the SCRINSHOT probe design pipeline from a (raw) configuration dict.
+
+    The dict is expected to follow the nested layout of ``data/configs/scrinshot_probe_designer.yaml``
+    (``general``, ``target_probe.*``, ``detection_oligo.*``). The caller is responsible for configuring
+    the library logger before invoking this function (see :func:`main`).
+
+    :param config: Pipeline configuration loaded via ``yaml.safe_load``.
+    :type config: dict
+    """
+
+    ##### preprocess the config file #####
+    config_dict = _preprocess_config(config)
+
+    ##### initialize probe designer pipeline #####
+    pipeline = ScrinshotProbeDesigner(
+        write_intermediate_steps=config_dict["general"]["write_intermediate_steps"],
+        dir_output=config_dict["general"]["dir_output"],
+        n_jobs=config_dict["general"]["n_jobs"],
+    )
+
+    ##### design target probes #####
+    oligo_database = pipeline.design_target_probes(
+        oligo_generation_parameters=config_dict["target_probe"]["oligo_generation"],
+        property_filters_parameters=config_dict["target_probe"]["property_filters"],
+        specificity_filters_parameters=config_dict["target_probe"]["specificity_filters"],
+        probe_set_selection_parameters=config_dict["target_probe"]["probe_set_selection"],
+        padlock_arms_parameters=config_dict["target_probe"]["padlock_arms_properties"],
+    )
+
+    ##### design detection oligos #####
+    oligo_database = pipeline.design_detection_oligos(
+        oligo_database=oligo_database,
+        oligo_generation_parameters=config_dict["detection_oligo"]["oligo_generation"],
+    )
+
+    ##### assemble padlock backbone #####
+    probe_database = pipeline.assemble_padlock_backbone(
+        oligo_database=oligo_database,
+        padlock_arms_parameters=config_dict["target_probe"]["padlock_arms_properties"],
+    )
+
+    ##### write outputs #####
+    pipeline.generate_output(probe_database=probe_database)
 
 
 def main() -> None:
     """
     Main entry point for running the SCRINSHOT probe design pipeline.
 
-    This function orchestrates the complete SCRINSHOT probe design workflow:
-    1. Parses command-line arguments using the base parser
-    2. Reads the configuration YAML file containing all pipeline parameters
-    3. Reads the gene IDs file (if provided) or uses all genes from FASTA files
-    4. Preprocesses melting temperature parameters for target probes and detection oligos
-    5. Initializes the ScrinshotProbeDesigner pipeline
-    6. Designs target probes for specified genes (padlock probe arms)
-    7. Designs detection oligos with uracil substitutions for optimal Tm
-    8. Assembles padlock probes by combining target probe arms with the composite backbone
-    9. Generates output files (YAML, TSV, Excel, order file)
-
-    The function is typically called from the command line:
-    ``scrinshot_probe_designer --config <path_to_config.yaml>``
-
-    Command-line arguments are parsed using `base_parser()`, which expects:
-    - `config`: Path to the YAML configuration file containing all pipeline parameters
+    Parses ``--config``, loads the YAML, configures the library logger to write into the configured
+    output directory, then delegates to :func:`scrinshot_probe_designer`.
     """
     print("--------------START PIPELINE--------------")
 
@@ -1921,110 +1668,13 @@ def main() -> None:
     with open(args["config"], "r") as handle:
         config = yaml.safe_load(handle)
 
-    ##### read the genes file #####
-    if config["file_regions"] is None:
-        print(
-            "No gene list file was provided! All genes from fasta file are used to generate the probes. This chioce can use a lot of resources."
-        )
-        region_ids = None
-    else:
-        with open(config["file_regions"]) as handle:
-            lines = handle.readlines()
-            # ensure that the list contains unique gene ids
-            region_ids = list(set([line.rstrip() for line in lines]))
-
-    ##### Preprocess Tm parameters #####
-    target_probe_Tm_parameters = preprocess_tm_parameters(config["target_probe_Tm_parameters"])
-
-    ##### initialize probe designer pipeline #####
-    pipeline = ScrinshotProbeDesigner(
-        write_intermediate_steps=config["write_intermediate_steps"],
-        dir_output=config["dir_output"],
-        n_jobs=config["n_jobs"],
-    )
-
-    # setup logger
+    # setup logger now that we know the output directory
     configure_root_logger(
-        dir_output=pipeline.dir_output,
+        dir_output=config["general"]["dir_output"],
         pipeline_name="scrinshot_probe_designer",
     )
 
-    ##### design probes #####
-    oligo_database = pipeline.design_target_probes(
-        # Step 1: Create Database Parameters
-        region_ids=region_ids,
-        files_fasta_target_probe_database=config["files_fasta_target_probe_database"],
-        target_probe_length_min=config["target_probe_length_min"],
-        target_probe_length_max=config["target_probe_length_max"],
-        target_probe_isoform_consensus=config["target_probe_isoform_consensus"],
-        # Step 2: Property Filter Parameters
-        target_probe_GC_content_min=config["target_probe_GC_content_min"],
-        target_probe_GC_content_max=config["target_probe_GC_content_max"],
-        target_probe_Tm_min=config["target_probe_Tm_min"],
-        target_probe_Tm_max=config["target_probe_Tm_max"],
-        target_probe_homopolymeric_base_n=config["target_probe_homopolymeric_base_n"],
-        detection_oligo_min_thymines=config["detection_oligo_min_thymines"],
-        detection_oligo_length_min=config["detection_oligo_length_min"],
-        detection_oligo_length_max=config["detection_oligo_length_max"],
-        target_probe_padlock_arm_length_min=config["target_probe_padlock_arm_length_min"],
-        target_probe_padlock_arm_Tm_dif_max=config["target_probe_padlock_arm_Tm_dif_max"],
-        target_probe_padlock_arm_Tm_min=config["target_probe_padlock_arm_Tm_min"],
-        target_probe_padlock_arm_Tm_max=config["target_probe_padlock_arm_Tm_max"],
-        target_probe_Tm_parameters=target_probe_Tm_parameters,
-        target_probe_Tm_chem_correction_parameters=config["target_probe_Tm_chem_correction_parameters"],
-        target_probe_Tm_salt_correction_parameters=config["target_probe_Tm_salt_correction_parameters"],
-        # Step 3: Specificity Filter Parameters
-        files_fasta_reference_database_target_probe=config["files_fasta_reference_database_target_probe"],
-        target_probe_specificity_blastn_search_parameters=config[
-            "target_probe_specificity_blastn_search_parameters"
-        ],
-        target_probe_specificity_blastn_hit_parameters=config[
-            "target_probe_specificity_blastn_hit_parameters"
-        ],
-        target_probe_cross_hybridization_blastn_search_parameters=config[
-            "target_probe_cross_hybridization_blastn_search_parameters"
-        ],
-        target_probe_cross_hybridization_blastn_hit_parameters=config[
-            "target_probe_cross_hybridization_blastn_hit_parameters"
-        ],
-        target_probe_ligation_region_size=config["target_probe_ligation_region_size"],
-        # Step 4: Probe Scoring and Set Selection Parameters
-        target_probe_isoform_weight=config["target_probe_isoform_weight"],
-        target_probe_GC_content_opt=config["target_probe_GC_content_opt"],
-        target_probe_GC_weight=config["target_probe_GC_weight"],
-        target_probe_Tm_opt=config["target_probe_Tm_opt"],
-        target_probe_Tm_weight=config["target_probe_Tm_weight"],
-        set_size_min=config["set_size_min"],
-        set_size_opt=config["set_size_opt"],
-        distance_between_target_probes=config["distance_between_target_probes"],
-        n_sets=config["n_sets"],
-        n_attempts_graph=config["n_attempts_graph"],
-        n_attempts_clique_enum=config["n_attempts_clique_enum"],
-        diversification_fraction=config["diversification_fraction"],
-        jaccard_opt=config["jaccard_opt"],
-        jaccard_step=config["jaccard_step"],
-    )
-
-    oligo_database = pipeline.design_detection_oligos(
-        oligo_database=oligo_database,
-        detection_oligo_length_min=config["detection_oligo_length_min"],
-        detection_oligo_length_max=config["detection_oligo_length_max"],
-        detection_oligo_min_thymines=config["detection_oligo_min_thymines"],
-        detection_oligo_U_distance=config["detection_oligo_U_distance"],
-        detection_oligo_Tm_opt=config["detection_oligo_Tm_opt"],
-        detection_oligo_Tm_parameters=preprocess_tm_parameters(config["detection_oligo_Tm_parameters"]),
-        detection_oligo_Tm_chem_correction_parameters=config["detection_oligo_Tm_chem_correction_parameters"],
-        detection_oligo_Tm_salt_correction_parameters=config["detection_oligo_Tm_salt_correction_parameters"],
-    )
-
-    probe_database = pipeline.assemble_padlock_backbone(
-        oligo_database=oligo_database,
-        target_probe_Tm_parameters=target_probe_Tm_parameters,
-        target_probe_Tm_chem_correction_parameters=config["target_probe_Tm_chem_correction_parameters"],
-        target_probe_Tm_salt_correction_parameters=config["target_probe_Tm_salt_correction_parameters"],
-    )
-
-    pipeline.generate_output(probe_database=probe_database)
+    scrinshot_probe_designer(config)
 
     print("--------------END PIPELINE--------------")
 

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -466,7 +466,7 @@ class ScrinshotProbeDesigner:
 
     def generate_output(
         self,
-        probe_database: OligoDatabase,
+        oligo_database: OligoDatabase,
         output_properties: list[str] | None = None,
     ) -> None:
         """
@@ -490,10 +490,10 @@ class ScrinshotProbeDesigner:
         4. **padlock_probes_order.yml**: Simplified YAML file containing only the essential sequences
            needed for ordering probes (padlock probe and detection oligo sequences).
 
-        :param probe_database: The `OligoDatabase` instance containing the final padlock probes
+        :param oligo_database: The `OligoDatabase` instance containing the final padlock probes
             with all sequences and properties. This should be the result of the `design_padlock_backbone`
             and `design_detection_oligos` methods.
-        :type probe_database: OligoDatabase
+        :type oligo_database: OligoDatabase
         :param output_properties: List of property names to include in the output files. If None, a default
             set of properties will be included. Available properties include: 'source', 'species', 'gene_id',
             'chromosome', 'start', 'end', 'strand', 'sequence_target', 'sequence_padlock_arm1',
@@ -537,19 +537,19 @@ class ScrinshotProbeDesigner:
                 "isoform_consensus",
             ]
 
-        probe_database.write_oligosets_to_yaml(
+        oligo_database.write_oligosets_to_yaml(
             properties=output_properties,
             ascending=True,
             filename="padlock_probes",
         )
 
-        probe_database.write_oligosets_to_table(
+        oligo_database.write_oligosets_to_table(
             properties=output_properties,
             ascending=True,
             filename="padlock_probes",
         )
 
-        probe_database.write_ready_to_order_yaml(
+        oligo_database.write_ready_to_order_yaml(
             properties=[
                 "sequence_padlock_probe",
                 "sequence_detection_oligo",
@@ -1623,7 +1623,7 @@ def scrinshot_probe_designer(config: dict[str, Any]) -> None:
     )
 
     ##### design target probes #####
-    oligo_database = pipeline.design_target_probes(
+    target_probe_database = pipeline.design_target_probes(
         oligo_generation_parameters=config_dict["target_probe"]["oligo_generation"],
         property_filters_parameters=config_dict["target_probe"]["property_filters"],
         specificity_filters_parameters=config_dict["target_probe"]["specificity_filters"],
@@ -1632,19 +1632,19 @@ def scrinshot_probe_designer(config: dict[str, Any]) -> None:
     )
 
     ##### design detection oligos #####
-    oligo_database = pipeline.design_detection_oligos(
-        oligo_database=oligo_database,
+    target_probe_database = pipeline.design_detection_oligos(
+        oligo_database=target_probe_database,
         oligo_generation_parameters=config_dict["detection_oligo"]["oligo_generation"],
     )
 
     ##### assemble padlock backbone #####
-    probe_database = pipeline.assemble_padlock_backbone(
-        oligo_database=oligo_database,
+    target_probe_database = pipeline.assemble_padlock_backbone(
+        oligo_database=target_probe_database,
         padlock_arms_parameters=config_dict["target_probe"]["padlock_arms_properties"],
     )
 
     ##### write outputs #####
-    pipeline.generate_output(probe_database=probe_database)
+    pipeline.generate_output(oligo_database=target_probe_database)
 
 
 def main() -> None:

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -171,7 +171,7 @@ class ScrinshotProbeDesigner:
         :type oligo_generation_parameters: dict
         :param property_filters_parameters: ``target_probe.property_filters`` block. Each filter sub-dict
             (``isoform_consensus_filter``, ``hard_masked_sequences_filter``, ``soft_masked_sequences_filter``,
-            ``homopolymeric_runs_filter``, ``GC_content_filter``, ``Tm_filter``, ``padlock_arm_filter``)
+            ``homopolymeric_runs_filter``, ``GC_content_filter``, ``Tm_filter``, ``detection_oligo_filter``)
             carries an ``enabled`` flag plus its parameters.
         :type property_filters_parameters: dict
         :param specificity_filters_parameters: ``target_probe.specificity_filters`` block. Contains the

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -851,9 +851,9 @@ class TargetProbeDesigner:
            each other, they may form dimers instead of binding to the target RNA. Probes from the
            larger genomic region are removed when cross-hybridization is detected.
 
-        The reference database is loaded from the provided FASTA files and shared between the BLASTN
-        specificity and cross-hybridization filters. Regions that do not meet the minimum oligo
-        requirement after filtering are removed from the database.
+        The BLASTN reference database is loaded from ``specificity_blastn_filter['files_fasta_reference_database']``
+        and used by the BLASTN-specificity filter. The cross-hybridization filter builds its own reference
+        database from the current oligos in the `OligoDatabase`.
 
         :param oligo_database: The `OligoDatabase` instance containing oligonucleotide sequences
             and their associated properties.

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -122,7 +122,7 @@ class TestScrinshotProbeDesigner(PipelinesBase, unittest.TestCase):
     def setup_output_dir(self) -> Any:
         with open(CONFIG_SCRINSHOT_PROBE_DESIGNER, "r") as handle:
             config = yaml.safe_load(handle)
-        dir_output = config.get("dir_output")
+        dir_output = config.get("general", {}).get("dir_output")
         if dir_output is None:
             return tempfile.mkdtemp()
         return os.path.abspath(dir_output)


### PR DESCRIPTION
# SCRINSHOT: restructure YAML + pipeline to nested dict layout

Second pipeline migration in the multi-pipeline restructure tracked in #185. Closes #196.

Refactors the SCRINSHOT probe designer to consume a **nested per-phase YAML config** and pass **grouped dicts** through the pipeline, mirroring the structural pattern already established by `_oligo_seq_probe_designer.py`. No Pydantic models are introduced yet. The YAML is still loaded with `yaml.safe_load` and consumed as a plain dict. Pydantic alignment will land in a follow-up PR for SCRINSHOT once the structural shape is in place across all pipelines.

The other four pipelines (HCR, Cycle HCR, MERFISH, SEQFISH+) and their flat YAMLs are **untouched** — each will get its own follow-up PR onto this branch.