### PR TITLE
feat: integrate BedParser for BED file handling in OligoDatabase and …

### DIFF
--- a/oligo_designer_toolsuite/database/_oligo_database.py
+++ b/oligo_designer_toolsuite/database/_oligo_database.py
@@ -19,6 +19,7 @@ from joblib_progress import joblib_progress
 from oligo_designer_toolsuite._constants import SEPARATOR_OLIGO_ID
 from oligo_designer_toolsuite._exceptions import DatabaseError, FileFormatError
 from oligo_designer_toolsuite.utils import (
+    BedParser,
     CustomYamlDumper,
     FastaParser,
     cast_to_list,
@@ -89,6 +90,7 @@ class OligoDatabase:
         self._dir_cache_files = safe_append_filename(self.dir_output, "cache_files")
 
         self.fasta_parser = FastaParser()
+        self.bed_parser = BedParser()
 
         # Initialize databse object
         backend = PickleBackend(storage_path=self._dir_cache_files)
@@ -540,6 +542,9 @@ class OligoDatabase:
         which can be used for downstream analysis. Entries which contain None for either
         chromosome, start, end or strand will be removed before the content is written to BED file.
 
+        Coordinates stored in the database (and in region-generator FASTA headers) are 1-based.
+        BED requires 0-based starts, so starts are converted before writing.
+
         :param filename: Name of the output BED file (without extension). Default is "db_oligo".
         :type filename: str
         :param dir_output: Directory path where output files will be saved.
@@ -572,10 +577,14 @@ class OligoDatabase:
             ["chromosome", "start", "end", "strand"], ignore_index=True
         )
         property_table_extended["score"] = "."
+        property_table_extended["start"] = self.bed_parser.convert_start(
+            property_table_extended["start"], "1-based", "0-based"
+        )
 
