### PR TITLE
Add pydantic input validation for the GenomicRegionGenerator pipeline

### DIFF
--- a/data/configs/genomic_region_generator_custom.yaml
+++ b/data/configs/genomic_region_generator_custom.yaml
@@ -2,18 +2,21 @@
 ### BASIC PARAMETERS ###
 #######################
 
+schema_version: 2
+
 ### General parameters
 dir_output: output_genomic_region_generator_custom # name of the directory where the output files will be written
 
 ### Parameters for genome and gene annotation
-source: custom # required: indicate that own annotation should be used
-source_params:
-  file_annotation: data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.gtf # required: GTF file with gene annotation
-  file_sequence: data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.fna # required: FASTA file with genome sequence
-  files_source: NCBI # optional: original source of the genomic files
-  species: Homo_sapiens # optional: species of provided annotation, leave empty if unknown
-  annotation_release: 110 # optional: release number of provided annotation, leave empty if unknown
-  genome_assembly: GRCh38 # optional: genome assembly of provided annotation, leave empty if unknown
+annotation:
+  source: custom # required: indicate that own annotation should be used
+  parameters:
+    file_annotation: data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.gtf # required: GTF file with gene annotation
+    file_sequence: data/annotations/custom_GCF_000001405.40_GRCh38.p14_genomic_chr16.fna # required: FASTA file with genome sequence
+    files_source: NCBI # optional: original source of the genomic files
+    species: Homo_sapiens # optional: species of provided annotation, leave empty if unknown
+    annotation_release: "110" # optional: release number of provided annotation, leave empty if unknown
+    genome_assembly: GRCh38 # optional: genome assembly of provided annotation, leave empty if unknown
 
 ### Parameters for sequences generation
 # List of genomic regions that should be generated, set the genomic regions you want to generate to true
@@ -26,6 +29,6 @@ genomic_regions:
   cds: true
   intron: true
 
-# If exon_exon_junction is ste to true, specify the block size, i.e. +/- "block_size" bp around the junction
+# If exon_exon_junction is set to true, specify the block size, i.e. +/- "block_size" bp around the junction
 # Hint: it does not make sense to set the block size larger than the maximum oligo length
 exon_exon_junction_block_size: 50

--- a/data/configs/genomic_region_generator_ensembl.yaml
+++ b/data/configs/genomic_region_generator_ensembl.yaml
@@ -2,14 +2,17 @@
 ### BASIC PARAMETERS ###
 #######################
 
+schema_version: 2
+
 ### General parameters
 dir_output: output_genomic_region_generator_ensembl # name of the directory where the output files will be written
 
 ### Parameters for genome and gene annotation
-source: ensembl # required: indicate that ensembl annotation should be used
-source_params:
-  species: homo_sapiens # required: species name in ensemble download format, e.g. 'homo_sapiens' for human; see http://ftp.ensembl.org/pub/release-108/gtf/ for available species names
-  annotation_release: current # required: release number of annotation, e.g. 'release-108' or 'current' to use most recent annotation release. Check out release numbers for ensemble at ftp.ensembl.org/pub/
+annotation:
+  source: ensembl # required: indicate that ensembl annotation should be used
+  parameters:
+    species: homo_sapiens # required: species name in ensembl download format, e.g. 'homo_sapiens' for human; see http://ftp.ensembl.org/pub/release-108/gtf/ for available species names
+    annotation_release: current # required: release number of annotation, e.g. 'release-108' or 'current' to use most recent annotation release. Check out release numbers for ensembl at ftp.ensembl.org/pub/
 
 ### Parameters for sequences generation
 # List of genomic regions that should be generated, set the genomic regions you want to generate to true
@@ -22,6 +25,6 @@ genomic_regions:
   cds: false
   intron: false
 
-# If exon_exon_junction is ste to true, specify the block size, i.e. +/- "block_size" bp around the junction
+# If exon_exon_junction is set to true, specify the block size, i.e. +/- "block_size" bp around the junction
 # Hint: it does not make sense to set the block size larger than the maximum oligo length
 exon_exon_junction_block_size: 50

--- a/data/configs/genomic_region_generator_ncbi.yaml
+++ b/data/configs/genomic_region_generator_ncbi.yaml
@@ -2,29 +2,31 @@
 ### BASIC PARAMETERS ###
 #######################
 
+schema_version: 2
+
 ### General parameters
 dir_output: output_genomic_region_generator_ncbi # name of the directory where the output files will be written
 
 ### Parameters for genome and gene annotation
-source: ncbi # required: indicate that ncbi annotation should be used
-source_params:
+annotation:
+  source: ncbi # required: indicate that ncbi annotation should be used
+  # required: How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'.
+  # For 'species', parameters needs the arguments 'taxon', 'species', 'assembly_source' and 'annotation_release'.
+  # For 'assembly', parameters needs the arguments 'refseq_assembly_accession' and 'assembly_name'.
   mode: species # required: How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'.
