### PR TITLE
Fix: Only keep one of each duplicate in `_get_duplicated_sequences`

### DIFF
--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_exact_matches.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_exact_matches.py
@@ -181,6 +181,7 @@ class ExactMatchFilter(BaseSpecificityFilter):
 
         This function takes a list of sequences, converts them to uppercase, and identifies sequences that appear more than once.
         It returns a list of these duplicated sequences, which can be used for further analysis or filtering.
+        If a sequence occurs more than twice, the output will only include it a single time.
 
         :param sequences: A list of sequences to be checked for duplicates.
         :type sequences: list[str]
@@ -192,17 +193,17 @@ class ExactMatchFilter(BaseSpecificityFilter):
 
         # keep track of seen sequences and found duplicates
         seen: set[str] = set()
-        duplicated_sequences = []
+        duplicated_sequences = set()
 
         # find the duplicates within the database
         for sequence in sequences:
             if sequence in seen:
                 # sequence was seen before -> duplicate
-                duplicated_sequences.append(sequence)
+                duplicated_sequences.add(sequence)
             else:
                 seen.add(sequence)
 
-        return duplicated_sequences
+        return list(duplicated_sequences)
 
     def _run_filter(
         self,


### PR DESCRIPTION
This PR is a fix for a regression introduced in #207, see https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/pull/233/changes#r3748174315.

Changes:
- add a sentence on >2 occurrences duplicate handling to the docstring
- replace `duplicated_sequences = []` with `duplicated_sequences = set()`
- replace `return duplicated_sequences` with `return list(duplicated_sequences)`

There's a performance benefit to be had downstream when keeping the returned duplicates as a set, but that would be a larger change that requires careful review. This is just the fix.