-        # save tabel content as BED file
-        property_table_extended[["chromosome", "start", "end", "oligo_id", "score", "strand"]].to_csv(
-            file_bed, sep="\t", header=False, index=False
+        self.bed_parser.write_bed(
+            property_table_extended,
+            file_bed,
+            columns=["chromosome", "start", "end", "oligo_id", "score", "strand"],
         )
 
         return file_bed

--- a/oligo_designer_toolsuite/oligo_property_calculator/_property_calculator.py
+++ b/oligo_designer_toolsuite/oligo_property_calculator/_property_calculator.py
@@ -9,7 +9,7 @@ from joblib_progress import joblib_progress
 
 from oligo_designer_toolsuite.database import OligoDatabase
 from oligo_designer_toolsuite.oligo_property_calculator import BaseProperty
-from oligo_designer_toolsuite.utils import check_if_key_in_database
+from oligo_designer_toolsuite.utils import cast_to_list, check_if_key_in_database
 
 ############################################
 # Property Calculator Class
@@ -31,15 +31,27 @@ class PropertyCalculator:
         """Constructor for the PropertyCalculator class."""
         self.properties = properties
 
-    def apply(self, oligo_database: OligoDatabase, sequence_type: str, n_jobs: int = 1) -> OligoDatabase:
+    def apply(
+        self,
+        oligo_database: OligoDatabase,
+        sequence_type: str,
+        region_ids: str | list[str] | None = None,
+        n_jobs: int = 1,
+    ) -> OligoDatabase:
         """
-        Apply the property calculators to all oligonucleotides in the OligoDatabase and update
+        Apply the property calculators to oligonucleotides in the OligoDatabase and update
         the database with the calculated property values.
+
+        By default all regions are processed. Pass ``region_ids`` to limit calculation to one
+        or more regions.
 
         :param oligo_database: The OligoDatabase instance containing oligonucleotide sequences and their associated properties. This database stores oligo data organized by genomic regions and can be used for filtering, property calculations, set generation, and output operations.
         :type oligo_database: OligoDatabase
         :param sequence_type: Type of sequence being processed.
         :type sequence_type: str
+        :param region_ids: If provided, only oligos in these regions are processed. Can be a single region ID (str)
+                           or a list of region IDs (list[str]). Otherwise all regions are processed.
+        :type region_ids: str | list[str] | None
         :param n_jobs: Number of parallel jobs to use for processing. Defaults to 1.
         :type n_jobs: int
         :return: The updated OligoDatabase with the calculated properties.
@@ -49,7 +61,9 @@ class PropertyCalculator:
             oligo_database.database, sequence_type
         ), f"Sequence type '{sequence_type}' not found in database."
 
-        region_ids = list(oligo_database.database.keys())
+        region_ids = (
+            cast_to_list(region_ids) if region_ids is not None else list(oligo_database.database.keys())
+        )
         with joblib_progress(description="Property Calculator", total=len(region_ids)):
             Parallel(n_jobs=n_jobs, prefer="threads", require="sharedmem")(
                 delayed(self._calculate_region)(oligo_database, region_id, sequence_type)

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -732,7 +732,10 @@ class BlastNSeedregionFilter(BlastNSeedregionFilterBase):
         ]
         calculator = PropertyCalculator(properties=properties)
         oligo_database = calculator.apply(
-            oligo_database=oligo_database, sequence_type=self.sequence_type, n_jobs=1
+            oligo_database=oligo_database,
+            sequence_type=self.sequence_type,
+            region_ids=region_id,
+            n_jobs=1,
         )
 
         seedregion = oligo_database.get_oligo_property_table(
@@ -848,7 +851,10 @@ class BlastNSeedregionSiteFilter(BlastNSeedregionFilterBase):
         ]
         calculator = PropertyCalculator(properties=properties)
         oligo_database = calculator.apply(
-            oligo_database=oligo_database, sequence_type=self.sequence_type, n_jobs=1
+            oligo_database=oligo_database,
+            sequence_type=self.sequence_type,
+            region_ids=region_id,
+            n_jobs=1,
         )
 
         seedregion = oligo_database.get_oligo_property_table(

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -233,27 +233,6 @@ class CustomGenomicRegionGenerator:
         :rtype: str
         """
 
-        def _get_chromosome_length() -> str:
-            """
-            Write chromosome lengths from the genome FASTA to a chrom.sizes file.
-
-            The file is used by bedtools when finding regions outside annotated
-            genes. Each line is ``seqid`` and length, tab-separated, with no header.
-
-            :return: Path to the chromosome-length file.
-            :rtype: str
-            """
-            chromosome_lengths = {}
-            for rec in SeqIO.parse(self.sequence_file, "fasta"):
-                chromosome_lengths[rec.id] = len(rec.seq)
-
-            file_chromosome_length = os.path.join(self.dir_output, "annotation.genome")
-            with open(file_chromosome_length, "w") as handle:
-                for key, value in sorted(chromosome_lengths.items()):
-                    handle.write(f"{key}\t{value}\n")
-
-            return file_chromosome_length
-
         def _compute_intergenic_annotation(
             annotation: pd.DataFrame, file_chromosome_length: str
         ) -> pd.DataFrame:
@@ -386,7 +365,7 @@ class CustomGenomicRegionGenerator:
             return intergenic_annotation
 
         # save chromosome sizes as genome file
-        file_chromosome_length = _get_chromosome_length()
+        file_chromosome_length = self._get_chromosome_length()
 
         # get gene annotation entries
         annotation = self._load_annotation()
@@ -1085,6 +1064,27 @@ class CustomGenomicRegionGenerator:
         del annotation
 
         return file_fasta
+
+    def _get_chromosome_length(self) -> str:
+        """
+        Write chromosome lengths from the genome FASTA to a chrom.sizes file.
+
+        The file is used by bedtools when finding regions outside annotated
+        genes. Each line is ``seqid`` and length, tab-separated, with no header.
+
+        :return: Path to the chromosome-length file.
+        :rtype: str
+        """
+        chromosome_lengths = {}
+        for rec in SeqIO.parse(self.sequence_file, "fasta"):
+            chromosome_lengths[rec.id] = len(rec.seq)
+
+        file_chromosome_length = os.path.join(self.dir_output, "annotation.genome")
+        with open(file_chromosome_length, "w") as handle:
+            for key, value in sorted(chromosome_lengths.items()):
+                handle.write(f"{key}\t{value}\n")
+
+        return file_chromosome_length
 
     def _load_annotation(self) -> pd.DataFrame:
         """

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -55,11 +55,17 @@ class CustomGenomicRegionGenerator:
     labels. Region extractors (gene, exon, intron, CDS, UTR, intergenic, exon-exon junction)
     write one FASTA file per region type.
 
-    Each sequence header starts with ``>`` and holds region ID, optional metadata, and
-    coordinates (chromosome, start, end, strand). Coordinates in the header are 1-based.
-    The region ID is required; other fields are optional.
+    Coordinate indexing:
 
-    Output Format (per sequence)::
+    Annotation files (GFF/GTF) use 1-based starts. Sequence extraction writes temporary
+    BED files, which use 0-based starts. FASTA headers written by this class also use
+    1-based starts so they stay aligned with the annotation.
+
+    Each sequence header starts with ``>`` and holds region ID, optional metadata, and
+    coordinates (chromosome, start, end, strand). The region ID is required; other
+    fields are optional.
+
+    Output Format (per sequence):
 
         >{region_id}::{additional information}::{chromosome}:{start}-{end}({strand})
         sequence
@@ -158,10 +164,10 @@ class CustomGenomicRegionGenerator:
         Build FASTA sequences for gene intervals from gene annotations.
 
         Loads gene features from the annotation, labels each with source and gene ID
-        metadata, and writes the sequences to a FASTA file. Coordinates in the FASTA
-        header are 1-based; BED used for extraction uses 0-based starts.
+        metadata, and writes the sequences to a FASTA file. FASTA headers use
+        1-based coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{gene_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id}
@@ -188,7 +194,7 @@ class CustomGenomicRegionGenerator:
         )
         annotation["region"] = self._get_annotation_region(annotation)
 
-        # add BED12 fields
+        # BED12 fields: start must be 0-based for BED sequence extraction.
         annotation["start"] = annotation["start_0base"]
         annotation["score"] = 0
         annotation["fasta_header"] = (
@@ -214,10 +220,10 @@ class CustomGenomicRegionGenerator:
 
         For each chromosome, gaps between genes are taken separately on the plus
         and minus strands. Chromosome lengths come from the genome FASTA. The
-        resulting intervals are written to a FASTA file. Coordinates in the FASTA
-        header are 1-based; BED used for extraction uses 0-based starts.
+        resulting intervals are written to a FASTA file. FASTA headers use
+        1-based coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{intergenic_region_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype}::{chromosome}:{start}-{end}({strand})
@@ -279,7 +285,7 @@ class CustomGenomicRegionGenerator:
                 intergenic_annotation.append(
                     _compute_intergenic_annotation_strand(
                         seqid=seqid,
-                        gene_annotatio=gene_annotation_plusstrand,
+                        gene_annotation=gene_annotation_plusstrand,
                         strand="+",
                         file_chromosome_length=file_chromosome_length,
                     )
@@ -287,7 +293,7 @@ class CustomGenomicRegionGenerator:
                 intergenic_annotation.append(
                     _compute_intergenic_annotation_strand(
                         seqid=seqid,
-                        gene_annotatio=gene_annotation_minusstrand,
+                        gene_annotation=gene_annotation_minusstrand,
                         strand="-",
                         file_chromosome_length=file_chromosome_length,
                     )
@@ -297,7 +303,7 @@ class CustomGenomicRegionGenerator:
             return intergenic_annotation_df
 
         def _compute_intergenic_annotation_strand(
-            seqid: str, gene_annotatio: pd.DataFrame, strand: str, file_chromosome_length: str
+            seqid: str, gene_annotation: pd.DataFrame, strand: str, file_chromosome_length: str
         ) -> pd.DataFrame:
             """
             Find intergenic intervals on one chromosome and strand.
@@ -308,8 +314,8 @@ class CustomGenomicRegionGenerator:
 
             :param seqid: Chromosome or sequence name.
             :type seqid: str
-            :param gene_annotatio: Gene intervals on this chromosome and strand.
-            :type gene_annotatio: pd.DataFrame
+            :param gene_annotation: Gene intervals on this chromosome and strand.
+            :type gene_annotation: pd.DataFrame
             :param strand: Strand to process (``+`` or ``-``).
             :type strand: str
             :param file_chromosome_length: Path to the chrom.sizes file with sequence lengths.
@@ -320,7 +326,7 @@ class CustomGenomicRegionGenerator:
             """
 
             # case 1: no annotated genes on the respective chromosome and strand
-            if gene_annotatio.empty:
+            if gene_annotation.empty:
                 chromosome_length = pd.read_csv(
                     file_chromosome_length, sep="\t", header=None, names=["seqid", "length"]
                 )
@@ -330,6 +336,7 @@ class CustomGenomicRegionGenerator:
                     region_id_name = "InterRegMinus"
                 else:
                     raise ConfigurationError(f"Invalid strand value: '{strand}'. Expected '+' or '-'.")
+                # Whole chromosome is intergenic: BED start 0, header start 1.
                 intergenic_annotation = pd.DataFrame(
                     {
                         "seqid": seqid,
@@ -348,8 +355,8 @@ class CustomGenomicRegionGenerator:
                 file_bed_out = os.path.join(self.dir_output, "annotation_out.bed")
 
                 # save the annotation as bed file
-                gene_annotatio = gene_annotatio.sort_values(by="start")
-                self.bed_parser.write_bed(gene_annotatio, file_bed_in)
+                gene_annotation = gene_annotation.sort_values(by="start")
+                self.bed_parser.write_bed(gene_annotation, file_bed_in)
 
                 # get complementary regions
                 get_complement_regions(file_bed_in, file_chromosome_length, file_bed_out)
@@ -358,6 +365,7 @@ class CustomGenomicRegionGenerator:
                 intergenic_annotation = self.bed_parser.read_bed(
                     file_bed_out, names=["seqid", "start_0base", "end"]
                 )
+                # bedtools complement returns BED (0-based); convert for FASTA headers.
                 intergenic_annotation["start_1base"] = self.bed_parser.convert_start(
                     intergenic_annotation["start_0base"], "0-based", "1-based"
                 )
@@ -395,7 +403,7 @@ class CustomGenomicRegionGenerator:
         )
         annotation["region"] = self._get_annotation_region(annotation)
 
-        # add BED12 fields
+        # BED12 fields: start must be 0-based for BED sequence extraction.
         annotation["start"] = annotation["start_0base"]
         annotation["score"] = 0
         annotation["fasta_header"] = (
@@ -424,10 +432,9 @@ class CustomGenomicRegionGenerator:
 
         Optionally merges exons that share the same start and end but come from
         different transcripts. FASTA headers include transcript IDs, exon numbers,
-        and the total transcript count per gene. Coordinates in the FASTA header
-        are 1-based; BED used for extraction uses 0-based starts.
+        and the total transcript count per gene. Headers use 1-based coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{gene_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
@@ -462,7 +469,7 @@ class CustomGenomicRegionGenerator:
         # add transcript counts for each gene
         annotation, annotation_transcript_inf = self._add_transcript_counts(annotation)
 
-        # add BED12 fields
+        # BED12 fields: start must be 0-based for BED sequence extraction.
         annotation["start"] = annotation["start_0base"]
         annotation["score"] = 0
         annotation["fasta_header"] = (
@@ -497,10 +504,9 @@ class CustomGenomicRegionGenerator:
         Introns are the gaps between consecutive exons within each transcript.
         Optionally merges introns that share the same start and end but come from
         different transcripts. FASTA headers include transcript IDs and intron
-        numbers. Coordinates in the FASTA header are 1-based; BED used for
-        extraction uses 0-based starts.
+        numbers. Headers use 1-based coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{gene_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
@@ -606,7 +612,7 @@ class CustomGenomicRegionGenerator:
         if collapse_duplicated_regions:
             annotation = self._collapse_duplicated_regions(annotation)
 
-        # add BED12 fields
+        # BED12 fields: start must be 0-based for BED sequence extraction.
         annotation["start"] = annotation["start_0base"]
         annotation["score"] = 0
         annotation["fasta_header"] = (
@@ -640,10 +646,10 @@ class CustomGenomicRegionGenerator:
 
         Optionally merges CDS intervals that share the same start and end but come
         from different transcripts. FASTA headers include transcript IDs, exon
-        numbers, and the total transcript count per gene. Coordinates in the FASTA
-        header are 1-based; BED used for extraction uses 0-based starts.
+        numbers, and the total transcript count per gene. Headers use 1-based
+        coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{gene_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
@@ -677,7 +683,7 @@ class CustomGenomicRegionGenerator:
         # add transcript counts for each gene
         annotation, annotation_transcript_inf = self._add_transcript_counts(annotation)
 
-        # add BED12 fields
+        # BED12 fields: start must be 0-based for BED sequence extraction.
         annotation["start"] = annotation["start_0base"]
         annotation["score"] = 0
         annotation["fasta_header"] = (
@@ -717,10 +723,9 @@ class CustomGenomicRegionGenerator:
         Derives 5' and/or 3' untranslated regions from exon spans outside the CDS
         boundaries of each transcript. Use ``five_prime`` and ``three_prime`` to
         choose which ends to keep. Optionally merges UTRs with identical coordinates.
-        Coordinates in the FASTA header are 1-based; BED used for extraction uses
-        0-based starts.
+        FASTA headers use 1-based coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{gene_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
@@ -778,6 +783,7 @@ class CustomGenomicRegionGenerator:
                 UTR_right = copy.deepcopy(exons)
                 UTR_right = UTR_right[UTR_right.end > cds_end]
                 UTR_right.type = UTR_right_type
+                # Keep 1-based and 0-based starts aligned when trimming to the CDS edge.
                 UTR_right.loc[UTR_right["start_1base"] <= cds_end, "start_1base"] = cds_end + 1
                 UTR_right.loc[(UTR_right["start_0base"] + 1) <= cds_end, "start_0base"] = cds_end
                 utrs.append(UTR_right)
@@ -822,7 +828,7 @@ class CustomGenomicRegionGenerator:
         # add transcript counts for each gene
         annotation, annotation_transcript_inf = self._add_transcript_counts(annotation)
 
-        # add BED12 fields
+        # BED12 fields: start must be 0-based for BED sequence extraction.
         annotation["start"] = annotation["start_0base"]
         annotation["score"] = 0
         annotation["fasta_header"] = (
@@ -864,10 +870,10 @@ class CustomGenomicRegionGenerator:
         For consecutive exons in a transcript, takes ``block_size`` bases on each
         side of the junction (or the full exon if shorter). Optionally merges
         junctions with identical coordinates from different transcripts. FASTA
-        headers include transcript IDs and joined exon numbers. Coordinates in
-        the FASTA header are 1-based; BED used for extraction uses 0-based starts.
+        headers include transcript IDs and joined exon numbers. Headers use
+        1-based coordinates.
 
-        Output Format (per sequence)::
+        Output Format (per sequence):
 
             >{gene_id}::source={source};species={species};annotation_release={annotation_release};
             genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
@@ -973,7 +979,7 @@ class CustomGenomicRegionGenerator:
                                     for attributes in exons_small
                                 ]
                             )
-                        # return region in 1-base offset
+                        # Header coords are 1-based; start_up/end_down below stay 0-based for BED.
                         region_up = f"{seqid}:{start_up + 1}-{start_up+block_size_up}({strand})"
                         region_down = f"{seqid}:{(end_down-block_size_down) + 1}-{end_down}({strand})"
                         junction_list.append(
@@ -1047,7 +1053,7 @@ class CustomGenomicRegionGenerator:
         # add transcript counts for each gene
         annotation, annotation_transcript_inf = self._add_transcript_counts(annotation)
 
-        # add BED12 fields
+        # BED12 fields: junction "start" is already 0-based from the exon walk above.
         annotation["score"] = 0
         annotation["thickStart"] = annotation["start"]
         annotation["thickEnd"] = annotation["end"]
@@ -1085,20 +1091,19 @@ class CustomGenomicRegionGenerator:
         Load the parsed GFF annotation and add 0-based and 1-based start columns.
 
         Reads the pickled annotation written at construction time. GFF starts are
-        1-based; a matching 0-based start column is added for BED-style extraction.
+        1-based and kept as ``start_1base`` for FASTA headers. A matching
+        ``start_0base`` column is added for BED-style sequence extraction.
 
         :return: Annotation table with ``start_1base`` and ``start_0base`` columns.
         :rtype: pd.DataFrame
         """
-        # read annotation file and store in dataframe
         annotation: pd.DataFrame = self.gff_parser.load_annotation_from_pickle(self.parsed_annotation_file)
 
-        # required to ensure that sorting is done correctly
+        # Required so numeric sorting of genomic coordinates is correct.
         annotation.start = annotation.start.astype("int")
         annotation.end = annotation.end.astype("int")
 
-        # add both annotations to dataframe: GFF 1-base offset and BED 0-base offset
-        # since we read in a GFF file, the start coordinates are 1-base offset
+        # GFF starts are 1-based; keep both so headers and BED extraction stay aligned.
         annotation.rename(columns={"start": "start_1base"}, inplace=True)
         annotation["start_0base"] = annotation.start_1base - 1
 
@@ -1195,7 +1200,7 @@ class CustomGenomicRegionGenerator:
         Format each annotation row as a 1-based coordinate string for FASTA headers.
 
         Builds ``seqid:start-end(strand)`` from ``seqid``, ``start_1base``, ``end``,
-        and ``strand``.
+        and ``strand``. Uses 1-based starts so the header matches GFF/GTF coordinates.
 
         :param annotation: Annotation rows with coordinate and strand columns.
         :type annotation: pd.DataFrame
@@ -1226,9 +1231,9 @@ class CustomGenomicRegionGenerator:
         Write sequences for annotated intervals to a FASTA file.
 
         Intervals are written as a temporary BED file with
-        :class:`~oligo_designer_toolsuite.utils.BedParser` (0-based starts), then
-        sequences are pulled from the genome FASTA. The temporary BED file is
-        removed afterward.
+        :class:`~oligo_designer_toolsuite.utils.BedParser`, then sequences are
+        pulled from the genome FASTA. The BED ``start`` column must already be
+        0-based. The temporary BED file is removed afterward.
 
         :param annotation: Intervals to extract. Must include the columns needed for BED and FASTA headers.
         :type annotation: pd.DataFrame
@@ -1244,12 +1249,11 @@ class CustomGenomicRegionGenerator:
         annotation = annotation.sort_values(by=["fasta_header"])
         annotation.reset_index(inplace=True, drop=True)
 
-        # save the annotation as bed file
+        # BED extraction expects 0-based starts (usually annotation["start"] = start_0base upstream).
         id = random.randint(0, 10000000)
         file_bed = safe_append_filename(self.dir_output, f"annotation_{id}.bed")
         self.bed_parser.write_bed(annotation, file_bed)
 
-        # create the fasta file
         get_sequence_from_annotation(
             file_bed,
             self.sequence_file,

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -306,9 +306,7 @@ class CustomGenomicRegionGenerator:
 
             # case 1: no annotated genes on the respective chromosome and strand
             if gene_annotation.empty:
-                chromosome_length = pd.read_csv(
-                    file_chromosome_length, sep="\t", header=None, names=["seqid", "length"]
-                )
+                chromosome_length = self._read_chromosome_length_file(file_chromosome_length)
                 if strand == "+":
                     region_id_name = "InterRegPlus"
                 elif strand == "-":
@@ -1085,6 +1083,20 @@ class CustomGenomicRegionGenerator:
                 handle.write(f"{key}\t{value}\n")
 
         return file_chromosome_length
+
+    def _read_chromosome_length_file(self, file_chromosome_length: str) -> pd.DataFrame:
+        """
+        Read chromosome lengths from a file.
+
+        Reads the chromosome lengths from a file and returns a DataFrame with
+        ``seqid`` and ``length`` columns.
+
+        :param file_chromosome_length: Path to the chromosome length file.
+        :type file_chromosome_length: str
+        :return: DataFrame with ``seqid`` and ``length`` columns.
+        :rtype: pd.DataFrame
+        """
+        return pd.read_csv(file_chromosome_length, sep="\t", header=None, names=["seqid", "length"])
 
     def _load_annotation(self) -> pd.DataFrame:
         """

--- a/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
+++ b/oligo_designer_toolsuite/sequence_generator/_genomic_region_generator.py
@@ -1,3 +1,13 @@
+"""
+Build FASTA sequences for annotated genomic regions from GFF and genome files.
+
+Given a genome annotation and the matching FASTA, this module extracts intervals
+such as genes, exons, introns, CDS, UTRs, intergenic stretches, and exon-exon junctions.
+Use :class:`CustomGenomicRegionGenerator` with local files, or
+:class:`NcbiGenomicRegionGenerator` / :class:`EnsemblGenomicRegionGenerator` to download
+annotation and sequence from NCBI or Ensembl first.
+"""
+
 ############################################
 # imports
 ############################################
@@ -25,6 +35,7 @@ from oligo_designer_toolsuite._constants import (
 from oligo_designer_toolsuite._exceptions import ConfigurationError
 from oligo_designer_toolsuite.sequence_generator import FtpLoaderEnsembl, FtpLoaderNCBI
 from oligo_designer_toolsuite.utils import (
+    BedParser,
     GffParser,
     get_complement_regions,
     get_sequence_from_annotation,
@@ -38,35 +49,39 @@ from oligo_designer_toolsuite.utils import (
 
 class CustomGenomicRegionGenerator:
     """
-    This class is designed to generate custom genomic regions based on provided annotation and sequence files.
-    It supports defining species, annotation release and genome assembly.
+    Build FASTA sequences for custom genomic regions from local annotation and genome files.
 
-    The generated sequences are saved as fasta file with region id, additional information and coordinates in header.
-    The header of each sequence must start with '>' and contain the following information:
-    region_id, additional_information (optional) and coordinates (chrom, start, end, strand),
-    where the region_id is compulsory and the other fileds are opional. Coordinated are saved in 1-base format.
+    Provide a GFF annotation and matching genome FASTA, plus optional species and assembly
+    labels. Region extractors (gene, exon, intron, CDS, UTR, intergenic, exon-exon junction)
+    write one FASTA file per region type.
 
-    Output Format (per sequence):
-    >{region_id}::{additional information}::{chromosome}:{start}-{end}({strand})
-    sequence
+    Each sequence header starts with ``>`` and holds region ID, optional metadata, and
+    coordinates (chromosome, start, end, strand). Coordinates in the header are 1-based.
+    The region ID is required; other fields are optional.
 
-    Example:
-    >ASR1::transcrip_id=XM456,exon_number=5::16:54552-54786(+)
-    AGTTGACAGACCCCAGATTAAAGTGTGTCGCGCAACAC
+    Output Format (per sequence)::
 
-    :param annotation_file: The path to the annotation file (e.g., GFF).
+        >{region_id}::{additional information}::{chromosome}:{start}-{end}({strand})
+        sequence
+
+    Example::
+
+        >ASR1::transcript_id=XM456,exon_number=5::16:54552-54786(+)
+        AGTTGACAGACCCCAGATTAAAGTGTGTCGCGCAACAC
+
+    :param annotation_file: Path to the annotation file (for example GFF/GTF).
     :type annotation_file: str
-    :param sequence_file: The path to the corresponding sequence file (e.g., FASTA).
+    :param sequence_file: Path to the matching genome FASTA.
     :type sequence_file: str
-    :param files_source: The source of the files (e.g., Ensembl, NCBI), defaults to "custom".
+    :param files_source: Label for the file source (for example Ensembl or NCBI). Defaults to ``custom``.
     :type files_source: str, optional
-    :param species: The species name related to the annotation and sequence files, defaults to "unknown".
+    :param species: Species name for the annotation and genome. Defaults to ``unknown``.
     :type species: str, optional
-    :param annotation_release: The annotation release version, defaults to "unknown".
+    :param annotation_release: Annotation release version. Defaults to ``unknown``.
     :type annotation_release: str, optional
-    :param genome_assembly: The genome assembly version, defaults to "unknown".
+    :param genome_assembly: Genome assembly version. Defaults to ``unknown``.
     :type genome_assembly: str, optional
-    :param dir_output: Directory path where output files will be saved. Defaults to "output".
+    :param dir_output: Directory for output files. Defaults to ``output``.
     :type dir_output: str, optional
     """
 
@@ -113,6 +128,7 @@ class CustomGenomicRegionGenerator:
 
         # load annotation file and store in pickel file
         self.gff_parser = GffParser()
+        self.bed_parser = BedParser()
         self.gff_parser.check_gff_format(self.annotation_file)
         self.gff_parser.parse_annotation_from_gff(
             annotation_file=self.annotation_file,
@@ -139,16 +155,20 @@ class CustomGenomicRegionGenerator:
 
     def get_sequence_gene(self) -> str:
         """
-        Generates gene sequences based on gene annotations. These sequences are then saved in a FASTA file.
+        Build FASTA sequences for gene intervals from gene annotations.
 
-        Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id}
-        ::{chromosome}:{start}-{end}({strand})
+        Loads gene features from the annotation, labels each with source and gene ID
+        metadata, and writes the sequences to a FASTA file. Coordinates in the FASTA
+        header are 1-based; BED used for extraction uses 0-based starts.
 
-        sequence
+        Output Format (per sequence)::
 
-        :return: The path to the generated FASTA file containing the gene sequences.
+            >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id}
+            ::{chromosome}:{start}-{end}({strand})
+            sequence
+
+        :return: Path to the FASTA file with gene sequences.
         :rtype: str
         """
         # get gene annotation entries
@@ -190,26 +210,31 @@ class CustomGenomicRegionGenerator:
 
     def get_sequence_intergenic(self) -> str:
         """