-  # For 'species', source_params needs the arguments 'taxon', 'species', 'assembly_source' and 'annotation_release'.
-  # For 'assembly', source_params needs the arguments 'refseq_assembly_accession' and 'assembly_name'.
-
-  # Mode 'species': set taxon/species/assembly_source/annotation_release
-  taxon: vertebrate_mammalian # required in Mode 'species'; supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral
-  species: Homo_sapiens # required in Mode 'species'; species name in NCBI download format
-  annotation_release: 110 # required in Mode 'species'; use release number only with assembly_source=annotation_releases; otherwise set to 'current'
-  assembly_source: auto # optional in Mode 'species': auto, annotation_releases, latest_assembly_versions, reference. Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory.
-  # 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'.
-  # 'latest_assembly_version' directory is available for all species and contains the latest assembly.
-  # 'reference' directory contains the reference genome. This is only available for a subset of species.
-  # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'
-
-  # Mode 'assembly': set both fields below
-  # refseq_assembly_accession: GCF_000001405.38
-  # assembly_name: GRCh38.p12
+  parameters:
+    # Mode 'species': set taxon/species/assembly_source/annotation_release
+    taxon: vertebrate_mammalian # required in Mode 'species'; supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral
+    species: Homo_sapiens # required in Mode 'species'; species name in NCBI download format
+    assembly_source: auto # optional in Mode 'species': auto, annotation_releases, latest_assembly_versions, reference. Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory.
+    # 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'.
+    # 'latest_assembly_version' directory is available for all species and contains the latest assembly.
+    # 'reference' directory contains the reference genome. This is only available for a subset of species.
+    # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'
+    annotation_release: "current" # required in Mode 'species'; use release number only with assembly_source=annotation_releases; otherwise set to 'current'
+    # Mode 'assembly': set both fields below
+    # refseq_assembly_accession: GCF_000001405.38
+    # assembly_name: GRCh38.p12
 
 ### Parameters for sequences generation
 # List of genomic regions that should be generated, set the genomic regions you want to generate to true
@@ -37,6 +39,6 @@ genomic_regions:
   cds: false
   intron: false
 
-# If exon_exon_junction is ste to true, specify the block size, i.e. +/- "block_size" bp around the junction
+# If exon_exon_junction is set to true, specify the block size, i.e. +/- "block_size" bp around the junction
 # Hint: it does not make sense to set the block size larger than the maximum oligo length
 exon_exon_junction_block_size: 50

--- a/data/configs/genomic_region_generator_ncbi.yaml
+++ b/data/configs/genomic_region_generator_ncbi.yaml
@@ -16,13 +16,13 @@ annotation:
   mode: species # required: How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'.
   parameters:
     # Mode 'species': set taxon/species/assembly_source/annotation_release
-    taxon: vertebrate_mammalian # required in Mode 'species'; supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral
+    taxon: vertebrate_mammalian # required in Mode 'species'; supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plant, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral
     species: Homo_sapiens # required in Mode 'species'; species name in NCBI download format
     assembly_source: auto # optional in Mode 'species': auto, annotation_releases, latest_assembly_versions, reference. Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory.
     # 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'.
-    # 'latest_assembly_version' directory is available for all species and contains the latest assembly.
+    # 'latest_assembly_versions' directory is available for all species and contains the latest assembly.
     # 'reference' directory contains the reference genome. This is only available for a subset of species.
-    # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'
+    # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_versions'
     annotation_release: "current" # required in Mode 'species'; use release number only with assembly_source=annotation_releases; otherwise set to 'current'
     # Mode 'assembly': set both fields below
     # refseq_assembly_accession: GCF_000001405.38

--- a/oligo_designer_toolsuite/_constants.py
+++ b/oligo_designer_toolsuite/_constants.py
@@ -19,3 +19,18 @@ _TYPES_FILE_SEQ = Literal["dna", "ncrna"]
 SEPARATOR_OLIGO_ID = "::"
 SEPARATOR_FASTA_HEADER_FIELDS = "::"
 SEPARATOR_FASTA_HEADER_FIELDS_LIST = ";"
+
+SUPPORTED_TAXA_SOURCES: dict[str, set[str]] = {
+    "archaea": {"latest_assembly_versions", "reference"},
+    "bacteria": {"latest_assembly_versions", "reference"},
+    "fungi": {"latest_assembly_versions", "reference"},
+    "invertebrate": {"annotation_releases", "latest_assembly_versions", "reference"},
+    "metagenomes": {"latest_assembly_versions"},
+    "plant": {"annotation_releases", "latest_assembly_versions", "reference"},
+    "plants": {"annotation_releases", "latest_assembly_versions", "reference"},
+    "protozoa": {"latest_assembly_versions", "reference"},
+    "unknown": {"latest_assembly_versions"},
+    "vertebrate_mammalian": {"annotation_releases", "latest_assembly_versions", "reference"},
+    "vertebrate_other": {"annotation_releases", "latest_assembly_versions", "reference"},
+    "viral": {"latest_assembly_versions"},
+}

--- a/oligo_designer_toolsuite/config/__init__.py
+++ b/oligo_designer_toolsuite/config/__init__.py
@@ -1,5 +1,7 @@
+from oligo_designer_toolsuite.config.pipelines.genomic_region_generator import GenomicRegionGeneratorConfig
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 
 __all__ = [
+    "GenomicRegionGeneratorConfig",
     "OligoSeqProbeDesignerConfig",
 ]

--- a/oligo_designer_toolsuite/config/pipelines/genomic_region_generator.py
+++ b/oligo_designer_toolsuite/config/pipelines/genomic_region_generator.py
@@ -93,7 +93,7 @@ class AnnotationParamsNcbiSpecies(BaseModel):
             "viral",
         ],
         Field(
-            description="Taxon of the species. Supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral.",
+            description="Taxon of the species. Supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plant, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral.",
             default="vertebrate_mammalian",
         ),
     ]