-        Generates intergenic sequences based on gene annotations.
+        Build FASTA sequences for intergenic regions from gene annotations.
 
-        This function extracts intergenic sequences (regions between genes) for both the positive and negative strands of a chromosome from the gene annotation and chromosome length.
-        These sequences are then saved in a FASTA file.
+        For each chromosome, gaps between genes are taken separately on the plus
+        and minus strands. Chromosome lengths come from the genome FASTA. The
+        resulting intervals are written to a FASTA file. Coordinates in the FASTA
+        header are 1-based; BED used for extraction uses 0-based starts.
 
-        Output Format (per sequence):
-        >{intergenic_region_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype}::{chromosome}:{start}-{end}({strand})
+        Output Format (per sequence)::
 
-        sequence
+            >{intergenic_region_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype}::{chromosome}:{start}-{end}({strand})
+            sequence
 
-        :return: The path to the generated FASTA file containing the intergenic region sequences.
+        :return: Path to the FASTA file with intergenic sequences.
         :rtype: str
         """
 
         def _get_chromosome_length() -> str:
             """
-            Calculates the length of each chromosome in the given FASTA file and writes the lengths to a file.
+            Write chromosome lengths from the genome FASTA to a chrom.sizes file.
 
-            :return: The path to the file containing chromosome lengths.
+            The file is used by bedtools when finding regions outside annotated
+            genes. Each line is ``seqid`` and length, tab-separated, with no header.
+
+            :return: Path to the chromosome-length file.
             :rtype: str
             """
             chromosome_lengths = {}
@@ -227,14 +252,16 @@ class CustomGenomicRegionGenerator:
             annotation: pd.DataFrame, file_chromosome_length: str
         ) -> pd.DataFrame:
             """
-            Computes the intergenic regions based on gene annotations for each chromosome and for both positive and negative strands.
-            It uses chromosome length data to determine the regions between annotated genes.
+            Find intergenic intervals for every chromosome on both strands.
 
-            :param annotation: DataFrame containing gene annotations.
+            Uses gene annotations and chromosome lengths to define the regions
+            between genes (or a whole chromosome when that strand has no genes).
+
+            :param annotation: Gene annotations for the genome.
             :type annotation: pd.DataFrame
-            :param file_chromosome_length: Path to the file containing chromosome lengths for each chromosome.
+            :param file_chromosome_length: Path to the chrom.sizes file with sequence lengths.
             :type file_chromosome_length: str
-            :return: DataFrame with intergenic annotations including chromosome ID, start, end, and other related fields.
+            :return: Intergenic intervals with coordinates, region IDs, and strand.
             :rtype: pd.DataFrame
             """
             intergenic_annotation = []
@@ -273,28 +300,29 @@ class CustomGenomicRegionGenerator:
             seqid: str, gene_annotatio: pd.DataFrame, strand: str, file_chromosome_length: str
         ) -> pd.DataFrame:
             """
-            Computes the intergenic regions for a given chromosome and strand based on gene annotations.
+            Find intergenic intervals on one chromosome and strand.
 
-            This method handles two cases:
-            1. When there are no annotated genes on the respective chromosome and strand, it generates an intergenic region spanning from the start to the end of the chromosome.
-            2. When there are annotated genes, it calculates intergenic regions between these genes using BED format files to determine the gaps.
+            If that strand has no genes, the interval spans the full chromosome.
+            Otherwise, gene intervals are written as BED, and the gaps between
+            them are taken with bedtools complement via :class:`~oligo_designer_toolsuite.utils.BedParser`.
 
-            :param seqid: Identifier of the chromosome or sequence.
+            :param seqid: Chromosome or sequence name.
             :type seqid: str
-            :param gene_annotatio: DataFrame containing gene annotations for the chromosome and strand.
+            :param gene_annotatio: Gene intervals on this chromosome and strand.
             :type gene_annotatio: pd.DataFrame
-            :param strand: The strand of interest ('+' or '-') to compute intergenic regions.
+            :param strand: Strand to process (``+`` or ``-``).
             :type strand: str
-            :param file_chromosome_length: Path to the file containing chromosome lengths for each chromosome.
+            :param file_chromosome_length: Path to the chrom.sizes file with sequence lengths.
             :type file_chromosome_length: str
-            :return: DataFrame with intergenic annotations including chromosome ID, start, end, and additional fields such as region_id and strand.
+            :return: Intergenic intervals for this chromosome and strand.
             :rtype: pd.DataFrame
+            :raises ConfigurationError: If ``strand`` is not ``+`` or ``-``.
             """
 
             # case 1: no annotated genes on the respective chromosome and strand
             if gene_annotatio.empty:
                 chromosome_length = pd.read_csv(
-                    file_chromosome_length, sep="\t", comment="t", header=0, names=["seqid", "length"]
+                    file_chromosome_length, sep="\t", header=None, names=["seqid", "length"]
                 )
                 if strand == "+":
                     region_id_name = "InterRegPlus"
@@ -321,16 +349,18 @@ class CustomGenomicRegionGenerator:
 
                 # save the annotation as bed file
                 gene_annotatio = gene_annotatio.sort_values(by="start")
-                gene_annotatio.to_csv(file_bed_in, sep="\t", header=False, index=False)
+                self.bed_parser.write_bed(gene_annotatio, file_bed_in)
 
                 # get complementary regions
                 get_complement_regions(file_bed_in, file_chromosome_length, file_bed_out)
 
                 # load intergenic regions
-                intergenic_annotation = pd.read_csv(
-                    file_bed_out, sep="\t", comment="t", header=0, names=["seqid", "start_0base", "end"]
+                intergenic_annotation = self.bed_parser.read_bed(
+                    file_bed_out, names=["seqid", "start_0base", "end"]
                 )
-                intergenic_annotation["start_1base"] = intergenic_annotation["start_0base"] + 1
+                intergenic_annotation["start_1base"] = self.bed_parser.convert_start(
+                    intergenic_annotation["start_0base"], "0-based", "1-based"
+                )
                 if strand == "+":
                     intergenic_annotation["region_id"] = (
                         "InterRegPlus" + str(seqid) + "_" + intergenic_annotation.index.astype("str")
@@ -390,22 +420,24 @@ class CustomGenomicRegionGenerator:
 
     def get_sequence_exon(self, collapse_duplicated_regions: bool = True) -> str:
         """
-        Generates exon sequences based on exon annotations.
+        Build FASTA sequences for exon intervals from exon annotations.
 
-        It optionally collapses duplicated regions, originating from different transcripts with the same start and end coordinates.
-        It includes additional information in the FASTA header, such as transcript IDs and exon numbers.
-        These sequences are then saved in a FASTA file.
+        Optionally merges exons that share the same start and end but come from
+        different transcripts. FASTA headers include transcript IDs, exon numbers,
+        and the total transcript count per gene. Coordinates in the FASTA header
+        are 1-based; BED used for extraction uses 0-based starts.
 
-        Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
-        exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
-        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
-        sequence
+        Output Format (per sequence)::
 
-        :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
+            >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+            exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
+            number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+            sequence
+
+        :param collapse_duplicated_regions: If ``True``, merge exons with identical coordinates into one entry. Defaults to ``True``.
         :type collapse_duplicated_regions: bool
-        :return: The path to the generated FASTA file containing the exon sequences.
+        :return: Path to the FASTA file with exon sequences.
         :rtype: str
         """
 
@@ -460,37 +492,41 @@ class CustomGenomicRegionGenerator:
 
     def get_sequence_intron(self, collapse_duplicated_regions: bool = True) -> str:
         """
-        Generates intron sequences based on exon annotations.
+        Build FASTA sequences for intron intervals derived from exon annotations.
 
-        It optionally collapses duplicated regions, originating from different transcripts with the same start and end coordinates.
-        It includes additional information in the FASTA header, such as transcript IDs and intron numbers.
-        These sequences are then saved in a FASTA file.
+        Introns are the gaps between consecutive exons within each transcript.
+        Optionally merges introns that share the same start and end but come from
+        different transcripts. FASTA headers include transcript IDs and intron
+        numbers. Coordinates in the FASTA header are 1-based; BED used for
+        extraction uses 0-based starts.
 
-        Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
-        intron_number={intron_number_x};transcript_id={transcript_id_b},intron_number={intron_number_y};
-        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
-        sequence
+        Output Format (per sequence)::
 
-        :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
+            >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+            intron_number={intron_number_x};transcript_id={transcript_id_b},intron_number={intron_number_y};
+            number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+            sequence
+
+        :param collapse_duplicated_regions: If ``True``, merge introns with identical coordinates into one entry. Defaults to ``True``.
         :type collapse_duplicated_regions: bool
-        :return: The path to the generated FASTA file containing the intron sequences.
+        :return: Path to the FASTA file with intron sequences.
         :rtype: str
         """
 
         def _compute_intron_annotation(annotation: pd.DataFrame) -> pd.DataFrame:
             """
-            Computes intron annotations based on exon annotations for each transcript.
+            Derive intron intervals from exon annotations for each transcript.
 
-            This method calculates intron regions by identifying the gaps between consecutive exons within each transcript.
-            The introns are classified by their position relative to the exons and strand orientation.
-            It generates a DataFrame containing intron annotations with details such as gene ID, transcript ID, and intron number.
+            Finds the gaps between consecutive exons within a transcript and
+            numbers them by position, accounting for strand orientation. Returns
+            intron rows with gene ID, transcript ID, and intron number.
 
-            :param annotation: DataFrame containing exon annotations.
+            :param annotation: Exon annotations for the genome.
             :type annotation: pd.DataFrame
-            :return: DataFrame with computed intron annotations.
+            :return: Intron intervals with gene, transcript, and intron number.
             :rtype: pd.DataFrame
+            :raises ConfigurationError: If no introns can be derived from the exons.
             """
 
             intron_list = []
@@ -600,22 +636,24 @@ class CustomGenomicRegionGenerator:
 
     def get_sequence_CDS(self, collapse_duplicated_regions: bool = True) -> str:
         """
-        Generates Coding Sequence (CDS) sequences based on CDS annotations.
+        Build FASTA sequences for coding sequence (CDS) intervals from CDS annotations.
 
-        It optionally collapses duplicated regions, originating from different transcripts with the same start and end coordinates.
-        It includes additional information in the FASTA header, such as transcript IDs and exon numbers.
-        These sequences are then saved in a FASTA file.
+        Optionally merges CDS intervals that share the same start and end but come
+        from different transcripts. FASTA headers include transcript IDs, exon
+        numbers, and the total transcript count per gene. Coordinates in the FASTA
+        header are 1-based; BED used for extraction uses 0-based starts.
 
-        Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
-        exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
-        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
-        sequence
+        Output Format (per sequence)::
 
-        :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
+            >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+            exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
+            number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+            sequence
+
+        :param collapse_duplicated_regions: If ``True``, merge CDS intervals with identical coordinates into one entry. Defaults to ``True``.
         :type collapse_duplicated_regions: bool
-        :return: The path to the generated FASTA file containing the CDS sequences.
+        :return: Path to the FASTA file with CDS sequences.
         :rtype: str
         """
         # get exon annotation entries
@@ -674,41 +712,43 @@ class CustomGenomicRegionGenerator:
         collapse_duplicated_regions: bool = True,
     ) -> str:
         """
-        Generates UTR (Untranslated Region) sequences based on exon and CDS (Coding Sequence) annotations.
+        Build FASTA sequences for UTR intervals from exon and CDS annotations.
 
-        This method calculates both 5' and 3' UTR regions for transcripts based on the provided annotations.
-        It allows for selective generation of 5' and/or 3' UTR sequences by specifying flags.
-        It optionally collapses duplicated regions, originating from different transcripts with the same start and end coordinates.
-        It includes additional information in the FASTA header, such as transcript IDs and exon numbers.
-        These sequences are then saved in a FASTA file.
+        Derives 5' and/or 3' untranslated regions from exon spans outside the CDS
+        boundaries of each transcript. Use ``five_prime`` and ``three_prime`` to
+        choose which ends to keep. Optionally merges UTRs with identical coordinates.
+        Coordinates in the FASTA header are 1-based; BED used for extraction uses
+        0-based starts.
 
-        Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
-        exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
-        number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
-        sequence
+        Output Format (per sequence)::
 
-        :param five_prime: Boolean flag indicating whether to include 5' UTR sequences. Defaults to True.
+            >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+            exon_number={exon_number_x};transcript_id={transcript_id_b},exon_number={exon_number_y};
+            number_total_transcripts={number_total_transcripts}::{chromosome}:{start}-{end}({strand})
+            sequence
+
+        :param five_prime: If ``True``, include 5' UTR sequences. Defaults to ``True``.
         :type five_prime: bool
-        :param three_prime: Boolean flag indicating whether to include 3' UTR sequences. Defaults to True.
+        :param three_prime: If ``True``, include 3' UTR sequences. Defaults to ``True``.
         :type three_prime: bool
-        :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
+        :param collapse_duplicated_regions: If ``True``, merge UTRs with identical coordinates into one entry. Defaults to ``True``.
         :type collapse_duplicated_regions: bool
-        :return: The path to the generated FASTA file containing the UTR sequences.
+        :return: Path to the FASTA file with UTR sequences.
         :rtype: str
+        :raises ConfigurationError: If no UTR intervals can be derived.
         """
 
         def _compute_UTR(annotation: pd.DataFrame) -> pd.DataFrame:
             """
-            Computes the 5' and 3' UTR (Untranslated Region) annotations from a DataFrame of exon and CDS annotations.
+            Derive 5' and 3' UTR intervals from exon and CDS annotations.
 
-            This function processes exon and CDS annotations to determine UTR regions based on the boundaries of CDS (Coding Sequence) annotations.
-            It distinguishes between 5' and 3' UTRs depending on the strand orientation and generates the corresponding annotations.
+            Uses CDS boundaries within each transcript to trim exons outside the
+            coding span. Strand orientation decides which side is 5' versus 3'.
 
-            :param annotation: DataFrame containing exon and CDS annotations.
+            :param annotation: Combined exon and CDS annotations for transcripts with CDS.
             :type annotation: pd.DataFrame
-            :return: DataFrame with computed UTR annotations, including 5' and/or 3' UTRs.
+            :return: UTR intervals labeled as five_prime_UTR or three_prime_UTR.
             :rtype: pd.DataFrame
             """
             utrs = []
@@ -819,42 +859,46 @@ class CustomGenomicRegionGenerator:
         self, block_size: int, collapse_duplicated_regions: bool = True
     ) -> str:
         """
-        Generates exon-exon junction sequences based on exon annotations.
+        Build FASTA sequences spanning exon-exon junctions from exon annotations.
 
-        This function identifies junctions between consecutive exons within transcripts, considering specified block sizes to ensure that the generated sequences are of sufficient length.
-        It computes the junction annotations and sequences based on exon boundaries.
-        It optionally collapses duplicated regions, originating from different transcripts with the same start and end coordinates.
-        It includes additional information in the FASTA header, such as transcript IDs and exon numbers.
-        These sequences are then saved in a FASTA file.
+        For consecutive exons in a transcript, takes ``block_size`` bases on each
+        side of the junction (or the full exon if shorter). Optionally merges
+        junctions with identical coordinates from different transcripts. FASTA
+        headers include transcript IDs and joined exon numbers. Coordinates in
+        the FASTA header are 1-based; BED used for extraction uses 0-based starts.
 
-        Output Format (per sequence):
-        >{gene_id}::source={source};species={species};annotation_release={annotation_release};
-        genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
-        exon_number={exon_number_x__JUNC__exon_number_y};transcript_id={transcript_id_b},
-        exon_number={exon_number_y__JUNC__exon_number_z};number_total_transcripts={number_total_transcripts}
-        ::{chromosome}:{start}-{end}({strand})
-        sequence
+        Output Format (per sequence)::
 
-        :param block_size: The size of the sequence block used to generate junctions between exons. This parameter determines the length of the sequence blocks flanking the junctions.
+            >{gene_id}::source={source};species={species};annotation_release={annotation_release};
+            genome_assembly={genome_assembly};regiontype={regiontype};gene_id={gene_id};transcript_id={transcript_id_a},
+            exon_number={exon_number_x__JUNC__exon_number_y};transcript_id={transcript_id_b},
+            exon_number={exon_number_y__JUNC__exon_number_z};number_total_transcripts={number_total_transcripts}
+            ::{chromosome}:{start}-{end}({strand})
+            sequence
+
+        :param block_size: Number of bases to take on each side of the junction.
         :type block_size: int
-        :param collapse_duplicated_regions: Whether to collapse duplicated regions into a single entry, defauls to True.
+        :param collapse_duplicated_regions: If ``True``, merge junctions with identical coordinates into one entry. Defaults to ``True``.
         :type collapse_duplicated_regions: bool
-        :return: The path to the generated FASTA file containing the exon-exon junction sequences.
+        :return: Path to the FASTA file with exon-exon junction sequences.
         :rtype: str
+        :raises ConfigurationError: If no exon-exon junctions can be derived.
         """
 
         def _compute_exon_exon_junction_annotation(annotation: pd.DataFrame, block_size: int) -> pd.DataFrame:
             """
-            Computes exon-exon junction annotations from exon data.
+            Derive exon-exon junction intervals from exon annotations.
 
-            This function identifies junctions between consecutive exons within transcripts. It handles cases where exons are shorter than a specified block size by
-            incorporating neighboring exons into the junction annotation, ensuring that the generated sequences are of sufficient length.
+            For consecutive exons in a transcript, builds a junction spanning
+            ``block_size`` bases on each side. If an exon is shorter than
+            ``block_size``, neighboring exons are included so the junction sequence
+            stays long enough.
 
-            :param annotation: A DataFrame containing exon annotations.
+            :param annotation: Exon annotations for the genome.
             :type annotation: pd.DataFrame
-            :param block_size: The length of the sequence blocks flanking the junctions, i.e. +/- "block_size" bp around the junction.
+            :param block_size: Number of bases to take on each side of the junction.
             :type block_size: int
-            :return: A DataFrame with annotations for exon-exon junctions.
+            :return: Junction intervals with block sizes for BED12-style extraction.
             :rtype: pd.DataFrame
             """
             junction_list = []
@@ -1038,12 +1082,12 @@ class CustomGenomicRegionGenerator:
 
     def _load_annotation(self) -> pd.DataFrame:
         """
-        Loads annotation data from a file and prepares it for processing.
+        Load the parsed GFF annotation and add 0-based and 1-based start columns.
 
-        This function reads a GFF annotation file, loads it into a DataFrame, and processes the coordinates to include both 1-based and 0-based offsets.
-        The resulting DataFrame includes columns for both coordinate systems, which are necessary for various genomic analyses.
+        Reads the pickled annotation written at construction time. GFF starts are
+        1-based; a matching 0-based start column is added for BED-style extraction.
 
-        :return: A DataFrame containing the loaded and processed annotation data with columns for 1-based and 0-based start coordinates.
+        :return: Annotation table with ``start_1base`` and ``start_0base`` columns.
         :rtype: pd.DataFrame
         """
         # read annotation file and store in dataframe
@@ -1062,14 +1106,17 @@ class CustomGenomicRegionGenerator:
 
     def _get_annotation_region_of_interest(self, annotation: pd.DataFrame, region: str) -> pd.DataFrame:
         """
-        Filters the provided annotation DataFrame to retain only the rows corresponding to a specific region type.
+        Keep only annotation rows of a given feature type.
 
-        :param annotation: A DataFrame containing genomic annotations. It must include a 'type' column to specify the type of region.
+        Filters on the ``type`` column (for example ``gene``, ``exon``, or ``CDS``).
+
+        :param annotation: Full annotation table.
         :type annotation: pd.DataFrame
-        :param region: The type of region to filter for in the annotation DataFrame. For example, "exon" or "CDS".
+        :param region: Feature type to keep.
         :type region: str
-        :return: A DataFrame containing only the rows where the 'type' column matches the specified region.
+        :return: Rows whose ``type`` matches ``region``.
         :rtype: pd.DataFrame
+        :raises ConfigurationError: If ``region`` is not present in the annotation.
         """
         region_annotation = annotation.loc[annotation["type"] == region]
         if region_annotation.shape[0] == 0:
@@ -1087,21 +1134,24 @@ class CustomGenomicRegionGenerator:
         exon_size: int | None = None,
     ) -> pd.Series:
         """
-        Generates a pandas Series containing attributes related to genomic features.
+        Bundle optional genomic feature fields into a single series.
 
-        :param start_0base: The start coordinate of the feature in 0-based indexing.
+        Used when walking exons within a transcript to carry coordinates and
+        exon metadata between steps.
+
+        :param start_0base: Feature start in 0-based coordinates.
         :type start_0base: int, optional
-        :param start_1base: The start coordinate of the feature in 1-based indexing.
+        :param start_1base: Feature start in 1-based coordinates.
         :type start_1base: int, optional
-        :param end: The end coordinate of the feature.
+        :param end: Feature end coordinate.
         :type end: int, optional
-        :param gene_id: The identifier for the gene associated with the feature.
+        :param gene_id: Gene identifier for the feature.
         :type gene_id: str, optional
-        :param exon_number: The number of the exon within the transcript.
+        :param exon_number: Exon number within the transcript.
         :type exon_number: int, optional
-        :param exon_size: The size of the exon.
+        :param exon_size: Length of the exon in bases.
         :type exon_size: int, optional
-        :return: A pandas Series containing the provided attributes.
+        :return: Series with the provided attribute fields.
         :rtype: pd.Series
         """
         attributes = pd.Series(
@@ -1119,11 +1169,15 @@ class CustomGenomicRegionGenerator:
 
     def _collapse_duplicated_regions(self, annotation: pd.DataFrame) -> pd.DataFrame:
         """
-        Merges duplicate genomic regions in the annotation DataFrame by aggregating the information for each region.
+        Merge annotation rows that share the same genomic region.
 
-        :param annotation: A DataFrame containing genomic annotations with possible duplicate regions. Each row represents a genomic feature, and there must be a 'region' column to identify the regions to be collapsed.
+        Groups by the ``region`` string and keeps one row per unique interval.
+        Extra info strings from duplicate rows are joined so transcript and exon
+        labels from all isoforms stay in the FASTA header.
+
+        :param annotation: Annotation rows that may contain duplicate intervals.
         :type annotation: pd.DataFrame
-        :return: A DataFrame with duplicate regions merged. The values in columns other than 'region' are aggregated, with a special aggregation for the 'add_inf' column.
+        :return: Annotation with one row per unique ``region``.
         :rtype: pd.DataFrame
         """
         aggregate_function: dict[str, str | Callable[[Iterable[str]], str]] = {
@@ -1138,11 +1192,14 @@ class CustomGenomicRegionGenerator:
 
     def _get_annotation_region(self, annotation: pd.DataFrame) -> pd.Series:
         """
-        Generates a formatted string representing the genomic region for each annotation entry.
+        Format each annotation row as a 1-based coordinate string for FASTA headers.
 
-        :param annotation: A DataFrame containing genomic annotations. It must include columns 'seqid', 'start_1base', 'end', and 'strand' to construct the region string.
+        Builds ``seqid:start-end(strand)`` from ``seqid``, ``start_1base``, ``end``,
+        and ``strand``.
+
+        :param annotation: Annotation rows with coordinate and strand columns.
         :type annotation: pd.DataFrame
-        :return: A string formatted as 'seqid:start_1base-end(strand)' for each annotation entry.
+        :return: Series of region strings, one per annotation row.
         :rtype: pd.Series
         """
         region: pd.Series = (
@@ -1166,17 +1223,23 @@ class CustomGenomicRegionGenerator:
         strand: bool = True,
     ) -> None:
         """
-        Generates a FASTA file from genomic annotations by first converting the annotations to a BED file and then extracting sequences.
+        Write sequences for annotated intervals to a FASTA file.
 
-        :param annotation: A DataFrame containing genomic annotations. Must include columns used to generate BED files and FASTA sequences.
+        Intervals are written as a temporary BED file with
+        :class:`~oligo_designer_toolsuite.utils.BedParser` (0-based starts), then
+        sequences are pulled from the genome FASTA. The temporary BED file is
+        removed afterward.
+
+        :param annotation: Intervals to extract. Must include the columns needed for BED and FASTA headers.
         :type annotation: pd.DataFrame
-        :param file_fasta: The path to the output FASTA file where the sequences will be saved.
+        :param file_fasta: Path of the FASTA file to create.
         :type file_fasta: str
-        :param split: A flag indicating hether to split the sequences. Given BED12 input, extract and concatenate the sequences from the BED “blocks” (e.g., exons), defaults to True.
+        :param split: If ``True`` and the BED is BED12-style, concatenate block sequences (for example exons). Defaults to ``True``.
         :type split: bool