@@ -104,7 +104,7 @@ class AnnotationParamsNcbiSpecies(BaseModel):
     assembly_source: Annotated[
         Literal["auto", "annotation_releases", "latest_assembly_versions", "reference"],
         Field(
-            description="Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory. 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'. 'latest_assembly_version' directory is available for all species and contains the latest assembly. 'reference' directory contains the reference genome. This is only available for a subset of species. 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'",
+            description="Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory. 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'. 'latest_assembly_versions' directory is available for all species and contains the latest assembly. 'reference' directory contains the reference genome. This is only available for a subset of species. 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'",
             default="auto",
         ),
     ]

--- a/oligo_designer_toolsuite/config/pipelines/genomic_region_generator.py
+++ b/oligo_designer_toolsuite/config/pipelines/genomic_region_generator.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, PositiveInt, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from typing_extensions import Self
 
 from oligo_designer_toolsuite._constants import SUPPORTED_TAXA_SOURCES
@@ -75,7 +75,7 @@ class AnnotationParamsEnsembl(BaseModel):
 
 
 class AnnotationParamsNcbiSpecies(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     taxon: Annotated[
         Literal[
@@ -121,7 +121,7 @@ class AnnotationParamsNcbiSpecies(BaseModel):
         available_sources = SUPPORTED_TAXA_SOURCES[self.taxon]
         if self.assembly_source != "auto" and self.assembly_source not in available_sources:
             supported_sources = ", ".join(sorted(available_sources))
-            raise ValidationError(
+            raise ValueError(
                 f"assembly_source '{self.assembly_source}' is not available for taxon '{self.taxon}'. "
                 f"Supported sources for this taxon are: {supported_sources}."
             )
@@ -129,7 +129,7 @@ class AnnotationParamsNcbiSpecies(BaseModel):
             self.assembly_source in {"latest_assembly_versions", "reference"}
             or (self.assembly_source == "auto" and "annotation_releases" not in available_sources)
         ):
-            raise ValidationError(
+            raise ValueError(
                 "A numeric annotation_release is only supported with assembly_source='annotation_releases'. "
                 "Use annotation_release='current' for latest_assembly_versions/reference."
             )
@@ -137,7 +137,7 @@ class AnnotationParamsNcbiSpecies(BaseModel):
 
 
 class AnnotationNcbiSpecies(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
     source: Annotated[
         Literal["ncbi"],
@@ -269,8 +269,8 @@ class GenomicRegionGeneratorConfig(BaseModel):
 
     @model_validator(mode="after")
     def _check_exon_exon_junction_block_size(self) -> Self:
-        if self.exon_exon_junction_block_size is None:
-            raise ValidationError(
+        if self.genomic_regions.exon_exon_junction and self.exon_exon_junction_block_size is None:
+            raise ValueError(
                 "exon_exon_junction_block_size must be set if exon_exon_junction is set to True."
             )
         return self

--- a/oligo_designer_toolsuite/config/pipelines/genomic_region_generator.py
+++ b/oligo_designer_toolsuite/config/pipelines/genomic_region_generator.py
@@ -1,0 +1,276 @@
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, ValidationError, model_validator
+from typing_extensions import Self
+
+from oligo_designer_toolsuite._constants import SUPPORTED_TAXA_SOURCES
+
+
+class GenomicRegions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    gene: Annotated[bool, Field(description="Generate gene regions.", default=False)]
+    intergenic: Annotated[bool, Field(description="Generate intergenic regions.", default=False)]
+    exon: Annotated[bool, Field(description="Generate exon regions.", default=True)]
+    exon_exon_junction: Annotated[
+        bool, Field(description="Generate exon–exon junction regions.", default=False)
+    ]
+    utr: Annotated[bool, Field(description="Generate UTR regions.", default=False)]
+    cds: Annotated[bool, Field(description="Generate coding sequence (CDS) regions.", default=False)]
+    intron: Annotated[bool, Field(description="Generate intron regions.", default=False)]
+
+
+class AnnotationParamsCustom(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    file_annotation: Annotated[
+        str,
+        Field(
+            description="Required: The path to the annotation file (GTF).",
+        ),
+    ]
+    file_sequence: Annotated[
+        str,
+        Field(
+            description="Required: The path to the corresponding sequence file (FASTA).",
+        ),
+    ]
+    files_source: Annotated[
+        str | None,
+        Field(
+            description="Optional: The original source of the files (e.g., Ensembl, NCBI), defaults to 'custom'.",
+            default="custom",
+        ),
+    ]
+    species: Annotated[
+        str | None,
+        Field(
+            description="Optional: The species name related to the annotation and sequence files, defaults to 'unknown'.",
+            default="unknown",
+        ),
+    ]
+    annotation_release: Annotated[
+        str | None,
+        Field(
+            description="Optional: The annotation release version, defaults to 'unknown'.", default="unknown"
+        ),
+    ]
+    genome_assembly: Annotated[
+        str | None,
+        Field(description="Optional: The genome assembly version, defaults to 'unknown'.", default="unknown"),
+    ]
+
+
+class AnnotationParamsEnsembl(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    species: str = Field(
+        description="The species of provided annotation.",
+        default="homo_sapiens",
+    )
+    annotation_release: str = Field(
+        description="The version of the annotation release to use, e.g. 'release-116'. Use 'current' to use the most recent annotation release. Check out release numbers for ensembl at ftp.ensembl.org/pub/",
+        default="current",
+    )
+
+
+class AnnotationParamsNcbiSpecies(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    taxon: Annotated[
+        Literal[
+            "archaea",
+            "bacteria",
+            "fungi",
+            "invertebrate",
+            "metagenomes",
+            "plant",
+            "plants",
+            "protozoa",
+            "unknown",
+            "vertebrate_mammalian",
+            "vertebrate_other",
+            "viral",
+        ],
+        Field(
+            description="Taxon of the species. Supported taxa are: archaea, bacteria, fungi, invertebrate, metagenomes, plants, protozoa, unknown, vertebrate_mammalian, vertebrate_other, viral.",
+            default="vertebrate_mammalian",
+        ),
+    ]
+    species: Annotated[
+        str,
+        Field(description="Species of provided annotation in NCBI download format.", default="Homo_sapiens"),
+    ]
+    assembly_source: Annotated[
+        Literal["auto", "annotation_releases", "latest_assembly_versions", "reference"],
+        Field(
+            description="Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory. 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'. 'latest_assembly_version' directory is available for all species and contains the latest assembly. 'reference' directory contains the reference genome. This is only available for a subset of species. 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'",
+            default="auto",
+        ),
+    ]
+    annotation_release: Annotated[
+        str,
+        Field(
+            description="Release number of provided annotation (e.g., '109' or 'current'); use release number only with assembly_source=annotation_releases; otherwise set to 'current'",
+            default="current",
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def _check_supported_taxa_sources_and_annotation_release(self) -> Self:
+        available_sources = SUPPORTED_TAXA_SOURCES[self.taxon]
+        if self.assembly_source != "auto" and self.assembly_source not in available_sources:
+            supported_sources = ", ".join(sorted(available_sources))
+            raise ValidationError(
+                f"assembly_source '{self.assembly_source}' is not available for taxon '{self.taxon}'. "
+                f"Supported sources for this taxon are: {supported_sources}."
+            )
+        if self.annotation_release != "current" and (
+            self.assembly_source in {"latest_assembly_versions", "reference"}
+            or (self.assembly_source == "auto" and "annotation_releases" not in available_sources)
+        ):
+            raise ValidationError(
+                "A numeric annotation_release is only supported with assembly_source='annotation_releases'. "
+                "Use annotation_release='current' for latest_assembly_versions/reference."
+            )
+        return self
+
+
+class AnnotationNcbiSpecies(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Annotated[
+        Literal["ncbi"],
+        Field(
+            description="Indicate which annotation should be used. Possible values are 'ensembl', 'ncbi' or 'custom'."
+        ),
+    ]
+
+    mode: Annotated[
+        Literal["species"],
+        Field(
+            description="How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'. For 'species', parameters needs the arguments 'taxon', 'species', 'assembly_source' and 'annotation_release'.  For 'assembly', parameters needs the arguments 'refseq_assembly_accession' and 'assembly_name'."
+        ),
+    ]
+
+    parameters: Annotated[
+        AnnotationParamsNcbiSpecies,
+        Field(
+            description="If a custom source, the metadata of the provided genome and annotation. If ensembl or ncbi, the parameters used to retrieve the genomic data."
+        ),
+    ]
+
+
+class AnnotationParamsNcbiAssembly(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    refseq_assembly_accession: Annotated[
+        str,
+        Field(
+            description="RefSeq assembly accession number (e.g., 'GCF_000001405.38') of the specified assembly.",
+            pattern=r"^(GCF)_(\d{9})\.(\d+)$",
+            default="GCF_000001405.38",
+        ),
+    ]
+    assembly_name: Annotated[
+        str, Field(description="Name (e.g., 'GRCh38.p12') of the specified assembly.", default="GRCh38.p12")
+    ]
+
+
+class AnnotationNcbiAssembly(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Annotated[
+        Literal["ncbi"],
+        Field(
+            description="Indicate which annotation should be used. Possible values are 'ensembl', 'ncbi' or 'custom'."
+        ),
+    ]
+
+    mode: Annotated[
+        Literal["assembly"],
+        Field(
+            description="How do you want to specify which genome you want to use? Possible values are 'species' and 'assembly'."
+        ),
+    ]
+
+    parameters: Annotated[
+        AnnotationParamsNcbiAssembly,
+        Field(
+            description="If a custom source, the metadata of the provided genome and annotation. If ensembl or ncbi, the parameters used to retrieve the genomic data."
+        ),
+    ]
+
+
+AnnotationNcbi = Annotated[AnnotationNcbiSpecies | AnnotationNcbiAssembly, Field(discriminator="mode")]
+
+
+class AnnotationCustom(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Annotated[
+        Literal["custom"],
+        Field(
+            description="Indicate which annotation should be used. Possible values are 'ensembl', 'ncbi' or 'custom'."
+        ),
+    ]
+    parameters: Annotated[
+        AnnotationParamsCustom,
+        Field(
+            description="If a custom source, the metadata of the provided genome and annotation. If ensembl or ncbi, the parameters used to retrieve the genomic data."
+        ),
+    ]
+
+
+class AnnotationEnsembl(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Annotated[
+        Literal["ensembl"],
+        Field(
+            description="Indicate which annotation should be used. Possible values are 'ensembl', 'ncbi' or 'custom'."
+        ),
+    ]
+    parameters: Annotated[
+        AnnotationParamsEnsembl,
+        Field(
+            description="If a custom source, the metadata of the provided genome and annotation. If ensembl or ncbi, the parameters used to retrieve the genomic data."
+        ),
+    ]
+
+
+AnnotationConfigs = Annotated[
+    AnnotationCustom | AnnotationEnsembl | AnnotationNcbi, Field(discriminator="source")
+]
+
+
+class GenomicRegionGeneratorConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal[2] = 2
+    dir_output: str | None = Field(description="Name of the directory where the output files will be written")
+    annotation: Annotated[AnnotationConfigs, Field(description="Parameters for genome and gene annotation.")]
+    genomic_regions: Annotated[
+        GenomicRegions,
+        Field(
+            description="List of genomic regions that should be generated, set the genomic regions you want to generate to true."
+        ),
+    ]
+    exon_exon_junction_block_size: PositiveInt | None = Field(
+        description="If exon_exon_junction is set to true, specify the block size, i.e. +/- 'block_size' bp around the junction. It does not make sense to set the block size larger than the maximum oligo length",
+        default=50,
+    )
+
+    @model_validator(mode="after")
+    def _default_dir_output(self) -> Self:
+        # The dir_output won't be rendered in odt-cloud, because there it is not set by the user, so a validator-derived default is fine here.
+        if self.dir_output is None:
+            self.dir_output = f"output_genomic_region_generator_{self.annotation.source}"
+        return self
+
+    @model_validator(mode="after")
+    def _check_exon_exon_junction_block_size(self) -> Self:
+        if self.exon_exon_junction_block_size is None:
+            raise ValidationError(
+                "exon_exon_junction_block_size must be set if exon_exon_junction is set to True."
+            )
+        return self

--- a/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
@@ -46,8 +46,6 @@ class GenomicRegionGenerator:
         """
         Loads annotations from the specified source (NCBI, Ensembl, or custom files).
 
-        :param source: The source of the annotations. Options: 'ncbi', 'ensembl', 'custom'.
-        :type source: str
         :param annotation: Parameters required for loading the annotations depending on the source.
             It needs to include the keys 'source' and 'parameters'.
             If source is 'ncbi', it additionally must contain the key 'mode'.
@@ -79,14 +77,17 @@ class GenomicRegionGenerator:
             if annotation["mode"] is None:
                 raise ConfigurationError("For source='ncbi', annotation parameter 'mode' must be provided.")
             # dowload the fasta files formthe NCBI server
+            # use get syntax for the parameters because depending on the mode,
+            # they can be missing because they are not needed for the selected source
+            # therefore, return None in this case
             region_generator = NcbiGenomicRegionGenerator(
                 mode=annotation["mode"],
-                taxon=annotation["parameters"]["taxon"],
-                species=annotation["parameters"]["species"],
-                annotation_release=annotation["parameters"]["annotation_release"],
-                assembly_source=annotation["parameters"]["assembly_source"],
-                refseq_assembly_accession=annotation["parameters"]["refseq_assembly_accession"],
-                assembly_name=annotation["parameters"]["assembly_name"],
+                taxon=annotation.get("parameters", {}).get("taxon"),
+                species=annotation.get("parameters", {}).get("species"),
+                annotation_release=annotation.get("parameters", {}).get("annotation_release"),
+                assembly_source=annotation.get("parameters", {}).get("assembly_source"),
+                refseq_assembly_accession=annotation.get("parameters", {}).get("refseq_assembly_accession"),
+                assembly_name=annotation.get("parameters", {}).get("assembly_name"),
                 dir_output=self.dir_output,
             )
         elif annotation["source"] == "ensembl":
@@ -197,7 +198,7 @@ def main() -> None:
     try:
         config_validated = GenomicRegionGeneratorConfig.model_validate(config_raw)
     except ValidationError as e:
-        print("Invalid configuration file:\n%s", e)
+        print(f"Invalid configuration file:\n{e}")
         raise
 
     config = config_validated.model_dump()

--- a/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/pipelines/_genomic_region_generator.py
@@ -7,8 +7,10 @@ import os
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from oligo_designer_toolsuite._exceptions import ConfigurationError
+from oligo_designer_toolsuite.config import GenomicRegionGeneratorConfig
 from oligo_designer_toolsuite.pipelines._utils import base_log_parameters, base_parser
 from oligo_designer_toolsuite.sequence_generator import (
     CustomGenomicRegionGenerator,
@@ -39,23 +41,24 @@ class GenomicRegionGenerator:
 
     def load_annotations(
         self,
-        source: str,
-        source_params: dict,
+        annotation: dict,
     ) -> CustomGenomicRegionGenerator:
         """
         Loads annotations from the specified source (NCBI, Ensembl, or custom files).
 
         :param source: The source of the annotations. Options: 'ncbi', 'ensembl', 'custom'.
         :type source: str
-        :param source_params: Parameters required for loading the annotations depending on the source.
-            If source is 'ncbi', it must contain 'mode'. The remaining required keys depend on that mode:
+        :param annotation: Parameters required for loading the annotations depending on the source.
+            It needs to include the keys 'source' and 'parameters'.
+            If source is 'ncbi', it additionally must contain the key 'mode'.
+            The remaining required keys depend on that mode:
             for taxonomy/species-based modes, provide 'taxon', 'species', and 'annotation_release';
             for 'assembly' mode, provide the assembly identifier via 'refseq_assembly_accession' and/or
             'assembly_name'. 'assembly_source' may also be provided when applicable.
             If source is 'ensembl', it should contain 'species' and 'annotation_release'.
             If source is 'custom', it should contain 'file_annotation', 'file_sequence', 'files_source',
             'species', 'annotation_release', and 'genome_assembly'.
-        :type source_params: dict
+        :type annotation: dict
         :return: An instance of the corresponding region generator class based on the source.
         :rtype: CustomGenomicRegionGenerator
         """
@@ -72,43 +75,41 @@ class GenomicRegionGenerator:
         ) = None
 
         ##### loading annotations from different sources #####
-        if source == "ncbi":
-            if source_params["mode"] is None:
-                raise ConfigurationError(
-                    "For source='ncbi', source_params parameter 'mode' must be provided."
-                )
+        if annotation["source"] == "ncbi":
+            if annotation["mode"] is None:
+                raise ConfigurationError("For source='ncbi', annotation parameter 'mode' must be provided.")
             # dowload the fasta files formthe NCBI server
             region_generator = NcbiGenomicRegionGenerator(
-                mode=source_params["mode"],
-                taxon=source_params["taxon"],
-                species=source_params["species"],
-                annotation_release=source_params["annotation_release"],
-                assembly_source=source_params["assembly_source"],
-                refseq_assembly_accession=source_params["refseq_assembly_accession"],
-                assembly_name=source_params["assembly_name"],
+                mode=annotation["mode"],
+                taxon=annotation["parameters"]["taxon"],
+                species=annotation["parameters"]["species"],
+                annotation_release=annotation["parameters"]["annotation_release"],
+                assembly_source=annotation["parameters"]["assembly_source"],
+                refseq_assembly_accession=annotation["parameters"]["refseq_assembly_accession"],
+                assembly_name=annotation["parameters"]["assembly_name"],
                 dir_output=self.dir_output,
             )
-        elif source == "ensembl":
+        elif annotation["source"] == "ensembl":
             # dowload the fasta files formthe NCBI server
             region_generator = EnsemblGenomicRegionGenerator(
-                species=source_params["species"],
-                annotation_release=source_params["annotation_release"],
+                species=annotation["parameters"]["species"],
+                annotation_release=annotation["parameters"]["annotation_release"],
                 dir_output=self.dir_output,
             )
-        elif source == "custom":
+        elif annotation["source"] == "custom":
             # use already dowloaded files
             region_generator = CustomGenomicRegionGenerator(
-                annotation_file=source_params["file_annotation"],
-                sequence_file=source_params["file_sequence"],
-                files_source=source_params["files_source"],
-                species=source_params["species"],
-                annotation_release=source_params["annotation_release"],
-                genome_assembly=source_params["genome_assembly"],
+                annotation_file=annotation["parameters"]["file_annotation"],
+                sequence_file=annotation["parameters"]["file_sequence"],
+                files_source=annotation["parameters"]["files_source"],
+                species=annotation["parameters"]["species"],
+                annotation_release=annotation["parameters"]["annotation_release"],
+                genome_assembly=annotation["parameters"]["genome_assembly"],
                 dir_output=self.dir_output,
             )
         else:
             raise ConfigurationError(
-                f"Source '{source}' is not supported. Supported sources are: 'NCBI', 'Ensembl', or 'custom'."
+                f"Source '{annotation['source']}' is not supported. Supported sources are: 'NCBI', 'Ensembl', or 'custom'."
             )
 
         ##### save annotation information #####
@@ -179,7 +180,7 @@ def main() -> None:
     """
     Main function to execute the genomic region generation pipeline.
 
-    The pipeline reads a configuration file, initializes a `GenomicRegionGenerator`,
+    The pipeline reads a configuration file, validates it, initializes a `GenomicRegionGenerator`,
     loads annotations from the specified source, and generates genomic regions based on the provided configuration.
 
     :param args: Command-line arguments parsed using the base parser. The arguments include:
@@ -191,7 +192,15 @@ def main() -> None:
 
     # read the config file
     with open(args["config"], "r") as handle:
-        config = yaml.safe_load(handle)
+        config_raw = yaml.safe_load(handle)
+
+    try:
+        config_validated = GenomicRegionGeneratorConfig.model_validate(config_raw)
+    except ValidationError as e:
+        print("Invalid configuration file:\n%s", e)
+        raise
+
+    config = config_validated.model_dump()
 
     pipeline = GenomicRegionGenerator(dir_output=config["dir_output"])
 
@@ -204,8 +213,7 @@ def main() -> None:
 
     # generate the genomic regions
     region_generator = pipeline.load_annotations(
-        source=config["source"],
-        source_params=config["source_params"],
+        annotation=config["annotation"],
     )
 
     files_fasta = pipeline.generate_genomic_regions(

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -1150,7 +1150,7 @@ def main() -> None:
     try:
         config_validated = OligoSeqProbeDesignerConfig.model_validate(config_raw)
     except ValidationError as e:
-        print("Invalid configuration file:\n%s", e)
+        print(f"Invalid configuration file:\n{e}")
         raise
 
     # setup logger

--- a/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
+++ b/oligo_designer_toolsuite/sequence_generator/_ftp_loader.py
@@ -262,9 +262,9 @@ class FtpLoaderNCBI(BaseFtpLoader):
     UNSUPPORTED_TAXA: set[str] = {"mitochondrion", "plasmids", "plastid"}
     # Determines how the assembly for a species is selected from the possible sources within the NCBI FTP directory.
     # 'annotation_releases' directory, should exist for all eukaryotic species and contains assemblies annotated with different annotation versions and the annotation version can be specified by 'annotation_release'.
-    # 'latest_assembly_version' directory is available for all species and contains the latest assembly.
+    # 'latest_assembly_versions' directory is available for all species and contains the latest assembly.
     # 'reference' directory contains the reference genome. This is only available for a subset of species.
-    # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_version'
+    # 'auto' automatically selects an assembly source in the following order (if available): 'annotation_releases', 'latest_assembly_versions'
     ALLOWED_ASSEMBLY_SOURCES: set[str] = {
         "auto",
         "annotation_releases",

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -1358,7 +1358,7 @@ class EnsemblGenomicRegionGenerator(CustomGenomicRegionGenerator):
         dir_output: str = "output",
     ) -> None:
         """Constructor for the EnsemblGenomicRegionGenerator class."""
-        files_source = "Ensemble"
+        files_source = "Ensembl"
         if species is None:
             species = "homo_sapiens"
             logger.warning(f"No species defined. Using default species {species}!")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,11 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
+from oligo_designer_toolsuite.config.pipelines.genomic_region_generator import (
+    AnnotationNcbiAssembly,
+    AnnotationNcbiSpecies,
+    GenomicRegionGeneratorConfig,
+)
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 
 _CONFIGS = Path("data/configs")
@@ -51,3 +56,160 @@ class TestOligoSeqYaml(unittest.TestCase):
         schema = OligoSeqProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "OligoSeqProbeDesignerConfig"
         assert "target_probe" in schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# GenomicRegionGeneratorConfig
+# ---------------------------------------------------------------------------
+
+
+class TestGenomicRegionGeneratorYaml(unittest.TestCase):
+    _FILES = {
+        "custom": "genomic_region_generator_custom.yaml",
+        "ensembl": "genomic_region_generator_ensembl.yaml",
+        "ncbi": "genomic_region_generator_ncbi.yaml",
+    }
+
+    def _cfg(self, source: str) -> GenomicRegionGeneratorConfig:
+        return GenomicRegionGeneratorConfig.model_validate(_load(self._FILES[source]))
+
+    def _ncbi_raw(self, **param_overrides: str) -> dict:
+        raw = _load(self._FILES["ncbi"])
+        raw["annotation"]["parameters"].update(param_overrides)
+        return raw
+
+    def test_parses_custom(self) -> None:
+        cfg = self._cfg("custom")
+        assert cfg.schema_version == 2
+        assert cfg.annotation.source == "custom"
+        assert cfg.annotation.parameters.file_annotation.endswith(".gtf")
+        assert cfg.genomic_regions.gene is True
+
+    def test_parses_ensembl(self) -> None:
+        cfg = self._cfg("ensembl")
+        assert cfg.schema_version == 2
+        assert cfg.annotation.source == "ensembl"
+        assert cfg.annotation.parameters.species == "homo_sapiens"
+        assert cfg.genomic_regions.exon is True
+
+    def test_parses_ncbi(self) -> None:
+        cfg = self._cfg("ncbi")
+        assert cfg.schema_version == 2
+        assert cfg.annotation.source == "ncbi"
+        assert cfg.annotation.mode == "species"
+        assert cfg.annotation.parameters.taxon == "vertebrate_mammalian"
+        assert cfg.annotation.parameters.assembly_source == "auto"
+
+    def test_round_trip_custom(self) -> None:
+        cfg = self._cfg("custom")
+        cfg2 = GenomicRegionGeneratorConfig.model_validate(cfg.model_dump())
+        assert cfg == cfg2
+
+    def test_round_trip_ensembl(self) -> None:
+        cfg = self._cfg("ensembl")
+        cfg2 = GenomicRegionGeneratorConfig.model_validate(cfg.model_dump())
+        assert cfg == cfg2
+
+    def test_round_trip_ncbi(self) -> None:
+        cfg = self._cfg("ncbi")
+        cfg2 = GenomicRegionGeneratorConfig.model_validate(cfg.model_dump())
+        assert cfg == cfg2
+
+    def test_unknown_top_level_field_forbidden_custom(self) -> None:
+        raw = _load(self._FILES["custom"])
+        raw["bogus"] = 1
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)
+
+    def test_unknown_top_level_field_forbidden_ensembl(self) -> None:
+        raw = _load(self._FILES["ensembl"])
+        raw["bogus"] = 1
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)
+
+    def test_unknown_top_level_field_forbidden_ncbi(self) -> None:
+        raw = _load(self._FILES["ncbi"])
+        raw["bogus"] = 1
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)
+
+    def test_json_schema(self) -> None:
+        # The JSON schema does not vary by pipeline; assert the model shape and
+        # that the annotation discriminated union exposes all three source branches.
+        schema = GenomicRegionGeneratorConfig.model_json_schema()
+        assert schema["title"] == "GenomicRegionGeneratorConfig"
+        for field in ("annotation", "genomic_regions", "dir_output", "exon_exon_junction_block_size"):
+            assert field in schema["properties"]
+        sources = {
+            defn["properties"]["source"]["const"]
+            for defn in schema["$defs"].values()
+            if "properties" in defn
+            and "source" in defn["properties"]
+            and "const" in defn["properties"]["source"]
+        }
+        assert {"custom", "ensembl", "ncbi"} <= sources
+
+    def test_source_discriminator_selects_ncbi_species(self) -> None:
+        cfg = self._cfg("ncbi")
+        assert cfg.annotation.source == "ncbi"
+        assert cfg.annotation.mode == "species"
+        assert hasattr(cfg.annotation.parameters, "taxon")
+
+    def test_ncbi_assembly_mode_parses(self) -> None:
+        raw = _load(self._FILES["ncbi"])
+        raw["annotation"]["mode"] = "assembly"
+        raw["annotation"]["parameters"] = {
+            "refseq_assembly_accession": "GCF_000001405.38",
+            "assembly_name": "GRCh38.p12",
+        }
+        cfg = GenomicRegionGeneratorConfig.model_validate(raw)
+        assert isinstance(cfg.annotation, AnnotationNcbiAssembly)
+        assert cfg.annotation.mode == "assembly"
+        assert cfg.annotation.parameters.assembly_name == "GRCh38.p12"
+
+    def test_dir_output_default_derived(self) -> None:
+        for source in self._FILES:
+            raw = _load(self._FILES[source])
+            raw["dir_output"] = None
+            cfg = GenomicRegionGeneratorConfig.model_validate(raw)
+            assert cfg.dir_output == f"output_genomic_region_generator_{source}"
+
+    # --- test cross-field validators
+
+    def test_assembly_source_not_available_for_taxon(self) -> None:
+        # bacteria supports only {latest_assembly_versions, reference}
+        raw = self._ncbi_raw(taxon="bacteria", assembly_source="annotation_releases")
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)
+
+    def test_numeric_release_requires_annotation_releases(self) -> None:
+        raw = self._ncbi_raw(
+            taxon="vertebrate_mammalian",
+            assembly_source="latest_assembly_versions",
+            annotation_release="110",
+        )
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)
+
+    def test_numeric_release_auto_without_annotation_releases(self) -> None:
+        # viral supports only {latest_assembly_versions}, so auto cannot use a numeric release
+        raw = self._ncbi_raw(taxon="viral", assembly_source="auto", annotation_release="110")
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)
+
+    def test_annotation_releases_with_numeric_release_ok(self) -> None:
+        raw = self._ncbi_raw(
+            taxon="vertebrate_mammalian",
+            assembly_source="annotation_releases",
+            annotation_release="110",
+        )
+        cfg = GenomicRegionGeneratorConfig.model_validate(raw)
+        assert isinstance(cfg.annotation, AnnotationNcbiSpecies)
+        assert cfg.annotation.parameters.annotation_release == "110"
+
+    def test_block_size_none_rejected(self) -> None:
+        # ncbi config has exon_exon_junction=True, so a null block size must be rejected.
+        raw = _load(self._FILES["ncbi"])
+        raw["exon_exon_junction_block_size"] = None
+        with self.assertRaises(ValidationError):
+            GenomicRegionGeneratorConfig.model_validate(raw)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import yaml
 
+from oligo_designer_toolsuite.config.pipelines.genomic_region_generator import GenomicRegionGeneratorConfig
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 
 ############################################
@@ -89,8 +90,8 @@ class PipelinesBase(unittest.TestCase, ABC):
 class TestGenomicRegionGenerator(PipelinesBase, unittest.TestCase):
     def setup_output_dir(self) -> Any:
         with open(CONFIG_GENOMIC_REGION_GENERATOR, "r") as handle:
-            config = yaml.safe_load(handle)
-        dir_output = config.get("dir_output")
+            config = GenomicRegionGeneratorConfig(**yaml.safe_load(handle))
+        dir_output = config.dir_output
         if dir_output is None:
             return tempfile.mkdtemp()
         return os.path.abspath(dir_output)


### PR DESCRIPTION
This PR adds pydantic input validation for the GenomicRegionGenerator. I had to make some tradeoffs compared with the other pipelines:

- because GenomicRegionGenerator can be used with all 3 YAML files for custom/ensembl/ncbi, the pydantic model doesn't exactly mirrors the different defaults used in the 3 different YAML files, but tries to unify it a bit
- especially for genomic_regions, the model provides only exon=True
- this means that the pydantic model can easily be used to validate the existing YAML files, but can't directly reproduce the values in the current existing YAML files in case we want to generate them automatically from the pydantic model
- dir_output is checked with a model_validator, this cannot directly be replicated in the schema for the UI, but shouldn't be needed as it won't be shown in the UI
- exon_exon_junction_block_size is not integrated with a discriminated union to only be shown when exon_exon_junction=True because then it would need to be directly integrated in genomic_regions and change how the genomic_regions dict is shown in the UI and how it is used later on in the pipeline. Therefore, it will always be shown with the default of 50 in the UI

closes #218 