-        :param strand: A flag indicating whether to force strandedness. If the feature occupies the antisense strand, the sequence will be reverse complemented, defaults to True.
+        :param strand: If ``True``, reverse-complement intervals on the minus strand. Defaults to ``True``.
         :type strand: bool
         :return: None
+        :rtype: None
         """
         annotation = annotation.sort_values(by=["fasta_header"])
         annotation.reset_index(inplace=True, drop=True)
@@ -1184,7 +1247,7 @@ class CustomGenomicRegionGenerator:
         # save the annotation as bed file
         id = random.randint(0, 10000000)
         file_bed = safe_append_filename(self.dir_output, f"annotation_{id}.bed")
-        annotation.to_csv(file_bed, sep="\t", header=False, index=False)
+        self.bed_parser.write_bed(annotation, file_bed)
 
         # create the fasta file
         get_sequence_from_annotation(
@@ -1199,13 +1262,14 @@ class CustomGenomicRegionGenerator:
 
     def _get_number_total_transcripts(self, gene_ids: set[str]) -> pd.DataFrame | None:
         """
-        Calculates the total number of transcripts per gene from the annotation data.
-        If no transcript information is available, returns None.
+        Count transcripts per gene for the requested gene IDs.
 
-        :param gene_ids: The list of gene_ids for which the transcript number is calculated. This is needed
-            because for some assemblies, the transcript information is not available for all gene_ids of one type.
+        Uses ``transcript`` features in the annotation when available. Returns
+        ``None`` if transcript counts cannot be computed for all requested genes.
+
+        :param gene_ids: Gene IDs that need a transcript count. Some assemblies lack transcript rows for every gene.
         :type gene_ids: set[str]
-        :return: A DataFrame where each row represents a gene with the total count of its transcripts.
+        :return: Table of ``gene_id`` and ``transcript_count``, or ``None`` if counts are unavailable.
         :rtype: pd.DataFrame | None
         """
         annotation = self._load_annotation()
@@ -1224,12 +1288,16 @@ class CustomGenomicRegionGenerator:
 
     def _add_transcript_counts(self, annotation: pd.DataFrame) -> tuple[pd.DataFrame, str | pd.Series]:
         """
-        Adds the transcript count for every gene to the annotation and generates a Series of strings for the BED header.
+        Attach per-gene transcript counts for FASTA header metadata.
 
-        :param annotation: DataFrame with the annotation information.
+        Looks up total transcripts per gene and builds a header fragment of the
+        form ``number_total_transcripts=...``. If counts are unavailable, the
+        fragment is an empty string.
+
+        :param annotation: Annotation rows that include a ``gene_id`` column.
         :type annotation: pd.DataFrame
-        :return: Updated annotation DataFrame and Series with strings fro BED header
-        :rtype: DataFrame
+        :return: Updated annotation and a string or series for the FASTA header.
+        :rtype: tuple[pd.DataFrame, str | pd.Series]
         """
         # add transcript counts for each gene
         number_total_transcripts = self._get_number_total_transcripts(set(annotation["gene_id"]))
@@ -1247,28 +1315,30 @@ class CustomGenomicRegionGenerator:
 
 class NcbiGenomicRegionGenerator(CustomGenomicRegionGenerator):
     """
-    This class generates custom genomic regions using data from NCBI.
-    It automatically downloads and processes annotation and sequence files. They can either be specified by taxon, species,
-    and annotation release (and optionally the assembly source). Alternatively, the RefSeq assembly accession number and
-    the assembly name can be specified directly. Only one mode can be used and the other parameters need to be set to
-    None.
+    Build genomic region FASTA files from NCBI annotation and genome downloads.
 
-    :param mode: How should be specified which genome to use? Options: 'species', 'assembly'
+    Downloads GTF annotation and genome FASTA via :class:`~oligo_designer_toolsuite.sequence_generator.FtpLoaderNCBI`,
+    then reuses :class:`CustomGenomicRegionGenerator` extractors. Choose the genome
+    either by taxon, species, and annotation release (``mode='species'``), or by
+    RefSeq assembly accession and assembly name (``mode='assembly'``). Only one
+    mode may be used; unused parameters should be ``None``.
+
+    :param mode: How to select the genome: ``species`` or ``assembly``.
     :type mode: str
-    :param taxon: The taxonomic classification of the species, used to locate the appropriate NCBI files, defaults to "vertebrate_mammalian".
+    :param taxon: NCBI taxon folder (for example ``vertebrate_mammalian``). Used when ``mode='species'``.
     :type taxon: str, optional
-    :param species: The species name for which genomic regions will be generated, defaults to "Homo_sapiens".
+    :param species: Species name (for example ``Homo_sapiens``). Used when ``mode='species'``.
     :type species: str, optional
-    :param annotation_release: The version of the annotation release to use, defaults to "current".
+    :param annotation_release: Annotation release version. Defaults to ``current`` when ``mode='species'``.
     :type annotation_release: str, optional
-    :param assembly_source: NCBI assembly source to use. Supported values are "auto", "annotation_releases",
-        "latest_assembly_versions", and "reference". Defaults to "auto".
+    :param assembly_source: NCBI assembly source. Supported values are ``auto``, ``annotation_releases``,
+        ``latest_assembly_versions``, and ``reference``. Defaults to ``auto``.
     :type assembly_source: str, optional
-    :param refseq_assembly_accession: Optional direct RefSeq assembly accession (e.g., "GCF_000001405.38").
-    :type refseq_assembly_accession: str | None, optional
-    :param assembly_name: Optional direct assembly name (e.g., "GRCh38.p12").
-    :type assembly_name: str | None, optional
-    :param dir_output: Directory path where output files will be saved. Defaults to "output".
+    :param refseq_assembly_accession: RefSeq assembly accession (for example ``GCF_000001405.38``). Used when ``mode='assembly'``.
+    :type refseq_assembly_accession: str, optional
+    :param assembly_name: Assembly name (for example ``GRCh38.p12``). Used when ``mode='assembly'``.
+    :type assembly_name: str, optional
+    :param dir_output: Directory for output files. Defaults to ``output``.
     :type dir_output: str, optional
     """
 
@@ -1340,14 +1410,18 @@ class NcbiGenomicRegionGenerator(CustomGenomicRegionGenerator):
 
 class EnsemblGenomicRegionGenerator(CustomGenomicRegionGenerator):
     """
-    This class generates custom genomic regions using data from Ensembl.
-    It automates the process of downloading and processing annotation and sequence files for the specified species and annotation release.
+    Build genomic region FASTA files from Ensembl annotation and genome downloads.
 
-    :param species: The species name for which genomic regions will be generated, defaults to "homo_sapiens".
+    Downloads GTF annotation and genome FASTA via
+    :class:`~oligo_designer_toolsuite.sequence_generator.FtpLoaderEnsembl`, then
+    reuses :class:`CustomGenomicRegionGenerator` extractors for the chosen species
+    and annotation release.
+
+    :param species: Species name (for example ``homo_sapiens``). Defaults to ``homo_sapiens``.
     :type species: str, optional
-    :param annotation_release: The version of the annotation release to use, defaults to "current".
+    :param annotation_release: Annotation release version. Defaults to ``current``.
     :type annotation_release: str, optional
-    :param dir_output: Directory path where output files will be saved. Defaults to "output".
+    :param dir_output: Directory for output files. Defaults to ``output``.
     :type dir_output: str, optional
     """
 

--- a/oligo_designer_toolsuite/utils/__init__.py
+++ b/oligo_designer_toolsuite/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-This module provides utilities for processing databases, parsing sequences, checking different file or object formats and logging.
+Shared helpers for databases, sequence file parsers, format checks, and logging.
 """
 
 from ._checkers_and_helpers import (
@@ -22,7 +22,7 @@ from ._database_processor import (
     merge_databases,
 )
 from ._logging import configure_root_logger, logger
-from ._sequence_parser import FastaParser, GffParser, VCFParser
+from ._sequence_parser import BedParser, FastaParser, GffParser, VCFParser
 from ._sequence_processor import (
     append_nucleotide_to_sequences,
     count_kmer_abundance,
@@ -33,6 +33,7 @@ from ._sequence_processor import (
 )
 
 __all__ = [
+    "BedParser",
     "FastaParser",
     "GffParser",
     "VCFParser",

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -791,7 +791,8 @@ class BedParser:
         Load genomic intervals from a BED file.
 
         Ignores blank lines and UCSC header or comment lines that start with
-        ``track``, ``browser``, or ``#``. Interval starts in the result are 0-based.
+        ``track``, ``browser``, or ``#``. Those lines are expected only at the
+        start of the file. Interval starts in the result are 0-based.
 
         For very large files, pass ``chunksize`` to read the intervals in batches
         instead of loading the whole table at once.
@@ -804,17 +805,24 @@ class BedParser:
         :return: Table of intervals, or a chunk iterator when ``chunksize`` is set.
         :rtype: pd.DataFrame | Any
         """
+        # Header lines (track/browser/#/blank) are only at the top; stop at first data row.
+        skiprows: list[int] = []
         with open(filepath) as handle:
-            skiprows = [i for i, line in enumerate(handle) if not self._is_bed_data_line(line)]
+            for i, line in enumerate(handle):
+                if self._is_bed_data_line(line):
+                    break
+                skiprows.append(i)
 
-        return pd.read_csv(
+        dataframe = pd.read_csv(
             filepath,
             sep="\t",
             header=None,
             names=names,
+            comment="#",
             skiprows=skiprows,
             **kwargs,
         )
+        return dataframe
 
     def _is_bed_data_line(self, line: str) -> bool:
         """

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -864,10 +864,10 @@ class BedParser:
 
     def convert_start(
         self,
-        start_coordinates: Any,
+        start_coordinates: pd.Series,
         from_indexing: str,
         to_indexing: str,
-    ) -> Any:
+    ) -> pd.Series:
         """
         Convert interval start positions between 0-based and 1-based indexing.
 
@@ -875,14 +875,14 @@ class BedParser:
         GFF/GTF or region-generator FASTA headers (1-based). Ends are unchanged
         in the usual half-open BED and inclusive GFF conventions.
 
-        :param start_coordinates: One start position or a series of starts.
-        :type start_coordinates: Any
+        :param start_coordinates: Series of start positions to convert.
+        :type start_coordinates: pd.Series
         :param from_indexing: Current indexing, ``0-based`` or ``1-based``.
         :type from_indexing: str
         :param to_indexing: Desired indexing, ``0-based`` or ``1-based``.
         :type to_indexing: str
-        :return: Converted start(s), same type as ``start_coordinates``.
-        :rtype: Any
+        :return: Converted start positions.
+        :rtype: pd.Series
         :raises ConfigurationError: If ``from_indexing`` or ``to_indexing`` is not supported.
         """
         if from_indexing not in self.VALID_INDEXINGS:

--- a/oligo_designer_toolsuite/utils/_sequence_parser.py
+++ b/oligo_designer_toolsuite/utils/_sequence_parser.py
@@ -1,3 +1,11 @@
+"""
+Parse annotation, sequence, variant, and interval files used across the toolsuite.
+
+GFF/GTF annotations, FASTA sequences, VCF variants, and BED intervals are the main
+file types for region extraction, probe design, and coordinate conversion.
+See :class:`GffParser`, :class:`FastaParser`, :class:`VCFParser`, and :class:`BedParser`.
+"""
+
 ############################################
 # imports
 ############################################
@@ -17,7 +25,7 @@ from oligo_designer_toolsuite._constants import (
     SEPARATOR_FASTA_HEADER_FIELDS,
     SEPARATOR_FASTA_HEADER_FIELDS_LIST,
 )
-from oligo_designer_toolsuite._exceptions import FileFormatError
+from oligo_designer_toolsuite._exceptions import ConfigurationError, FileFormatError
 
 from ._checkers_and_helpers import cast_to_list
 
@@ -28,10 +36,11 @@ from ._checkers_and_helpers import cast_to_list
 
 class GffParser:
     """
-    A parser class for handling GFF (General Feature Format) files.
+    Parse genome annotations from GFF or GTF files.
 
-    GFF is a standard format for describing features of DNA, RNA, and protein sequences.
-    This class provides utilities to parse and process GFF files.
+    GFF/GTF files describe features such as genes, transcripts, and exons on a
+    reference sequence. Feature starts are 1-based. Use this class to check format,
+    load annotations into a table, and optionally cache them as a pickle for reuse.
     """
 
     def __init__(self) -> None:
@@ -52,16 +61,30 @@ class GffParser:
 
     def check_gff_format(self, file: str) -> bool:
         """
-        Checks if the provided GFF file is in the correct format by attempting to parse its content.
+        Check whether a GFF/GTF annotation file exists and has valid content.
 
-        :param file: The path to the GFF file to be checked.
+        Reads a sample of feature rows to confirm the file can be parsed. Useful
+        before loading a full annotation into a pipeline step.
+
+        :param file: Path to the GFF or GTF file to check.
         :type file: str
-        :raises ValueError: If the file does not exist or if the GFF format is incorrect.
-        :return: True if the file exists and is in the correct format, otherwise raises an error.
+        :raises FileFormatError: If the file is missing or not a valid GFF/GTF.
+        :return: ``True`` when the file exists and is a valid GFF/GTF.
         :rtype: bool
         """
 
         def _check_gff_content(file: str) -> bool:
+            """
+            Check whether the annotation file yields at least one feature row.
+
+            Parses a short sample of the file. An empty result means the content
+            is not usable as GFF/GTF.
+
+            :param file: Path to the GFF or GTF file to sample.
+            :type file: str
+            :return: ``True`` if at least one feature row is found.
+            :rtype: bool
+            """
             gtf = self.parse_annotation_from_gff(file, target_lines=100)
             return any(gtf)
 
@@ -80,17 +103,22 @@ class GffParser:
         target_lines: int = 100000000,
     ) -> str | pd.DataFrame:
         """
-        Parses the GFF annotation file and converts it into a DataFrame. Optionally, saves the DataFrame to a pickle file.
+        Parse a GFF/GTF annotation into a table of genomic features.
 
-        :param annotation_file: The path to the GFF annotation file to be parsed.
+        Combines the standard GFF columns with attribute fields into one DataFrame.
+        Feature starts are 1-based. Optionally write the table to a pickle for faster
+        reloads later.
+
+        :param annotation_file: Path to the GFF or GTF annotation file.
         :type annotation_file: str
-        :param file_pickle: The path to save the resulting DataFrame as a pickle file (optional).
+        :param file_pickle: Optional path to save the table as a pickle. If set, that
+            path is returned instead of the DataFrame.
         :type file_pickle: str | None
-        :param chunk_size: The number of lines to process at a time from the GFF file.
+        :param chunk_size: Number of lines to process per batch.
         :type chunk_size: int
-        :param target_lines: The number of lines to parse before stopping (useful for sampling).
+        :param target_lines: Maximum number of lines to read (useful for sampling).
         :type target_lines: int
-        :return: The parsed annotation as a DataFrame or the path to the pickle file if specified.
+        :return: Feature table, or the pickle path when ``file_pickle`` is set.
         :rtype: str | pd.DataFrame
         """
         csv_file, extra_info_file = self._split_annotation(
@@ -119,11 +147,14 @@ class GffParser:
 
     def load_annotation_from_pickle(self, file_pickel: str) -> pd.DataFrame:
         """
-        Loads a GFF annotation DataFrame from a pickle file.
+        Load a previously saved GFF/GTF annotation table from a pickle file.
 
-        :param file_pickel: The path to the pickle file containing the GFF annotation DataFrame.
+        Use this after :meth:`parse_annotation_from_gff` wrote a pickle, to avoid
+        re-parsing the original annotation.
+
+        :param file_pickel: Path to the pickle file with the annotation table.
         :type file_pickel: str
-        :return: The loaded DataFrame containing the GFF annotation.
+        :return: Table of genomic features from the pickle.
         :rtype: pd.DataFrame
         """
         dataframe_gff: pd.DataFrame = pickle.load(open(file_pickel, "rb"))
@@ -132,16 +163,19 @@ class GffParser:
 
     def _split_annotation(self, annotation_file: str, chunk_size: int, target_lines: int) -> tuple[str, str]:
         """
-        Splits the GFF annotation file into two separate files: one containing the standard GFF columns and the other containing the extra information.
+        Split a GFF/GTF file into standard columns and attribute fields.
 
-        :param annotation_file: The path to the GFF annotation file.
+        Writes two temporary files: one with the eight core GFF columns, and one
+        with the ninth-column attributes. Comment lines starting with ``#`` are skipped.
+
+        :param annotation_file: Path to the GFF or GTF annotation file.
         :type annotation_file: str
-        :param chunk_size: The number of lines to read at a time from the annotation file.
+        :param chunk_size: Number of lines to read per batch.
         :type chunk_size: int
-        :param target_lines: The maximum number of lines to process from the annotation file.
+        :param target_lines: Maximum number of lines to process.
         :type target_lines: int
-        :return: A tuple containing the paths to the CSV file with the main GFF content and the text file with extra information.
-        :rtype: Tuple[str, str]
+        :return: Paths to the core-column file and the attributes file.
+        :rtype: tuple[str, str]
         """
         csv_file = ".".join(annotation_file.split(".")[:-1]) + ".csv"
         extra_info_file = ".".join(annotation_file.split(".")[:-1]) + ".txt"
@@ -175,11 +209,14 @@ class GffParser:
 
     def _parse_fields(self, line: str) -> dict[str, Any]:
         """
-        Parse the attributes from a GFF line.
+        Parse attribute key-value pairs from a GFF/GTF attributes column.
 
-        :param line: The line of text containing attribute information from a GFF file.
+        Turns semicolon-separated tags such as gene and transcript IDs into a
+        dictionary for joining with the core feature columns.
+
+        :param line: Attributes text from one GFF/GTF feature row.
         :type line: str
-        :return: A dictionary where keys are attribute names and values are the corresponding values from the GFF line.
+        :return: Attribute names mapped to their values.
         :rtype: dict[str, Any]
         """
         result = {}
@@ -206,11 +243,14 @@ class GffParser:
 
     def _get_value(self, value: str) -> str | list[str] | None:
         """
-        Process the value extracted from a GFF line, handling special cases like lists, empty values, and standardization.
+        Normalize one attribute value from a GFF/GTF attributes field.
 
-        :param value: The value from an attribute in a GFF line.
+        Strips quotes, splits comma-separated lists, and treats empty, ``.``, and
+        ``NA`` as missing.
+
+        :param value: Raw attribute value text.
         :type value: str
-        :return: Processed value, which may be None, a string, or a list of strings.
+        :return: Cleaned string, list of strings, or ``None`` if missing.
         :rtype: str | list[str] | None
         """
         if not value:
@@ -230,11 +270,14 @@ class GffParser:
 
     def _info_to_df_chunk(self, data_chunk: list[str]) -> pd.DataFrame:
         """
-        Convert a chunk of data into a DataFrame by parsing its fields.
+        Convert a batch of GFF/GTF attribute lines into a table.
 
-        :param data_chunk: A chunk of data read from the GFF info file.
+        Each line becomes one row of parsed attribute columns for later merge
+        with the core GFF columns.
+
+        :param data_chunk: Attribute lines from the temporary info file.
         :type data_chunk: list[str]
-        :return: A DataFrame with parsed fields.
+        :return: Table of parsed attributes for the batch.
         :rtype: pd.DataFrame
         """
         parsed_fields = [self._parse_fields(line) for line in data_chunk]
@@ -242,13 +285,16 @@ class GffParser:
 
     def _info_to_df(self, info_file: str, chunk_size: int) -> pd.DataFrame:
         """
-        Read an info file in chunks and convert it into a DataFrame.
+        Load all GFF/GTF attribute lines from a temporary file into one table.
 
-        :param info_file: The path to the info file containing GFF attribute data.
+        Reads the file in batches so large annotations stay manageable, then
+        concatenates the batches.
+
+        :param info_file: Path to the temporary attributes file.
         :type info_file: str
-        :param chunk_size: The number of lines to process in each chunk.
+        :param chunk_size: Number of lines to parse per batch.
         :type chunk_size: int
-        :return: A DataFrame combining all chunks.
+        :return: Combined table of attribute columns.
         :rtype: pd.DataFrame
         """
         info_dfs = []
@@ -268,11 +314,12 @@ class GffParser:
 
 class FastaParser:
     """
-    A parser class for handling FASTA files.
+    Read, write, and merge nucleic acid sequences in FASTA format.
 
-    The FastaParser class provides methods for processing and manipulating sequences within FASTA files.
-    It is designed to support various sequence-related tasks, such as reading sequences, parsing sequence headers,
-    and performing operations on the parsed data.
+    FASTA files store reference genomes, extracted regions, and oligo sequences
+    used throughout the toolsuite. Headers from the region generator carry a region
+    ID plus optional metadata and 1-based coordinates
+    (``chromosome:start-end(strand)``).
     """
 
     def __init__(self) -> None:
@@ -280,17 +327,29 @@ class FastaParser:
 
     def check_fasta_format(self, file: str) -> bool:
         """
-        Validates whether the given file is in correct FASTA format.
+        Check whether a FASTA file exists and contains valid sequence records.
 
-        This function checks if a file exists and verifies whether it is in proper FASTA format by inspecting its content.
+        Confirms the file can be opened as FASTA before downstream read or merge
+        steps rely on it.
 
-        :param file: The path to the file to be checked.
+        :param file: Path to the FASTA file to check.
         :type file: str
-        :return: True if the file is a valid FASTA file, otherwise raises a ValueError.
+        :raises FileFormatError: If the file is missing or not a valid FASTA.
+        :return: ``True`` when the file exists and is a valid FASTA.
         :rtype: bool
         """
 
         def _check_fasta_content(file: str) -> bool:
+            """
+            Check whether the FASTA file yields at least one sequence record.
+
+            An empty index means the content is not usable as FASTA.
+
+            :param file: Path to the FASTA file to sample.
+            :type file: str
+            :return: ``True`` if at least one sequence record is found.
+            :rtype: bool
+            """
             fasta = SeqIO.index(file, "fasta")
             return any(fasta)  # False when `fasta` is empty, i.e. wasn't a FASTA file
 
@@ -306,11 +365,14 @@ class FastaParser:
 
     def is_coordinate(self, entry: str) -> bool:
         """
-        Checks if a given string is a valid coordinate format.
+        Check whether a header field looks like a genomic coordinate string.
 
-        :param entry: The string to be checked for coordinate format.
+        Matches the region-generator form ``chromosome:start-end(strand)``, where
+        starts are 1-based.
+
+        :param entry: Header field text to test.
         :type entry: str
-        :return: True if the string matches the coordinate pattern, otherwise False.
+        :return: ``True`` if the text matches the coordinate pattern.
         :rtype: bool
         """
         pattern = r"(\S+):(\d+)-(\d+)\(.*\)"
@@ -318,10 +380,13 @@ class FastaParser:
 
     def parse_number(self, s: str) -> int | float | str:
         """
-        Check if a string is an integer or a float. If so, return
-        the integer or float value. Otherwise, return the original string.
+        Parse a string as an integer or float when possible.
 
-        Examples:
+        Used when reading numeric metadata from FASTA header key-value fields.
+        Non-numeric text is returned unchanged.
+
+        Examples::
+
             >>> parse_number("42")
             42
             >>> parse_number("3.14")
@@ -329,11 +394,11 @@ class FastaParser:
             >>> parse_number("abc")
             "abc"
             >>> parse_number("5.0")
-            5.0   # note that "5.0" is treated as a float, not an integer
+            5.0
 
-        :param s: The string to parse.
+        :param s: Text to parse.
         :type s: str
-        :return: The parsed integer or float value if successful, or None otherwise.
+        :return: Integer, float, or the original string.
         :rtype: int | float | str
         """
         try:
@@ -350,11 +415,14 @@ class FastaParser:
 
     def get_fasta_regions(self, file_fasta_in: str) -> list[str]:
         """
-        Extracts unique region identifiers from a FASTA file.
+        List unique region IDs from a FASTA file.
 
-        :param file_fasta_in: The path to the input FASTA file.
+        Region IDs are taken from the first field of each sequence header, as
+        produced by the genomic region generator.
+
+        :param file_fasta_in: Path to the input FASTA file.
         :type file_fasta_in: str
-        :return: A list of unique region identifiers found in the FASTA file.
+        :return: Unique region identifiers found in the file.
         :rtype: list[str]
         """
         region_ids = []
@@ -369,17 +437,17 @@ class FastaParser:
         self, file_fasta_in: str, region_ids: str | list[str] | None = None
     ) -> list[Any]:
         """
-        Reads sequences from a FASTA file, optionally filtering by specific region identifiers.
+        Load sequences from a FASTA file, optionally filtered by region ID.
 
-        This function reads sequences from the specified FASTA file. If a list of region IDs is provided,
-        only the sequences corresponding to those regions are extracted.
+        When ``region_ids`` is set, only sequences whose header region matches are
+        returned. Otherwise every record in the file is loaded.
 
-        :param file_fasta_in: The path to the input FASTA file.
+        :param file_fasta_in: Path to the input FASTA file.
         :type file_fasta_in: str
-        :param region_ids: Region identifier(s) to process. Can be a single region ID (str) or a list of region IDs (list[str]). If None, all regions in the database are processed, defaults to None.
-        :type region_ids: str | list[str], optional
-        :return: A list of sequences from the FASTA file, filtered by region if specified.
-        :rtype: list
+        :param region_ids: One region ID, a list of IDs, or ``None`` for all regions.
+        :type region_ids: str | list[str] | None
+        :return: Sequence records from the file (filtered when IDs are given).
+        :rtype: list[Any]
         """
         region_ids_set = set(region_ids) if region_ids else None
 
@@ -404,19 +472,21 @@ class FastaParser:
         self, header: str, parse_coordinates: bool = True, parse_additional_info: bool = True
     ) -> tuple[str, dict[str, list[Any]] | str, dict[str, list[Any]]]:
         """
-        Parses the header of a FASTA sequence to extract region, coordinates, and additional information.
+        Parse region ID, coordinates, and metadata from a FASTA header.
 
-        This function processes the header of a FASTA sequence to extract the region name,
-        optional genomic coordinates, and additional key-value pair information.
+        Headers from the region generator look like
+        ``region_id::key=value::chr:start-end(strand)``. Coordinate starts are
+        1-based. Set the parse flags to skip coordinates or metadata when not needed.
 
-        :param header: The header string from a FASTA sequence.
+        :param header: FASTA header text (with or without a leading ``>``).
         :type header: str
-        :param parse_coordinates: Whether to parse genomic coordinates from the header, defaults to True.
-        :type parse_coordinates: bool, optional
-        :param parse_additional_info: Whether to parse additional information from the header, defaults to True.
-        :type parse_additional_info: bool, optional
-        :return: A tuple containing the region name, additional info dictionary, and coordinates dictionary.
-        :rtype: tuple[str, dict[str, list[Any]], dict[str, list[Any]]]
+        :param parse_coordinates: If ``True``, extract chromosome, start, end, and strand.
+        :type parse_coordinates: bool
+        :param parse_additional_info: If ``True``, parse key-value metadata into a dict;
+            if ``False``, return that field as a string when present.
+        :type parse_additional_info: bool
+        :return: Region ID, additional info (dict or string), and coordinates dict.
+        :rtype: tuple[str, dict[str, list[Any]] | str, dict[str, list[Any]]]
         """
         region: str = ""
         additional_info: dict[str, list[Any]] | str = {}
@@ -474,29 +544,33 @@ class FastaParser:
 
     def write_fasta_sequences(self, fasta_sequences: list[Any], file_out: str) -> None:
         """
-        Write a list of fasta sequences to an output file.
+        Write sequence records to a FASTA file.
 
-        :param fasta_sequences: list of fasta sequences to be written.
+        Overwrites ``file_out`` with the given records in standard FASTA layout.
+
+        :param fasta_sequences: Sequence records to write.
         :type fasta_sequences: list[Any]
-        :param file_out: Path to the output fasta file.
+        :param file_out: Path of the output FASTA file.
         :type file_out: str
+        :return: None
         """
         with open(file_out, "w") as handle_fasta:
             SeqIO.write(fasta_sequences, handle_fasta, "fasta")
 
     def merge_fasta_files(self, files_in: list[str], file_out: str, overwrite: bool = False) -> None:
         """
-        Merges multiple FASTA files into a single output file.
+        Merge several FASTA files into one output file.
 
-        This method takes a list of input FASTA files and merges their contents into a single output file.
-        The output file can either overwrite any existing file or append to it based on the `overwrite` parameter.
+        Concatenates all sequence records from the inputs. Set ``overwrite`` to
+        replace an existing output; otherwise records are appended.
 
-        :param files_in: A list of input FASTA files to be merged.
+        :param files_in: Paths of the FASTA files to merge.
         :type files_in: list[str]
-        :param file_out: The path to the output FASTA file.
+        :param file_out: Path of the merged FASTA file.
         :type file_out: str
-        :param overwrite: Whether to overwrite the output file if it exists, defaults to False.
+        :param overwrite: If ``True``, replace ``file_out``; if ``False``, append.
         :type overwrite: bool
+        :return: None
         """
         files_in = cast_to_list(files_in)
         file_out_mode = "w" if overwrite else "a"
@@ -508,14 +582,16 @@ class FastaParser:
 
     def index_fasta_file(self, file_fasta: str) -> None:
         """
-        Creates or refreshes the FASTA index file (.fai) for the given FASTA file.
+        Create or refresh a ``.fai`` index for a FASTA file.
 
-        This method ensures that a valid index exists for the FASTA file. Any existing index
-        will be removed before creating a new one. This is useful after overwriting a FASTA
-        file to ensure the index matches the new content.
+        Removes any existing index, then builds a new one with ``samtools faidx``.
+        Call this after rewriting a FASTA so tools such as bedtools see matching
+        sequence offsets.
 
         :param file_fasta: Path to the FASTA file to index.
         :type file_fasta: str
+        :raises FileFormatError: If the FASTA is missing or indexing fails.
+        :return: None
         """
         if not os.path.exists(file_fasta):
             raise FileFormatError(f"FASTA file '{file_fasta}' does not exist.")
@@ -548,8 +624,11 @@ class FastaParser:
 
 class VCFParser:
     """
-    A parser for handling VCF (Variant Call Format) files, including reading, writing,
-    merging, and verifying VCF file formats.
+    Read, write, and merge variant records in VCF format.
+
+    VCF files store SNPs and other variants relative to a reference genome.
+    Use this class to check format, load variants for filtering or annotation,
+    write selected records, and merge multiple VCF inputs into one file.
     """
 
     def __init__(self) -> None:
@@ -557,16 +636,28 @@ class VCFParser:
 
     def check_vcf_format(self, file: str) -> bool:
         """
-        Check if the provided file is a valid VCF file.
+        Check whether a VCF file exists and contains valid variant records.
+
+        Confirms the file can be opened as VCF before read or merge steps use it.
 
         :param file: Path to the VCF file to check.
         :type file: str
-        :return: True if the file is a valid VCF file, raises an exception otherwise.
+        :raises FileFormatError: If the file is missing or not a valid VCF.
+        :return: ``True`` when the file exists and is a valid VCF.
         :rtype: bool
-        :raises ValueError: If the file is missing or has an incorrect VCF format.
         """
 
         def _check_vcf_content(file: str) -> bool:
+            """
+            Check whether the VCF file yields at least one variant record.
+
+            An empty result means the content is not usable as VCF.
+
+            :param file: Path to the VCF file to sample.
+            :type file: str
+            :return: ``True`` if at least one variant record is found.
+            :rtype: bool
+            """
             vcf = VCF(file)
             return any(vcf)  # False when `vcf` is empty, i.e. wasn't a vcf file
 
@@ -580,13 +671,16 @@ class VCFParser:
 
     def read_vcf_variants(self, file: str) -> tuple[list[Any], Any]:
         """
-        Read variants from a VCF file.
+        Load variant records from a VCF file.
+
+        Checks format first, then returns every variant plus the VCF handle used
+        for writing compatible output later.
 
         :param file: Path to the VCF file to read.
         :type file: str
-        :return: A list of variant records and the VCF file handler.
-        :rtype: list
-        :raises ValueError: If the VCF file is not correctly formatted.
+        :raises FileFormatError: If the file is missing or not a valid VCF.
+        :return: List of variant records and the VCF file handle.
+        :rtype: tuple[list[Any], Any]
         """
         self.check_vcf_format(file)
 
@@ -600,14 +694,18 @@ class VCFParser:
 
     def write_vcf_variants(self, vcf_variants: list, vcf_in: str, file_out: str) -> None:
         """
-        Write a list of VCF variants to an output file.
+        Write variant records to a VCF file.
 
-        :param vcf_variants: list of variant records to be written.
+        Uses the input VCF handle for header and formatting so the output stays
+        compatible with the source file.
+
+        :param vcf_variants: Variant records to write.
         :type vcf_variants: list
-        :param vcf_in: VCF file handler used for formatting.
+        :param vcf_in: VCF handle that supplies header and format information.
         :type vcf_in: str
-        :param file_out: Path to the output VCF file.
+        :param file_out: Path of the output VCF file.
         :type file_out: str
+        :return: None
         """
         vcf_out = Writer(file_out, vcf_in)
         for variant in vcf_variants:
@@ -616,12 +714,16 @@ class VCFParser:
 
     def merge_vcf_files(self, files_in: list[str], file_out: str) -> None:
         """
-        Merge multiple VCF files into a single VCF file.
+        Merge several VCF files into one output file.
 
-        :param files_in: list of input VCF files to be merged.
-        :type files_in: list
-        :param file_out: Path to the output merged VCF file.
+        Compresses, sorts, and indexes inputs as needed, then merges them with
+        bcftools into a single uncompressed VCF.
+
+        :param files_in: Paths of the VCF files to merge.
+        :type files_in: list[str]
+        :param file_out: Path of the merged VCF file.
         :type file_out: str
+        :return: None
         """
         # Track compressed files that need to be cleaned up
         compressed_files_to_cleanup: list[str] = []
@@ -657,3 +759,134 @@ class VCFParser:
                 index_file = f"{file_vcf_compressed}{index_ext}"
                 if os.path.exists(index_file):
                     os.remove(index_file)
+
+
+############################################
+# BED Parser Class
+############################################
+
+
+class BedParser:
+    """
+    Read and write genomic intervals in BED format.
+
+    BED starts are 0-based. Region-generator FASTA headers and GFF/GTF annotations
+    use 1-based starts; convert with :meth:`convert_start` when moving between those
+    coordinate systems. On read, UCSC ``track``, ``browser``, and ``#`` lines are skipped.
+    """
+
+    BED_SKIP_LINE_PREFIXES = ("track", "browser", "#")
+    VALID_INDEXINGS = ("0-based", "1-based")
+
+    def __init__(self) -> None:
+        """Constructor for the BedParser class."""
+
+    def read_bed(
+        self,
+        filepath: str,
+        names: list[str] | None = None,
+        **kwargs: Any,
+    ) -> pd.DataFrame | Any:
+        """
+        Load genomic intervals from a BED file.
+
+        Ignores blank lines and UCSC header or comment lines that start with
+        ``track``, ``browser``, or ``#``. Interval starts in the result are 0-based.
+
+        For very large files, pass ``chunksize`` to read the intervals in batches
+        instead of loading the whole table at once.
+
+        :param filepath: Path to the BED file to load.
+        :type filepath: str
+        :param names: Column names for the BED fields. If ``None``, columns are numbered.
+        :type names: list[str] | None
+        :param kwargs: Extra options for ``pandas.read_csv`` (for example ``chunksize``).
+        :return: Table of intervals, or a chunk iterator when ``chunksize`` is set.
+        :rtype: pd.DataFrame | Any
+        """
+        with open(filepath) as handle:
+            skiprows = [i for i, line in enumerate(handle) if not self._is_bed_data_line(line)]
+
+        return pd.read_csv(
+            filepath,
+            sep="\t",
+            header=None,
+            names=names,
+            skiprows=skiprows,
+            **kwargs,
+        )
+
+    def _is_bed_data_line(self, line: str) -> bool:
+        """
+        Check whether a line is a BED interval row.
+
+        Returns ``False`` for blank lines and for UCSC ``track``, ``browser``, or
+        ``#`` comment lines.
+
+        :param line: One line from a BED file.
+        :type line: str
+        :return: ``True`` if the line should be kept as interval data.
+        :rtype: bool
+        """
+        return bool(line.strip()) and not line.startswith(self.BED_SKIP_LINE_PREFIXES)
+
+    def write_bed(
+        self,
+        bed: pd.DataFrame,
+        filepath: str,
+        columns: list[str] | None = None,
+    ) -> None:
+        """
+        Write genomic intervals to a BED file.
+
+        The file has no header row. Starts must already be 0-based. If your
+        coordinates come from FASTA headers or GFF/GTF (1-based), convert them
+        with :meth:`convert_start` first.
+
+        :param bed: Table of intervals to write.
+        :type bed: pd.DataFrame
+        :param filepath: Path of the BED file to create.
+        :type filepath: str
+        :param columns: Columns to write, in order. If ``None``, all columns are written.
+        :type columns: list[str] | None
+        :return: None
+        """
+        bed_to_write = bed[columns] if columns is not None else bed
+        bed_to_write.to_csv(filepath, sep="\t", header=False, index=False)
+
+    def convert_start(
+        self,
+        start_coordinates: Any,
+        from_indexing: str,
+        to_indexing: str,
+    ) -> Any:
+        """
+        Convert interval start positions between 0-based and 1-based indexing.
+
+        Use this when moving starts between BED (0-based) and formats such as
+        GFF/GTF or region-generator FASTA headers (1-based). Ends are unchanged
+        in the usual half-open BED and inclusive GFF conventions.
+
+        :param start_coordinates: One start position or a series of starts.
+        :type start_coordinates: Any
+        :param from_indexing: Current indexing, ``0-based`` or ``1-based``.
+        :type from_indexing: str
+        :param to_indexing: Desired indexing, ``0-based`` or ``1-based``.
+        :type to_indexing: str
+        :return: Converted start(s), same type as ``start_coordinates``.
+        :rtype: Any
+        :raises ConfigurationError: If ``from_indexing`` or ``to_indexing`` is not supported.
+        """
+        if from_indexing not in self.VALID_INDEXINGS:
+            raise ConfigurationError(
+                f"Invalid from_indexing '{from_indexing}'. Expected one of {self.VALID_INDEXINGS}."
+            )
+        if to_indexing not in self.VALID_INDEXINGS:
+            raise ConfigurationError(
+                f"Invalid to_indexing '{to_indexing}'. Expected one of {self.VALID_INDEXINGS}."
+            )
+        if from_indexing == to_indexing:
+            return start_coordinates
+        if from_indexing == "0-based" and to_indexing == "1-based":
+            return start_coordinates + 1
+        return start_coordinates - 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -11,7 +11,7 @@ import yaml
 
 from oligo_designer_toolsuite.database import OligoDatabase, ReferenceDatabase
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
-from oligo_designer_toolsuite.utils import FastaParser, VCFParser, check_tsv_format
+from oligo_designer_toolsuite.utils import BedParser, FastaParser, VCFParser, check_tsv_format
 
 ############################################
 # setup
@@ -299,11 +299,12 @@ class TestOligoDatabase(unittest.TestCase):
 
         assert check_tsv_format(file_bed) == True, f"error: wrong file format"
 
-        bed_table = pd.read_csv(
-            file_bed, sep="\t", names=["chromosome", "start", "end", "name", "score", "strand"]
+        # DB/FASTA coordinates are 1-based; BED export must use 0-based starts.
+        bed_table = BedParser().read_bed(
+            file_bed, names=["chromosome", "start", "end", "name", "score", "strand"]
         )
 
-        assert bed_table.loc[0, "start"] == 70289456
+        assert bed_table.loc[0, "start"] == 70289455
         assert bed_table.loc[0, "end"] == 70289485
 
     def test_write_oligosets_to_yaml(self) -> None:

--- a/tests/test_oligo_property_calculator.py
+++ b/tests/test_oligo_property_calculator.py
@@ -69,6 +69,30 @@ class TestOligoProperties(unittest.TestCase):
         assert length1 == 20, "error: wrong oligo length"
         assert length2 == 29, "error: wrong oligo length"
 
+    def test_calculate_oligo_length_single_region(self) -> None:
+        length_property = LengthProperty()
+        calculator = PropertyCalculator(properties=[length_property])
+        oligo_database = calculator.apply(
+            oligo_database=self.oligo_database,
+            sequence_type="oligo",
+            region_ids="region_1",
+            n_jobs=1,
+        )
+
+        length_region_1 = oligo_database.get_oligo_property_value(
+            property="length_oligo", flatten=True, region_id="region_1", oligo_id="region_1::1"
+        )
+        length_region_2 = oligo_database.get_oligo_property_value(
+            property="length_oligo", flatten=True, region_id="region_2", oligo_id="region_2::1"
+        )
+        length_region_3 = oligo_database.get_oligo_property_value(
+            property="length_oligo", flatten=True, region_id="region_3", oligo_id="region_3::1"
+        )
+
+        assert length_region_1 == 20, "error: wrong oligo length for selected region"
+        assert length_region_2 is None, "error: property calculated for unselected region"
+        assert length_region_3 is None, "error: property calculated for unselected region"
+
     def test_calculate_reverse_complement_sequence(self) -> None:
         reverse_complement_property = ReverseComplementSequenceProperty(
             sequence_type_reverse_complement="oligo"

--- a/tests/test_sequence_generator.py
+++ b/tests/test_sequence_generator.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, cast
 from unittest.mock import patch
 
+import pandas as pd
 from Bio import SeqIO
 
 from oligo_designer_toolsuite._exceptions import ConfigurationError
@@ -24,7 +25,7 @@ from oligo_designer_toolsuite.sequence_generator import (
     FtpLoaderNCBI,
     OligoSequenceGenerator,
 )
-from oligo_designer_toolsuite.utils import FastaParser, check_if_dna_sequence
+from oligo_designer_toolsuite.utils import FastaParser, check_if_dna_sequence, get_complement_regions
 
 from .expected_values_region_generator import (
     EXPECTED_HEADER_VALUES_BACTERIA_NCBI,
@@ -613,6 +614,38 @@ class GenomicRegionGeneratorBase(unittest.TestCase, ABC):
 
     def test_intron(self) -> None:
         self._run_generation_test("intron", self.region_generator.get_sequence_intron)
+
+    def test_chromosome_length_file_keeps_first_row_with_header_none(self) -> None:
+        # chrom.sizes / bedtools -g files are headerless; header=0 would drop the first chromosome.
+        file_fasta = os.path.join(self.tmp_path, "genome.fna")
+        with open(file_fasta, "w") as handle:
+            handle.write(">chr1\n")
+            handle.write("A" * 1000 + "\n")
+            handle.write(">chr2\n")
+            handle.write("C" * 2000 + "\n")
+
+        self.region_generator.sequence_file = file_fasta
+        file_chromosome_length = self.region_generator._get_chromosome_length()
+
+        # Same load path as get_sequence_intergenic when a chromosome has no genes.
+        chromosome_length = pd.read_csv(
+            file_chromosome_length, sep="\t", header=None, names=["seqid", "length"]
+        )
+        assert list(chromosome_length["seqid"]) == ["chr1", "chr2"]
+        assert list(chromosome_length["length"]) == [1000, 2000]
+
+        # Same file is the -g argument to bedtools complement via get_complement_regions.
+        file_bed_in = os.path.join(self.tmp_path, "annotation_in.bed")
+        file_bed_out = os.path.join(self.tmp_path, "annotation_out.bed")
+        with open(file_bed_in, "w") as handle:
+            handle.write("chr1\t100\t200\n")
+
+        get_complement_regions(file_bed_in, file_chromosome_length, file_bed_out)
+
+        complement = self.region_generator.bed_parser.read_bed(file_bed_out, names=["seqid", "start", "end"])
+        assert list(complement["seqid"]) == ["chr1", "chr1"]
+        assert list(complement["start"]) == [0, 200]
+        assert list(complement["end"]) == [100, 1000]
 
 
 class TestGenomicRegionGeneratorNCBI(GenomicRegionGeneratorBase):

--- a/tests/test_sequence_generator.py
+++ b/tests/test_sequence_generator.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Callable, cast
 from unittest.mock import patch
 
-import pandas as pd
 from Bio import SeqIO
 
 from oligo_designer_toolsuite._exceptions import ConfigurationError
@@ -628,9 +627,7 @@ class GenomicRegionGeneratorBase(unittest.TestCase, ABC):
         file_chromosome_length = self.region_generator._get_chromosome_length()
 
         # Same load path as get_sequence_intergenic when a chromosome has no genes.
-        chromosome_length = pd.read_csv(
-            file_chromosome_length, sep="\t", header=None, names=["seqid", "length"]
-        )
+        chromosome_length = self.region_generator._read_chromosome_length_file(file_chromosome_length)
         assert list(chromosome_length["seqid"]) == ["chr1", "chr2"]
         assert list(chromosome_length["length"]) == [1000, 2000]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -523,18 +523,6 @@ class TestBedParser(unittest.TestCase):
         with self.assertRaises(ConfigurationError):
             self.parser.convert_start(starts, "0-based", "one")
 
-    def test_chromosome_length_file_keeps_first_row_with_header_none(self) -> None:
-        # chrom.sizes / bedtools -g files are headerless; header=0 would drop the first chromosome.
-        file_genome = os.path.join(self.tmp_path, "annotation.genome")
-        with open(file_genome, "w") as handle:
-            handle.write("chr1\t1000\n")
-            handle.write("chr2\t2000\n")
-
-        chromosome_length = pd.read_csv(file_genome, sep="\t", header=None, names=["seqid", "length"])
-
-        assert list(chromosome_length["seqid"]) == ["chr1", "chr2"]
-        assert list(chromosome_length["length"]) == [1000, 2000]
-
 
 class TestFastaParser(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ import pandas as pd
 from Bio.SeqUtils import MeltingTemp as mt
 from effidict import EffiDict, LRUReplacement, PickleBackend
 
+from oligo_designer_toolsuite._exceptions import ConfigurationError
 from oligo_designer_toolsuite.database import OligoDatabase
 from oligo_designer_toolsuite.pipelines._utils import (
     get_highly_abundant_kmer_sequences,
@@ -19,6 +20,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
 )
 from oligo_designer_toolsuite.sequence_generator import OligoSequenceGenerator
 from oligo_designer_toolsuite.utils import (
+    BedParser,
     FastaParser,
     GffParser,
     VCFParser,
@@ -416,6 +418,123 @@ class TestGffParser(unittest.TestCase):
         """Test loading annotation from a pickle file."""
         result = self.parser.load_annotation_from_pickle(FILE_PICKLE)
         assert type(result) == pd.DataFrame, f"error: GTF dataframe not correctly loaded from pickle file"
+
+
+class TestBedParser(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_path = os.path.join(os.getcwd(), "tmp_bed_parser")
+        Path(self.tmp_path).mkdir(parents=True, exist_ok=True)
+        self.parser = BedParser()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp_path)
+
+    def test_read_bed_skips_track_browser_and_comment_lines(self) -> None:
+        file_bed = os.path.join(self.tmp_path, "with_headers.bed")
+        with open(file_bed, "w") as handle:
+            handle.write("browser position chr1:1-1000\n")
+            handle.write('track name="test" description="demo"\n')
+            handle.write("# comment line\n")
+            handle.write("\n")
+            handle.write("chr1\t0\t100\tfeat1\t.\t+\n")
+            handle.write("chr1\t200\t300\tfeat2\t.\t-\n")
+
+        bed = self.parser.read_bed(file_bed, names=["seqid", "start", "end", "name", "score", "strand"])
+
+        assert len(bed) == 2, "error: track/browser/comment/blank lines should be skipped"
+        assert bed.loc[0, "seqid"] == "chr1"
+        assert bed.loc[0, "start"] == 0
+        assert bed.loc[0, "end"] == 100
+        assert bed.loc[1, "name"] == "feat2"
+
+    def test_read_bed_does_not_truncate_contig_names_containing_t(self) -> None:
+        file_bed = os.path.join(self.tmp_path, "contig_with_t.bed")
+        with open(file_bed, "w") as handle:
+            handle.write("chr1_alt\t10\t20\n")
+            handle.write("scaffold_t1\t30\t40\n")
+
+        bed = self.parser.read_bed(file_bed, names=["seqid", "start", "end"])
+
+        assert list(bed["seqid"]) == ["chr1_alt", "scaffold_t1"]
+        assert list(bed["start"]) == [10, 30]
+        assert list(bed["end"]) == [20, 40]
+
+    def test_write_bed_and_read_bed_roundtrip(self) -> None:
+        file_bed = os.path.join(self.tmp_path, "roundtrip.bed")
+        bed_in = pd.DataFrame(
+            {
+                "seqid": ["chr1", "chr2"],
+                "start": [0, 100],
+                "end": [50, 150],
+                "name": ["a", "b"],
+                "score": [".", "."],
+                "strand": ["+", "-"],
+            }
+        )
+
+        self.parser.write_bed(
+            bed_in,
+            file_bed,
+            columns=["seqid", "start", "end", "name", "score", "strand"],
+        )
+
+        with open(file_bed) as handle:
+            first_line = handle.readline()
+        assert not first_line.startswith(("track", "browser", "#"))
+        assert "seqid" not in first_line
+
+        bed_out = self.parser.read_bed(file_bed, names=["seqid", "start", "end", "name", "score", "strand"])
+        pd.testing.assert_frame_equal(bed_out, bed_in)
+
+    def test_read_bed_chunksize_streams_filtered_rows(self) -> None:
+        file_bed = os.path.join(self.tmp_path, "chunked.bed")
+        with open(file_bed, "w") as handle:
+            handle.write('track name="demo"\n')
+            handle.write("# comment\n")
+            for i in range(5):
+                handle.write(f"chr1\t{i * 10}\t{i * 10 + 5}\n")
+
+        chunks = self.parser.read_bed(file_bed, names=["seqid", "start", "end"], chunksize=2)
+        frames = list(chunks)
+        chunks.close()
+
+        assert len(frames) == 3
+        bed = pd.concat(frames, ignore_index=True)
+        assert len(bed) == 5
+        assert list(bed["start"]) == [0, 10, 20, 30, 40]
+
+    def test_convert_start_0_to_1_and_1_to_0(self) -> None:
+        assert self.parser.convert_start(99, "0-based", "1-based") == 100
+        assert self.parser.convert_start(100, "1-based", "0-based") == 99
+
+        starts = pd.Series([0, 10, 20])
+        converted = self.parser.convert_start(starts, "0-based", "1-based")
+        pd.testing.assert_series_equal(converted, pd.Series([1, 11, 21]))
+
+        roundtrip = self.parser.convert_start(converted, "1-based", "0-based")
+        pd.testing.assert_series_equal(roundtrip, starts)
+
+    def test_convert_start_same_indexing_is_identity(self) -> None:
+        assert self.parser.convert_start(50, "0-based", "0-based") == 50
+        assert self.parser.convert_start(50, "1-based", "1-based") == 50
+
+    def test_convert_start_invalid_indexing_raises(self) -> None:
+        with self.assertRaises(ConfigurationError):
+            self.parser.convert_start(10, "zero", "1-based")
+        with self.assertRaises(ConfigurationError):
+            self.parser.convert_start(10, "0-based", "one")
+
+    def test_chromosome_length_file_keeps_first_row_with_header_none(self) -> None:
+        # chrom.sizes / bedtools -g files are headerless; header=0 would drop the first chromosome.
+        file_genome = os.path.join(self.tmp_path, "annotation.genome")
+        with open(file_genome, "w") as handle:
+            handle.write("chr1\t1000\n")
+            handle.write("chr2\t2000\n")
+
+        chromosome_length = pd.read_csv(file_genome, sep="\t", header=None, names=["seqid", "length"])
+
+        assert list(chromosome_length["seqid"]) == ["chr1", "chr2"]
+        assert list(chromosome_length["length"]) == [1000, 2000]
 
 
 class TestFastaParser(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -504,9 +504,6 @@ class TestBedParser(unittest.TestCase):
         assert list(bed["start"]) == [0, 10, 20, 30, 40]
 
     def test_convert_start_0_to_1_and_1_to_0(self) -> None:
-        assert self.parser.convert_start(99, "0-based", "1-based") == 100
-        assert self.parser.convert_start(100, "1-based", "0-based") == 99
-
         starts = pd.Series([0, 10, 20])
         converted = self.parser.convert_start(starts, "0-based", "1-based")
         pd.testing.assert_series_equal(converted, pd.Series([1, 11, 21]))
@@ -515,14 +512,16 @@ class TestBedParser(unittest.TestCase):
         pd.testing.assert_series_equal(roundtrip, starts)
 
     def test_convert_start_same_indexing_is_identity(self) -> None:
-        assert self.parser.convert_start(50, "0-based", "0-based") == 50
-        assert self.parser.convert_start(50, "1-based", "1-based") == 50
+        starts = pd.Series([50, 100])
+        pd.testing.assert_series_equal(self.parser.convert_start(starts, "0-based", "0-based"), starts)
+        pd.testing.assert_series_equal(self.parser.convert_start(starts, "1-based", "1-based"), starts)
 
     def test_convert_start_invalid_indexing_raises(self) -> None:
+        starts = pd.Series([10])
         with self.assertRaises(ConfigurationError):
-            self.parser.convert_start(10, "zero", "1-based")
+            self.parser.convert_start(starts, "zero", "1-based")
         with self.assertRaises(ConfigurationError):
-            self.parser.convert_start(10, "0-based", "one")
+            self.parser.convert_start(starts, "0-based", "one")
 
     def test_chromosome_length_file_keeps_first_row_with_header_none(self) -> None:
         # chrom.sizes / bedtools -g files are headerless; header=0 would drop the first chromosome.


### PR DESCRIPTION
## Summary
- Add `BedParser` for reading/writing BED files and converting between 0-based and 1-based starts
- Fix intergenic region generation: stop using `comment="t"` / `header=0` on genome and complement BED files (dropped first rows / truncated lines with `t`)
- Fix `write_database_to_bed` to export 0-based BED starts (was writing 1-based FASTA/DB coords)
- Align region-generator temp BED I/O with `BedParser`; expand docstrings; add unit tests