### PR TITLE
213 pydantic for merfish

### DIFF
--- a/data/configs/merfish_probe_designer.yaml
+++ b/data/configs/merfish_probe_designer.yaml
@@ -150,9 +150,7 @@ readout_probes:
     probe_set_selection: # Select a set of readout probes with homogeneous Tm / GC content (uses HomogeneousPropertyOligoSelection).
       set_size: 16 # Total number of readout probes to select (must equal n_bits so each bit gets a probe).
       n_combinations: 100000 # Number of candidate sets to evaluate; higher values may find better sets but increase computation time.
-      homogeneous_properties_weights: # Weights for property homogeneity in the score minimised across the set (weighted sum of variances).
-        TmNN_oligo: 1.0 # Melting temperature.
-        GC_content_oligo: 1.0 # GC content.
+      homogeneous_properties_weights: {TmNN_oligo: 1.0, GC_content_oligo: 1.0} # Weights for property homogeneity in the score minimised across the set (weighted sum of variances).
 
     global_parameters:
       Tm_parameters:

--- a/data/configs/merfish_probe_designer.yaml
+++ b/data/configs/merfish_probe_designer.yaml
@@ -57,7 +57,7 @@ target_probes:
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
       hit_parameters: {"min_alignment_length": 17} # Hit criteria. Hits satisfying these lead to oligo rejection.
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Shared with the cross-hybridization filter. Use genomic_region_generator for custom reference sets.
+      files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
         - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
         - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
@@ -138,7 +138,7 @@ readout_probes:
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
         hit_parameters: {"min_alignment_length": 11}
-        files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Shared with the cross-hybridization filter.
+        files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
           - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
           - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 

--- a/data/configs/seqfish_plus_probe_designer.yaml
+++ b/data/configs/seqfish_plus_probe_designer.yaml
@@ -52,7 +52,7 @@ target_probes:
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
       hit_parameters: {"min_alignment_length": 15} # Hit criteria. Hits satisfying these lead to oligo rejection.
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Shared with the cross-hybridization filter. Use genomic_region_generator for custom reference sets.
+      files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
         - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
         - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
@@ -112,7 +112,7 @@ readout_probes:
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
         hit_parameters: {"min_alignment_length": 10}
-        files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Shared with the cross-hybridization filter.
+        files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
           - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
           - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
@@ -169,7 +169,7 @@ primers:
         enabled: true
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
         hit_parameters: {"min_alignment_length": 14}
-        files_fasta_reference_database: # FASTA file(s) used as reference for primer specificity.
+        files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
           - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
           - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 

--- a/oligo_designer_toolsuite/config/__init__.py
+++ b/oligo_designer_toolsuite/config/__init__.py
@@ -2,10 +2,14 @@ from oligo_designer_toolsuite.config.pipelines.cycle_hcr_probe_designer import C
 from oligo_designer_toolsuite.config.pipelines.hcr_probe_designer import HcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.scrinshot_probe_designer import ScrinshotProbeDesignerConfig
+from oligo_designer_toolsuite.config.pipelines.seqfish_plus_probe_designer import (
+    SeqfishPlusProbeDesignerConfig,
+)
 
 __all__ = [
     "CycleHcrProbeDesignerConfig",
     "HcrProbeDesignerConfig",
     "OligoSeqProbeDesignerConfig",
     "ScrinshotProbeDesignerConfig",
+    "SeqfishPlusProbeDesignerConfig",
 ]

--- a/oligo_designer_toolsuite/config/__init__.py
+++ b/oligo_designer_toolsuite/config/__init__.py
@@ -1,5 +1,6 @@
 from oligo_designer_toolsuite.config.pipelines.cycle_hcr_probe_designer import CycleHcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.hcr_probe_designer import HcrProbeDesignerConfig
+from oligo_designer_toolsuite.config.pipelines.merfish_probe_designer import MerfishProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.scrinshot_probe_designer import ScrinshotProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.seqfish_plus_probe_designer import (
@@ -9,6 +10,7 @@ from oligo_designer_toolsuite.config.pipelines.seqfish_plus_probe_designer impor
 __all__ = [
     "CycleHcrProbeDesignerConfig",
     "HcrProbeDesignerConfig",
+    "MerfishProbeDesignerConfig",
     "OligoSeqProbeDesignerConfig",
     "ScrinshotProbeDesignerConfig",
     "SeqfishPlusProbeDesignerConfig",

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -27,10 +27,22 @@ class General(BaseModel):
 
 class HomopolymericRunThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    A: PositiveInt | None = None
-    T: PositiveInt | None = None
-    C: PositiveInt | None = None
-    G: PositiveInt | None = None
+    A: PositiveInt | None = Field(
+        default=None,
+        description=" Minimum run length per base to count as homopolymeric. Oligos with longer runs are rejected.",
+    )
+    T: PositiveInt | None = Field(
+        default=None,
+        description=" Minimum run length per base to count as homopolymeric. Oligos with longer runs are rejected.",
+    )
+    C: PositiveInt | None = Field(
+        default=None,
+        description=" Minimum run length per base to count as homopolymeric. Oligos with longer runs are rejected.",
+    )
+    G: PositiveInt | None = Field(
+        default=None,
+        description=" Minimum run length per base to count as homopolymeric. Oligos with longer runs are rejected.",
+    )
 
 
 class BaseProbabilities(BaseModel):

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -33,6 +33,22 @@ class HomopolymericRunThreshold(BaseModel):
     G: PositiveInt | None = None
 
 
+class BaseProbabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    A: float = Field(ge=0, le=1, description="Probability of base 'A' when generating random sequences.")
+    C: float = Field(ge=0, le=1, description="Probability of base 'C' when generating random sequences.")
+    G: float = Field(ge=0, le=1, description="Probability of base 'G' when generating random sequences.")
+    T: float = Field(ge=0, le=1, description="Probability of base 'T' when generating random sequences.")
+
+    @model_validator(mode="after")
+    def _check_sum(self) -> Self:
+        total = self.A + self.C + self.G + self.T
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(f"Base probabilities must sum to 1.0 (got {total}).")
+        return self
+
+
 class BlastnSearchParameters(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_by_name=True, validate_by_alias=True)
 

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -20,12 +20,15 @@ class IndependentSetSelection(BaseModel):
 
     n_sets: PositiveInt = Field(
         description="Number of probe sets to generate per gene.",
+        json_schema_extra={"x-quick-setting": True},
     )
     set_size_min: PositiveInt = Field(
         description="Minimum set size. Genes that cannot form a set of at least this size are reported as insufficient.",
+        json_schema_extra={"x-quick-setting": True},
     )
     set_size_opt: PositiveInt = Field(
         description="Preferred (optimal) number of oligos per set.",
+        json_schema_extra={"x-quick-setting": True},
     )
     distance_between_probes: int = Field(
         description="Required spacing: negative = allow overlap (bases), 0 = adjacent OK, positive = minimum gap (bases).",

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -94,14 +94,14 @@ class UTRScore(BaseModel):
     )
 
 
-class GCContentScoreBasic(BaseModel):
+class GCContentScore(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     weight: float = Field(description="Weight for GC content in the set-selection scoring function.")
     GC_content_opt: GCContentOptT
 
 
-class GCContentScoreExpanded(GCContentScoreBasic):
+class GCContentScoreNormalized(GCContentScore):
     GC_content_min: GCContentMinT
     GC_content_max: GCContentMaxT
 

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -10,6 +10,10 @@ from oligo_designer_toolsuite.config._types import (
     TmOptT,
 )
 
+PROBE_SET_SELECTION_DESC = (
+    "Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
+)
+
 
 class IndependentSetSelection(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -15,37 +15,37 @@ class IndependentSetSelection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     n_sets: PositiveInt = Field(
-        description="Number of oligo sets to generate per region. Multiple sets allow for redundancy and selection of the best-performing set based on scoring criteria.",
+        description="Number of probe sets to generate per gene.",
     )
     set_size_min: PositiveInt = Field(
-        description="Minimum size (number of probes) required for each oligo set. Sets with fewer probes than this value will be rejected, and regions that cannot generate sets meeting this minimum will be removed. Regions with less oligos will be filtered out and stored in regions_with_insufficient_oligos_for_db_probes.",
+        description="Minimum set size. Genes that cannot form a set of at least this size are reported as insufficient.",
     )
     set_size_opt: PositiveInt = Field(
-        description="Optimal size (number of probes) for each oligo set. The set selection algorithm will attempt to generate sets of this size, but may produce sets with fewer probes if constraints cannot be met.",
+        description="Preferred (optimal) number of oligos per set.",
     )
     distance_between_probes: int = Field(
-        description="How much overlap should be allowed between oligos, e.g. if oligos can overlap x bases choose -x, if oligos can be next to one another choose 0, if oligos should be x bases apart choose x.",
+        description="Required spacing: negative = allow overlap (bases), 0 = adjacent OK, positive = minimum gap (bases).",
     )
     n_attempts_graph: PositiveInt = Field(
-        description="Number of randomized graph attempts. In each attempt, a fraction of nodes is randomly removed from the compatibility graph to create diversity; more attempts increase diversity at the cost of runtime.",
+        description="Number of randomized graph attempts used to diversify set selection.",
     )
     n_attempts_clique_enum: PositiveInt = Field(
-        description="Maximum number of cliques enumerated per graph attempt. Limits how many cliques are explored before stopping enumeration for the current graph.",
+        description="Maximum cliques enumerated per graph attempt.",
     )
     diversification_fraction: float = Field(
         ge=0,
         le=1,
-        description="Fraction of oligos to remove from the graph per attempt to create diversity in the set selection.",
+        description="Fraction of oligos removed from the graph in each attempt to increase set diversity.",
     )
     jaccard_opt: float = Field(
         ge=0,
         le=1,
-        description="Optimal maximum Jaccard overlap allowed between selected sets. Lower values enforce more diversity between sets.",
+        description="Target maximum Jaccard similarity between selected sets; lower = more distinct sets.",
     )
     jaccard_step: float = Field(
         ge=0,
         le=1,
-        description="Step size used to relax the Jaccard constraint when not enough sets are found.",
+        description="Step size for relaxing Jaccard threshold when too few sets are found.",
     )
 
     @model_validator(mode="after")
@@ -63,25 +63,41 @@ class ScoreBaseConfig(BaseModel):
     weight: float = Field(description="Weight assigned in the scoring function.")
 
 
-class UniformDistanceScore(ScoreBaseConfig):
-    pass
+class UniformDistanceScore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    weight: float = Field(description="Weight for uniform spacing in the set-selection scoring function.")
 
 
-class IsoformConsensusScore(ScoreBaseConfig):
-    pass
+class IsoformConsensusScore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    weight: float = Field(description="Weight for isoform coverage in the set-selection scoring function.")
 
 
-class TargetedExonsScore(ScoreBaseConfig):
+class TargetedExonsScore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    weight: float = Field(
+        description="Weight for targeted-exon coverage in the set-selection scoring function."
+    )
     targeted_exons: list[str] = Field(
         description="List of exon identifiers that should be preferentially targeted by probes, e.g. ['1', '2', '3']. Probes overlapping these exons receive higher scores."
     )
 
 
-class UTRScore(ScoreBaseConfig):
-    pass
+class UTRScore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    weight: float = Field(
+        description="Weight for UTR-overlap targeting in the set-selection scoring function."
+    )
 
 
-class GCContentScoreBasic(ScoreBaseConfig):
+class GCContentScoreBasic(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    weight: float = Field(description="Weight for GC content in the set-selection scoring function.")
     GC_content_opt: GCContentOptT
 
 
@@ -98,7 +114,10 @@ class GCContentScoreExpanded(GCContentScoreBasic):
         return self
 
 
-class TmScore(ScoreBaseConfig):
+class TmScore(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    weight: float = Field(description="Weight for Tm in the set-selection scoring function.")
     Tm_min: TmMinT
     Tm_opt: TmOptT
     Tm_max: TmMaxT

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -118,8 +118,12 @@ class TmScore(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     weight: float = Field(description="Weight for Tm in the set-selection scoring function.")
-    Tm_min: TmMinT
     Tm_opt: TmOptT
+
+
+class TmScoreNormalized(TmScore):
+
+    Tm_min: TmMinT
     Tm_max: TmMaxT
 
     @model_validator(mode="after")

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -77,9 +77,16 @@ class TargetedExonsScore(ScoreBaseConfig):
     )
 
 
-class GCContentScore(ScoreBaseConfig):
-    GC_content_min: GCContentMinT
+class UTRScore(ScoreBaseConfig):
+    pass
+
+
+class GCContentScoreBasic(ScoreBaseConfig):
     GC_content_opt: GCContentOptT
+
+
+class GCContentScoreExpanded(GCContentScoreBasic):
+    GC_content_min: GCContentMinT
     GC_content_max: GCContentMaxT
 
     @model_validator(mode="after")

--- a/oligo_designer_toolsuite/config/_property_filters.py
+++ b/oligo_designer_toolsuite/config/_property_filters.py
@@ -181,7 +181,13 @@ class TmFilterEnabled(FilterBaseConfigEnabled):
         return self
 
 
-TmFilterConfig = Annotated[TmFilterEnabled | TmFilterDisabled, Field(discriminator="enabled")]
+TmFilterConfig = Annotated[
+    TmFilterEnabled | TmFilterDisabled,
+    Field(
+        discriminator="enabled",
+        description="Enforce melting temperature (Tm) within a range (additionally uses Tm parameters).",
+    ),
+]
 
 
 class GCClampFilterDisabled(FilterBaseConfigDisabled):

--- a/oligo_designer_toolsuite/config/_property_filters.py
+++ b/oligo_designer_toolsuite/config/_property_filters.py
@@ -18,12 +18,12 @@ from oligo_designer_toolsuite.config._types import (
 
 class FilterBaseConfigEnabled(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    enabled: Literal[True]
+    enabled: Literal[True] = Field(description="Turn this filter on or off.")
 
 
 class FilterBaseConfigDisabled(BaseModel):
     model_config = ConfigDict(extra="ignore")
-    enabled: Literal[False]
+    enabled: Literal[False] = Field(description="Turn this filter on or off.")
 
 
 class IsoformConsensusFilterDisabled(FilterBaseConfigDisabled):
@@ -42,7 +42,11 @@ class IsoformConsensusFilterEnabled(FilterBaseConfigEnabled):
 
 
 IsoformConsensusFilterConfig = Annotated[
-    IsoformConsensusFilterEnabled | IsoformConsensusFilterDisabled, Field(discriminator="enabled")
+    IsoformConsensusFilterEnabled | IsoformConsensusFilterDisabled,
+    Field(
+        discriminator="enabled",
+        description="Require oligos to be supported by a minimum fraction of gene transcripts.",
+    ),
 ]
 
 
@@ -62,11 +66,15 @@ TargetedExonsFilterConfig = Annotated[
 
 
 class HardMaskedFilterConfig(BaseModel):
+    """Exclude oligos overlapping hard-masked (e.g. N) regions in the reference."""
+
     model_config = ConfigDict(extra="forbid")
     enabled: bool
 
 
 class SoftMaskedFilterConfig(BaseModel):
+    """Exclude oligos overlapping soft-masked (lowercase) regions in the reference."""
+
     model_config = ConfigDict(extra="forbid")
     enabled: bool
 
@@ -85,7 +93,10 @@ class HomopolymericRunsFilterEnabled(FilterBaseConfigEnabled):
 
 
 HomopolymericRunsFilterConfig = Annotated[
-    HomopolymericRunsFilterEnabled | HomopolymericRunsFilterDisabled, Field(discriminator="enabled")
+    HomopolymericRunsFilterEnabled | HomopolymericRunsFilterDisabled,
+    Field(
+        discriminator="enabled", description="Exclude oligos containing long homopolymeric runs (e.g. AAAAA)."
+    ),
 ]
 
 
@@ -107,7 +118,8 @@ class GCContentFilterEnabled(FilterBaseConfigEnabled):
 
 
 GCContentFilterConfig = Annotated[
-    GCContentFilterEnabled | GCContentFilterDisabled, Field(discriminator="enabled")
+    GCContentFilterEnabled | GCContentFilterDisabled,
+    Field(discriminator="enabled", description="Enforce GC content within a specified range."),
 ]
 
 
@@ -149,7 +161,8 @@ class SelfComplementarityFilterEnabled(FilterBaseConfigEnabled):
 
 
 SelfComplementarityFilterConfig = Annotated[
-    SelfComplementarityFilterEnabled | SelfComplementarityFilterDisabled, Field(discriminator="enabled")
+    SelfComplementarityFilterEnabled | SelfComplementarityFilterDisabled,
+    Field(discriminator="enabled", description="Limit self-complementarity to avoid hairpins."),
 ]
 
 
@@ -186,7 +199,13 @@ class GCClampFilterEnabled(FilterBaseConfigEnabled):
     ]
 
 
-GCClampFilterConfig = Annotated[GCClampFilterEnabled | GCClampFilterDisabled, Field(discriminator="enabled")]
+GCClampFilterConfig = Annotated[
+    GCClampFilterEnabled | GCClampFilterDisabled,
+    Field(
+        discriminator="enabled",
+        description="Require G/C nucleotides at the 3' end of the primer for stable binding.",
+    ),
+]
 
 
 class ComplementReversePrimerFilterDisabled(FilterBaseConfigDisabled):
@@ -204,7 +223,10 @@ class ComplementReversePrimerFilterEnabled(FilterBaseConfigEnabled):
 
 ComplementReversePrimerFilterConfig = Annotated[
     ComplementReversePrimerFilterEnabled | ComplementReversePrimerFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(
+        discriminator="enabled",
+        description="Limit complementarity between the forward primer and the (known) reverse primer to prevent primer-dimer formation.",
+    ),
 ]
 
 
@@ -218,5 +240,9 @@ class SecondaryStructureFilterEnabled(FilterBaseConfigEnabled):
 
 
 SecondaryStructureFilterConfig = Annotated[
-    SecondaryStructureFilterEnabled | SecondaryStructureFilterDisabled, Field(discriminator="enabled")
+    SecondaryStructureFilterEnabled | SecondaryStructureFilterDisabled,
+    Field(
+        discriminator="enabled",
+        description="Reject oligos with stable secondary structure at the given temperature.",
+    ),
 ]

--- a/oligo_designer_toolsuite/config/_property_filters.py
+++ b/oligo_designer_toolsuite/config/_property_filters.py
@@ -141,7 +141,7 @@ class SelfComplementarityFilterEnabled(FilterBaseConfigEnabled):
     max_len_selfcomplement: Annotated[
         NonNegativeInt,
         Field(
-            description="Maximum allowable length of self-complementary sequences. Probes with longer self-complementary regions can form hairpins and reduce hybridization efficiency."
+            description="Maximum allowable length of self-complementary sequences. Probes with longer self-complementary regions can form hairpins."
         ),
     ]
 
@@ -167,6 +167,43 @@ class TmFilterEnabled(FilterBaseConfigEnabled):
 
 
 TmFilterConfig = Annotated[TmFilterEnabled | TmFilterDisabled, Field(discriminator="enabled")]
+
+
+class GCClampFilterDisabled(FilterBaseConfigDisabled):
+    pass
+
+
+class GCClampFilterEnabled(FilterBaseConfigEnabled):
+    number_GC_GCclamp: Annotated[
+        PositiveInt,
+        Field(description="Minimum number of G or C nucleotides required at the 3' end."),
+    ]
+    number_three_prime_base_GCclamp: Annotated[
+        PositiveInt,
+        Field(description="Number of bases from the 3' end to consider for the GC clamp."),
+    ]
+
+
+GCClampFilterConfig = Annotated[GCClampFilterEnabled | GCClampFilterDisabled, Field(discriminator="enabled")]
+
+
+class ComplementReversePrimerFilterDisabled(FilterBaseConfigDisabled):
+    pass
+
+
+class ComplementReversePrimerFilterEnabled(FilterBaseConfigEnabled):
+    max_len_complement: Annotated[
+        NonNegativeInt,
+        Field(
+            description="Maximum allowable length of complementarity between the forward primer and the (known) reverse primer, to prevent primer-dimer formation."
+        ),
+    ]
+
+
+ComplementReversePrimerFilterConfig = Annotated[
+    ComplementReversePrimerFilterEnabled | ComplementReversePrimerFilterDisabled,
+    Field(discriminator="enabled"),
+]
 
 
 class SecondaryStructureFilterDisabled(FilterBaseConfigDisabled):

--- a/oligo_designer_toolsuite/config/_property_filters.py
+++ b/oligo_designer_toolsuite/config/_property_filters.py
@@ -34,7 +34,7 @@ class IsoformConsensusFilterEnabled(FilterBaseConfigEnabled):
     isoform_consensus: Annotated[
         float,
         Field(
-            description="Threshold for isoform consensus filtering in %. Probes with isoform consensus values below this threshold will be filtered out. This ensures that selected probes target sequences that are conserved across multiple transcript isoforms.",
+            description="Minimum isoform consensus (%). Oligos must be covered by at least this fraction of a gene's transcripts.",
             ge=0,
             le=100,
         ),
@@ -78,7 +78,9 @@ class HomopolymericRunsFilterDisabled(FilterBaseConfigDisabled):
 class HomopolymericRunsFilterEnabled(FilterBaseConfigEnabled):
     homopolymeric_base_n: Annotated[
         HomopolymericRunThreshold,
-        Field(description="minimum number of nucleotides to consider it a homopolymeric run per base"),
+        Field(
+            description="Minimum run length per base to count as homopolymeric (any base not listed is unrestricted). Oligos with longer runs are rejected."
+        ),
     ]
 
 

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -41,13 +41,11 @@ class CrossHybridizationBlastnFilterDisabled(FilterBaseConfigDisabled):
 class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
-        Field(description="Parameters for BLASTN searches used in cross-hybridization filtering."),
+        Field(description="BLAST options for the cross-hybridization search."),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(
-            description="Parameters for filtering BLASTN hits in cross-hybridization searches. Use either coverage or min_alignment_length."
-        ),
+        Field(description="Hit criteria. Hits satisfying these lead to oligo rejection."),
     ]
 
 

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -82,6 +82,31 @@ SpecificityBlastnFilterConfig = Annotated[
 ]
 
 
+class HybridizationProbesBlastnFilterDisabled(FilterBaseConfigDisabled):
+    pass
+
+
+class HybridizationProbesBlastnFilterEnabled(FilterBaseConfigEnabled):
+    search_parameters: Annotated[
+        BlastnSearchParameters,
+        Field(
+            description="BLASTN search parameters for filtering primers that match the assembled hybridization probes."
+        ),
+    ]
+    hit_parameters: Annotated[
+        BlastnHitParameters,
+        Field(
+            description="Parameters for filtering BLASTN hits against the hybridization probes. Use either coverage or min_alignment_length."
+        ),
+    ]
+
+
+HybridizationProbesBlastnFilterConfig = Annotated[
+    HybridizationProbesBlastnFilterEnabled | HybridizationProbesBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
 class VariantFilterDisabled(FilterBaseConfigDisabled):
     pass
 

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -5,6 +5,10 @@ from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt
 from oligo_designer_toolsuite.config._general_models import BlastnHitParameters, BlastnSearchParameters
 from oligo_designer_toolsuite.config._types import FilesFastaReferenceDatabaseT, VCFReferenceDatabaseT
 
+SPECIFICITY_TARGET_DESC = "Ensure oligo specificity against a reference database (BLAST-based)."
+SPECIFICITY_READOUT_DESC = "Remove readout probes with significant hits to the reference (BLAST-based)."
+SPECIFICITY_PRIMER_DESC = "Ensure primer specificity against a reference database (BLAST-based)."
+
 
 class FilterBaseConfigEnabled(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -39,6 +43,8 @@ class CrossHybridizationBlastnFilterDisabled(FilterBaseConfigDisabled):
 
 
 class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
+    """Remove oligos that may cross-hybridize to other probes (BLAST-based)."""
+
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(description="BLAST options for the cross-hybridization search."),
@@ -62,14 +68,12 @@ class SpecificityBlastnFilterDisabled(FilterBaseConfigDisabled):
 class SpecificityBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
-        Field(
-            description="BLASTN search parameters for specificity filtering. These parameters control how BLASTN searches are performed to identify off-target binding sites."
-        ),
+        Field(description="BLAST options for the specificity search."),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
         Field(
-            description="Parameters for filtering BLASTN hits during specificity analysis. Use either coverage or min_alignment_length."
+            description="Hit criteria (either coverage % or mininum alignment length). Hits satisfying these lead to oligo rejection."
         ),
     ]
     files_fasta_reference_database: FilesFastaReferenceDatabaseT
@@ -101,7 +105,10 @@ class HybridizationProbesBlastnFilterEnabled(FilterBaseConfigEnabled):
 
 HybridizationProbesBlastnFilterConfig = Annotated[
     HybridizationProbesBlastnFilterEnabled | HybridizationProbesBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(
+        discriminator="enabled",
+        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
+    ),
 ]
 
 

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -47,7 +47,10 @@ class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
 
     search_parameters: Annotated[
         BlastnSearchParameters,
-        Field(description="BLAST options for the cross-hybridization search."),
+        Field(
+            description="BLAST options for the cross-hybridization search.",
+            json_schema_extra={"x-collapsed": True},
+        ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
@@ -68,7 +71,10 @@ class SpecificityBlastnFilterDisabled(FilterBaseConfigDisabled):
 class SpecificityBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
-        Field(description="BLAST options for the specificity search."),
+        Field(
+            description="BLAST options for the specificity search.",
+            json_schema_extra={"x-collapsed": True},
+        ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
@@ -92,7 +98,8 @@ class HybridizationProbesBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLASTN search parameters for filtering primers that match the assembled hybridization probes."
+            description="BLASTN search parameters for filtering primers that match the assembled hybridization probes.",
+            json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[

--- a/oligo_designer_toolsuite/config/_types.py
+++ b/oligo_designer_toolsuite/config/_types.py
@@ -30,17 +30,13 @@ VCFReferenceDatabaseT = Annotated[
     ),
 ]
 
-LengthMinT = Annotated[
-    NonNegativeInt, Field(description="Minimum length (in nucleotides) for oligo sequences.")
-]
-LengthMaxT = Annotated[
-    NonNegativeInt, Field(description="Maximum length (in nucleotides) for probe sequences.")
-]
+LengthMinT = Annotated[NonNegativeInt, Field(description=" Minimum allowed oligo length (bases)")]
+LengthMaxT = Annotated[NonNegativeInt, Field(description="Maximum allowed oligo length (bases).")]
 
 GCContentMinT = Annotated[
     float,
     Field(
-        description="Minimum GC content (in %) for probes. Probes with GC content below this value will be filtered out/rejected.",
+        description="Minimum GC content (%). Oligos below this are rejected.",
         ge=0,
         le=100,
     ),
@@ -48,7 +44,7 @@ GCContentMinT = Annotated[
 GCContentMaxT = Annotated[
     float,
     Field(
-        description="Maximum GC content (in %) for probes. Probes with GC content above this value will be filtered out/rejected.",
+        description="Maximum GC content (%). Oligos above this are rejected.",
         ge=0,
         le=100,
     ),
@@ -56,7 +52,7 @@ GCContentMaxT = Annotated[
 GCContentOptT = Annotated[
     float,
     Field(
-        description="Optimal GC content (in %) for target probes. Used in scoring to prioritize probes closer to this value.",
+        description="Target (optimal) GC content (%) for scoring.",
         ge=0,
         le=100,
     ),
@@ -68,33 +64,25 @@ FractionT = Annotated[float, Field(ge=0, le=1)]
 
 TmMinT = Annotated[
     NonNegativeFloat,
-    Field(
-        description="Minimum melting temperature (Tm) in degrees Celsius for probes. Probes with calculated Tm below this value will be filtered out."
-    ),
+    Field(description="Minimum melting temperature (°C). Oligos below this are rejected."),
 ]
 TmMaxT = Annotated[
     NonNegativeFloat,
-    Field(
-        description="Maximum melting temperature (Tm) in degrees Celsius for probes. Probes with calculated Tm above this value will be filtered out."
-    ),
+    Field(description="Maximum melting temperature (°C). Oligos above this are rejected."),
 ]
 TmOptT = Annotated[
     NonNegativeFloat,
-    Field(
-        description="Optimal melting temperature (Tm) for oligos in degrees Celsius. Used in scoring to prioritize probes closer to this value."
-    ),
+    Field(description="Target (optimal) Tm (°C) for scoring."),
 ]
 
 TSecondaryStructureT = Annotated[
     PositiveInt,
-    Field(
-        description="Temperature in degrees Celsius at which to evaluate secondary structure formation (free energy calculation). Secondary structures that form at this temperature can interfere with probe binding."
-    ),
+    Field(description="Temperature (°C) at which secondary structure free energy is evaluated."),
 ]
 
 SecondaryStructuresThresholdDeltaGT = Annotated[
     float,
     Field(
-        description="DeltaG threshold (in kcal/mol) for secondary structure stability. Probes with secondary structures having deltaG values more negative (more stable) than this threshold will be filtered out.",
+        description="Free-energy threshold (kcal/mol). Oligos with ΔG ≤ thr_DG (stable structure) are rejected.",
     ),
 ]

--- a/oligo_designer_toolsuite/config/_types.py
+++ b/oligo_designer_toolsuite/config/_types.py
@@ -86,3 +86,13 @@ SecondaryStructuresThresholdDeltaGT = Annotated[
         description="Free-energy threshold (kcal/mol). Oligos with ΔG ≤ thr_DG (stable structure) are rejected.",
     ),
 ]
+
+HomogeneousPropertiesWeightsT = Annotated[
+    dict[str, float],
+    Field(
+        min_length=1,
+        description=(
+            "Weights for property homogeneity in the score minimised across the set (weighted sum of variances)."
+        ),
+    ),
+]

--- a/oligo_designer_toolsuite/config/_types.py
+++ b/oligo_designer_toolsuite/config/_types.py
@@ -5,22 +5,20 @@ from pydantic import Field, NonNegativeFloat, NonNegativeInt, PositiveInt
 RegionListT = Annotated[
     str | None,
     Field(
-        description="File with a list the genes used to generate the probe sequences, leave empty if all the genes are used. For examples, see 'data/genes'."
+        description="Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA."
     ),
 ]
 FastaFileListT = Annotated[list[str], Field(min_length=1)]
 FilesFastaDatabaseT = Annotated[
     FastaFileListT,
     Field(
-        description="List of paths to FASTA file(s) containing sequences from which probes will be generated. These files should contain genomic regions of interest (e.g., exons, exon-exon junctions). Hint: use the genomic_region_generator pipeline to create FASTA files of genomic regions of interest. For examples, see 'data/genomic_regions'."
+        description="FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.."
     ),
 ]
 
 FilesFastaReferenceDatabaseT = Annotated[
     FastaFileListT,
-    Field(
-        description="List of paths to FASTA file(s) containing reference sequences against which specificity will be evaluated. These typically include the entire genome or transcriptome to identify off-target binding sites. Hint: use the genomic_region_generator pipeline to create FASTA files of genomic regions of interest. For examples, see 'data/genomic_regions'."
-    ),
+    Field(description="FASTA file(s) used as reference for specificity."),
 ]
 
 VCFReferenceDatabaseT = Annotated[
@@ -30,7 +28,7 @@ VCFReferenceDatabaseT = Annotated[
     ),
 ]
 
-LengthMinT = Annotated[NonNegativeInt, Field(description=" Minimum allowed oligo length (bases)")]
+LengthMinT = Annotated[NonNegativeInt, Field(description="Minimum allowed oligo length (bases)")]
 LengthMaxT = Annotated[NonNegativeInt, Field(description="Maximum allowed oligo length (bases).")]
 
 GCContentMinT = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -22,7 +22,7 @@ from oligo_designer_toolsuite.config._general_models import (
 from oligo_designer_toolsuite.config._oligo_scoring import (
     IndependentSetSelection,
     IsoformConsensusScore,
-    ScoreBaseConfig,
+    TmScore,
 )
 from oligo_designer_toolsuite.config._property_filters import (
     GCContentFilterConfig,
@@ -48,7 +48,6 @@ from oligo_designer_toolsuite.config._types import (
     DRNAT,
     FilesFastaDatabaseT,
     RegionListT,
-    TmOptT,
 )
 
 ############################################
@@ -86,12 +85,6 @@ CycleHcrSpecificityBlastnFilterConfig = Annotated[
     CycleHcrSpecificityBlastnFilterEnabled | CycleHcrSpecificityBlastnFilterDisabled,
     Field(discriminator="enabled"),
 ]
-
-
-class CycleHcrTmScore(ScoreBaseConfig):
-    # CycleHCR only scores against a single optimal Tm (weight + Tm_opt); the generic TmScore
-    # additionally requires Tm_min/Tm_max, which the CycleHCR YAML does not provide.
-    Tm_opt: TmOptT
 
 
 ############################################
@@ -173,7 +166,7 @@ class TargetProbeProbeSetSelection(BaseModel):
         jaccard_step=0.1,
     )
     isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=10)
-    Tm_score: CycleHcrTmScore = CycleHcrTmScore(weight=1, Tm_opt=75)
+    Tm_score: TmScore = TmScore(weight=1, Tm_opt=75)
 
 
 class TargetProbeGlobal(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -49,6 +49,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_PRIMER_DESC,
+    SPECIFICITY_READOUT_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
@@ -120,7 +122,7 @@ class MerfishReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnable
 
 MerfishReadoutSpecificityBlastnFilterConfig = Annotated[
     MerfishReadoutSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(discriminator="enabled", description=SPECIFICITY_READOUT_DESC),
 ]
 
 
@@ -139,7 +141,7 @@ class MerfishPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled
 
 MerfishPrimerSpecificityBlastnFilterConfig = Annotated[
     MerfishPrimerSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(discriminator="enabled", description=SPECIFICITY_PRIMER_DESC),
 ]
 
 
@@ -268,44 +270,46 @@ class TargetProbes(BaseModel):
 # extra="ignore" so the shipped YAML validates in either branch.
 
 
-class MerfishCodebookLoad(BaseModel):
+class MerfishCodebookBase(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["load"]
-    file: str = Field(
-        description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
-    )
-    hamming_weight: PositiveInt = Field(
-        description="Number of bits set to 1 in each barcode (MERFISH standard = 2). Equals readout overhangs per encoding probe (first half 5' of target, second half 3').",
-        default=2,
-    )
-
-
-class MerfishCodebookGenerate(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    source: Literal["generate"]
     n_bits: PositiveInt = Field(
         description="Number of bits in each barcode.",
         default=16,
     )
-    min_hamming_dist: PositiveInt = Field(
-        description="Minimum Hamming distance between any two valid barcodes (MHD4 = 4 for single-bit error correction).",
-        default=4,
-    )
     hamming_weight: PositiveInt = Field(
         description="Number of bits set to 1 in each barcode (MERFISH standard = 2). Equals readout overhangs per encoding probe (first half 5' of target, second half 3').",
         default=2,
     )
 
 
-MerfishCodebook = Annotated[MerfishCodebookLoad | MerfishCodebookGenerate, Field(discriminator="source")]
+class MerfishCodebookLoad(MerfishCodebookBase):
+    source: Literal["load"] = "load"
+    file: str = Field(
+        description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
+    )
+
+
+class MerfishCodebookGenerate(MerfishCodebookBase):
+    source: Literal["generate"] = "generate"
+    min_hamming_dist: PositiveInt = Field(
+        description="Minimum Hamming distance between any two valid barcodes (MHD4 = 4 for single-bit error correction).",
+        default=4,
+    )
+
+
+MerfishCodebook = Annotated[
+    # use this order so that react-jsonschema-forms in ODT-Cloud selects the first
+    # model as a default when no defaults are specified (as is currently the case)
+    MerfishCodebookGenerate | MerfishCodebookLoad,
+    Field(discriminator="source"),
+]
 
 
 class MerfishReadoutProbeTableLoad(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["load"]
+    source: Literal["load"] = "load"
     file: str = Field(
         description="Path to the bit-indexed readout probe table (csv/tsv) with columns 'channel', 'readout_probe_id', 'readout_probe_sequence'."
     )
@@ -331,26 +335,20 @@ class MerfishReadoutProbeOligoGeneration(BaseModel):
 class MerfishReadoutProbePropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
-        default=HomopolymericRunsFilterEnabled(
-            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
-        ),
-        description="Exclude probes containing long homopolymeric runs.",
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
     )
-    GC_content_filter: GCContentFilterConfig = Field(
-        default=GCContentFilterEnabled(enabled=True, GC_content_min=40, GC_content_max=50),
-        description="Enforce GC content within a specified range.",
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=40, GC_content_max=50
     )
 
 
 class MerfishReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: MerfishReadoutSpecificityBlastnFilterConfig = Field(
-        description="Remove readout probes with significant hits to the reference (BLAST-based)."
-    )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
-        default=CrossHybridizationBlastnFilterEnabled(
+    specificity_blastn_filter: MerfishReadoutSpecificityBlastnFilterConfig
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
+        CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -361,8 +359,7 @@ class MerfishReadoutProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=11),
-        ),
-        description="Remove readout probes that cross-hybridize to each other (BLAST-based).",
+        )
     )
 
 
@@ -408,7 +405,7 @@ class MerfishReadoutProbesGlobal(BaseModel):
 class MerfishReadoutProbeTableGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["generate"]
+    source: Literal["generate"] = "generate"
     channels_ids: list[str] = Field(
         description="Fluorescence channels used for round-robin channel assignment across bits.",
         default=["Alexa488", "Cy3b", "Alexa647"],
@@ -421,7 +418,10 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
 
 
 MerfishReadoutProbeTable = Annotated[
-    MerfishReadoutProbeTableLoad | MerfishReadoutProbeTableGenerate, Field(discriminator="source")
+    # use this order so that react-jsonschema-forms in ODT-Cloud selects the first
+    # model as a default when no defaults are specified (as is currently the case)
+    MerfishReadoutProbeTableGenerate | MerfishReadoutProbeTableLoad,
+    Field(discriminator="source"),
 ]
 
 
@@ -445,10 +445,8 @@ class ReadoutProbes(BaseModel):
 class MerfishForwardPrimerLoad(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["load"]
-    sequence: DRNAT = Field(
-        description="Forward primer sequence placed at the 5' end of the DNA template probe."
-    )
+    source: Literal["load"] = "load"
+    sequence: DRNAT = Field(description="Only used when source = load.")
 
 
 class MerfishForwardPrimerOligoGeneration(BaseModel):
@@ -474,21 +472,17 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
         enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
     )
-    GC_content_filter: GCContentFilterConfig = Field(
-        default=GCContentFilterEnabled(enabled=True, GC_content_min=50, GC_content_max=65),
-        description="Enforce GC content within a specified range.",
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=50, GC_content_max=65
     )
-    GC_clamp_filter: GCClampFilterConfig = Field(
-        default=GCClampFilterEnabled(enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2),
-        description="Require G/C nucleotides at the 3' end of the primer for stable binding.",
+    GC_clamp_filter: GCClampFilterConfig = GCClampFilterEnabled(
+        enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2
     )
-    self_complementarity_filter: SelfComplementarityFilterConfig = Field(
-        default=SelfComplementarityFilterEnabled(enabled=True, max_len_selfcomplement=6),
-        description="Limit self-complementarity to avoid hairpins.",
+    self_complementarity_filter: SelfComplementarityFilterConfig = SelfComplementarityFilterEnabled(
+        enabled=True, max_len_selfcomplement=6
     )
-    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = Field(
-        default=ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5),
-        description="Limit complementarity between the forward primer and the (known) reverse primer to prevent primer-dimer formation.",
+    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = (
+        ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5)
     )
     Tm_filter: TmFilterConfig = TmFilterEnabled(enabled=True, Tm_min=60, Tm_max=75)
     secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
@@ -499,11 +493,9 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
 class MerfishForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: MerfishPrimerSpecificityBlastnFilterConfig = Field(
-        description="Ensure primer specificity against a reference database (BLAST-based)."
-    )
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = Field(
-        default=HybridizationProbesBlastnFilterEnabled(
+    specificity_blastn_filter: MerfishPrimerSpecificityBlastnFilterConfig
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
+        HybridizationProbesBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -515,8 +507,7 @@ class MerfishForwardPrimerSpecificityFilter(BaseModel):
                 max_hsps=1000,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=11),
-        ),
-        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
+        )
     )
 
 
@@ -556,7 +547,10 @@ class MerfishForwardPrimerGenerate(BaseModel):
 
 
 MerfishForwardPrimer = Annotated[
-    MerfishForwardPrimerLoad | MerfishForwardPrimerGenerate, Field(discriminator="source")
+    # use this order so that react-jsonschema-forms in ODT-Cloud selects the first
+    # model as a default when no defaults are specified (as is currently the case)
+    MerfishForwardPrimerGenerate | MerfishForwardPrimerLoad,
+    Field(discriminator="source"),
 ]
 
 
@@ -565,7 +559,7 @@ class MerfishReversePrimer(BaseModel):
 
     source: Literal["load"] = "load"
     sequence: DRNAT = Field(
-        description="Reverse primer sequence placed at the 3' end of the DNA template probe. The default is the reverse complement of the 20 nt T7 promoter sequence.",
+        description="The default is the reverse complement of 20 nt T7 promoter sequence. Only used when source = load.",
         default="CCCTATAGTGAGTCGTATTA",
     )
 
@@ -574,7 +568,7 @@ class Primers(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     forward_primer: MerfishForwardPrimer
-    reverse_primer: MerfishReversePrimer = MerfishReversePrimer()
+    reverse_primer: MerfishReversePrimer
 
 
 ############################################

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -276,10 +276,12 @@ class MerfishCodebookBase(BaseModel):
     n_bits: PositiveInt = Field(
         description="Number of bits in each barcode.",
         default=16,
+        json_schema_extra={"x-quick-setting": True},
     )
     hamming_weight: PositiveInt = Field(
         description="Number of bits set to 1 in each barcode (MERFISH standard = 2). Equals readout overhangs per encoding probe (first half 5' of target, second half 3').",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -22,7 +22,8 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    GCContentScoreBasic,
+    PROBE_SET_SELECTION_DESC,
+    GCContentScore,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -48,6 +49,7 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
     HybridizationProbesBlastnFilterConfig,
@@ -99,7 +101,7 @@ class MerfishTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled
 
 MerfishTargetSpecificityBlastnFilterConfig = Annotated[
     MerfishTargetSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
 ]
 
 
@@ -151,8 +153,8 @@ class TargetProbeOligoGeneration(BaseModel):
 
     file_region_ids: RegionListT
     files_fasta_probe_database: FilesFastaDatabaseT
-    probe_length_min: LengthMinT = 30
-    probe_length_max: LengthMaxT = 30
+    probe_length_min: LengthMinT = Field(default=30, json_schema_extra={"x-quick-setting": True})
+    probe_length_max: LengthMaxT = Field(default=30, json_schema_extra={"x-quick-setting": True})
 
     @model_validator(mode="after")
     def _check_min_max(self) -> Self:
@@ -166,46 +168,29 @@ class TargetProbeOligoGeneration(BaseModel):
 class TargetProbePropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    isoform_consensus_filter: IsoformConsensusFilterConfig = Field(
-        default=IsoformConsensusFilterEnabled(enabled=True, isoform_consensus=50),
-        description="Require oligos to be supported by a minimum fraction of gene transcripts.",
+    isoform_consensus_filter: IsoformConsensusFilterConfig = IsoformConsensusFilterEnabled(
+        enabled=True, isoform_consensus=50
     )
-    hard_masked_sequences_filter: HardMaskedFilterConfig = Field(
-        default=HardMaskedFilterConfig(enabled=True),
-        description="Exclude oligos overlapping hard-masked (e.g. N) regions in the reference.",
+    hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
+    soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
     )
-    soft_masked_sequences_filter: SoftMaskedFilterConfig = Field(
-        default=SoftMaskedFilterConfig(enabled=True),
-        description="Exclude oligos overlapping soft-masked (lowercase) regions in the reference.",
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=43, GC_content_max=63
     )
-    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
-        default=HomopolymericRunsFilterEnabled(
-            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
-        ),
-        description="Exclude oligos containing long homopolymeric runs (e.g. AAAAA).",
-    )
-    GC_content_filter: GCContentFilterConfig = Field(
-        default=GCContentFilterEnabled(enabled=True, GC_content_min=43, GC_content_max=63),
-        description="Enforce GC content within a specified range.",
-    )
-    Tm_filter: TmFilterConfig = Field(
-        default=TmFilterEnabled(enabled=True, Tm_min=66, Tm_max=76),
-        description="Enforce melting temperature (Tm) within a range (uses Tm parameters below).",
-    )
-    secondary_structure_filter: SecondaryStructureFilterConfig = Field(
-        default=SecondaryStructureFilterEnabled(enabled=True, T=76, thr_DG=0),
-        description="Reject oligos with stable secondary structure at the given temperature.",
+    Tm_filter: TmFilterConfig = TmFilterEnabled(enabled=True, Tm_min=66, Tm_max=76)
+    secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
+        enabled=True, T=76, thr_DG=0
     )
 
 
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: MerfishTargetSpecificityBlastnFilterConfig = Field(
-        description="Ensure oligo specificity against a reference database (BLAST-based)."
-    )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
-        default=CrossHybridizationBlastnFilterEnabled(
+    specificity_blastn_filter: MerfishTargetSpecificityBlastnFilterConfig
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
+        CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -216,8 +201,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=17),
-        ),
-        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
+        )
     )
 
 
@@ -235,7 +219,7 @@ class TargetProbeProbeSetSelection(BaseModel):
         jaccard_opt=0.5,
         jaccard_step=0.1,
     )
-    GC_content_score: GCContentScoreBasic = GCContentScoreBasic(weight=1, GC_content_opt=55)
+    GC_content_score: GCContentScore = GCContentScore(weight=1, GC_content_opt=55)
     Tm_score: TmScore = TmScore(weight=1, Tm_opt=72)
     isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=2)
 
@@ -271,9 +255,7 @@ class TargetProbes(BaseModel):
     oligo_generation: TargetProbeOligoGeneration
     property_filters: TargetProbePropertyFilter
     specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection = Field(
-        description="Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
-    )
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
     global_parameters: TargetProbeGlobal
 
 
@@ -291,7 +273,7 @@ class MerfishCodebookLoad(BaseModel):
 
     source: Literal["load"]
     file: str = Field(
-        description="Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
+        description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
     )
     hamming_weight: PositiveInt = Field(
         description="Number of bits set to 1 in each barcode (MERFISH standard = 2). Equals readout overhangs per encoding probe (first half 5' of target, second half 3').",
@@ -302,7 +284,7 @@ class MerfishCodebookLoad(BaseModel):
 class MerfishCodebookGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["generate"] = "generate"
+    source: Literal["generate"]
     n_bits: PositiveInt = Field(
         description="Number of bits in each barcode.",
         default=16,
@@ -426,7 +408,7 @@ class MerfishReadoutProbesGlobal(BaseModel):
 class MerfishReadoutProbeTableGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["generate"] = "generate"
+    source: Literal["generate"]
     channels_ids: list[str] = Field(
         description="Fluorescence channels used for round-robin channel assignment across bits.",
         default=["Alexa488", "Cy3b", "Alexa647"],
@@ -446,7 +428,7 @@ MerfishReadoutProbeTable = Annotated[
 class ReadoutProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    codebook: MerfishCodebook = MerfishCodebookGenerate()
+    codebook: MerfishCodebook
     readout_probe_table: MerfishReadoutProbeTable
 
 

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -1,0 +1,614 @@
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    model_validator,
+)
+from typing_extensions import Self
+
+from oligo_designer_toolsuite.config._general_models import (
+    BaseProbabilities,
+    BlastnHitParameters,
+    BlastnSearchParameters,
+    General,
+    HomopolymericRunThreshold,
+    TmChemCorrectionParameters,
+    TmChemCorrectionParametersDisabled,
+    TmParameters,
+    TmSaltCorrectionParameters,
+    TmSaltCorrectionParametersDisabled,
+)
+from oligo_designer_toolsuite.config._oligo_scoring import (
+    GCContentScoreBasic,
+    IndependentSetSelection,
+    IsoformConsensusScore,
+    TmScore,
+)
+from oligo_designer_toolsuite.config._property_filters import (
+    ComplementReversePrimerFilterConfig,
+    ComplementReversePrimerFilterEnabled,
+    GCClampFilterConfig,
+    GCClampFilterEnabled,
+    GCContentFilterConfig,
+    GCContentFilterEnabled,
+    HardMaskedFilterConfig,
+    HomopolymericRunsFilterConfig,
+    HomopolymericRunsFilterEnabled,
+    IsoformConsensusFilterConfig,
+    IsoformConsensusFilterEnabled,
+    SecondaryStructureFilterConfig,
+    SecondaryStructureFilterEnabled,
+    SelfComplementarityFilterConfig,
+    SelfComplementarityFilterEnabled,
+    SoftMaskedFilterConfig,
+    TmFilterConfig,
+    TmFilterEnabled,
+)
+from oligo_designer_toolsuite.config._specificity_filters import (
+    CrossHybridizationBlastnFilterConfig,
+    CrossHybridizationBlastnFilterEnabled,
+    HybridizationProbesBlastnFilterConfig,
+    HybridizationProbesBlastnFilterEnabled,
+    SpecificityBlastnFilterDisabled,
+    SpecificityBlastnFilterEnabled,
+)
+from oligo_designer_toolsuite.config._types import (
+    DRNAT,
+    FilesFastaDatabaseT,
+    HomogeneousPropertiesWeightsT,
+    LengthMaxT,
+    LengthMinT,
+    RegionListT,
+)
+
+############################################
+# MERFISH-specific overrides
+############################################
+
+# The specificity BLASTN filter carries a required reference-database path
+# (files_fasta_reference_database, no default). These subclasses only set the
+# MERFISH default search/hit parameters; the path stays required, so the whole
+# filter must be supplied by the user.
+
+
+class MerfishSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
+    pass
+
+
+class MerfishTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=80,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description="BLAST options for the specificity search.",
+    )
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParameters(min_alignment_length=17),
+        description="Hit criteria. Hits satisfying these lead to oligo rejection.",
+    )
+
+
+MerfishTargetSpecificityBlastnFilterConfig = Annotated[
+    MerfishTargetSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class MerfishReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=100,
+        strand="minus",
+        word_size=7,
+        dust="no",
+        soft_masking=False,
+        max_target_seqs=10,
+        max_hsps=1000,
+    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=11)
+
+
+MerfishReadoutSpecificityBlastnFilterConfig = Annotated[
+    MerfishReadoutSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class MerfishPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=100,
+        strand="minus",
+        word_size=7,
+        dust="no",
+        soft_masking=False,
+        max_target_seqs=10,
+        max_hsps=1000,
+    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=14)
+
+
+MerfishPrimerSpecificityBlastnFilterConfig = Annotated[
+    MerfishPrimerSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+############################################
+# Target probe
+############################################
+
+
+class TargetProbeOligoGeneration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    file_region_ids: RegionListT
+    files_fasta_probe_database: FilesFastaDatabaseT
+    probe_length_min: LengthMinT = 30
+    probe_length_max: LengthMaxT = 30
+
+    @model_validator(mode="after")
+    def _check_min_max(self) -> Self:
+        if self.probe_length_min > self.probe_length_max:
+            raise ValueError(
+                f"'probe_length_min' ({self.probe_length_min}) must be <= 'probe_length_max' ({self.probe_length_max})"
+            )
+        return self
+
+
+class TargetProbePropertyFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    isoform_consensus_filter: IsoformConsensusFilterConfig = Field(
+        default=IsoformConsensusFilterEnabled(enabled=True, isoform_consensus=50),
+        description="Require oligos to be supported by a minimum fraction of gene transcripts.",
+    )
+    hard_masked_sequences_filter: HardMaskedFilterConfig = Field(
+        default=HardMaskedFilterConfig(enabled=True),
+        description="Exclude oligos overlapping hard-masked (e.g. N) regions in the reference.",
+    )
+    soft_masked_sequences_filter: SoftMaskedFilterConfig = Field(
+        default=SoftMaskedFilterConfig(enabled=True),
+        description="Exclude oligos overlapping soft-masked (lowercase) regions in the reference.",
+    )
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
+        default=HomopolymericRunsFilterEnabled(
+            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        ),
+        description="Exclude oligos containing long homopolymeric runs (e.g. AAAAA).",
+    )
+    GC_content_filter: GCContentFilterConfig = Field(
+        default=GCContentFilterEnabled(enabled=True, GC_content_min=43, GC_content_max=63),
+        description="Enforce GC content within a specified range.",
+    )
+    Tm_filter: TmFilterConfig = Field(
+        default=TmFilterEnabled(enabled=True, Tm_min=66, Tm_max=76),
+        description="Enforce melting temperature (Tm) within a range (uses Tm parameters below).",
+    )
+    secondary_structure_filter: SecondaryStructureFilterConfig = Field(
+        default=SecondaryStructureFilterEnabled(enabled=True, T=76, thr_DG=0),
+        description="Reject oligos with stable secondary structure at the given temperature.",
+    )
+
+
+class TargetProbeSpecificityFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    specificity_blastn_filter: MerfishTargetSpecificityBlastnFilterConfig = Field(
+        description="Ensure oligo specificity against a reference database (BLAST-based)."
+    )
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
+        default=CrossHybridizationBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=80,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=17),
+        ),
+        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
+    )
+
+
+class TargetProbeProbeSetSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    independent_set_selection: IndependentSetSelection = IndependentSetSelection(
+        n_sets=3,
+        set_size_min=50,
+        set_size_opt=50,
+        distance_between_probes=0,
+        n_attempts_graph=50,
+        n_attempts_clique_enum=50,
+        diversification_fraction=0.1,
+        jaccard_opt=0.5,
+        jaccard_step=0.1,
+    )
+    GC_content_score: GCContentScoreBasic = GCContentScoreBasic(weight=1, GC_content_opt=55)
+    Tm_score: TmScore = TmScore(weight=1, Tm_opt=72)
+    isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=2)
+
+
+class TargetProbeGlobal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    Tm_parameters: TmParameters = TmParameters(
+        nn_table="DNA_NN4",
+        tmm_table="DNA_TMM1",
+        imm_table="DNA_IMM1",
+        de_table="DNA_DE1",
+        dnac1=5,
+        dnac2=0,
+        saltcorr=5,
+        Na=300,
+        K=0,
+        Tris=0,
+        Mg=0,
+        dNTPs=0,
+    )
+    Tm_chem_correction_parameters: TmChemCorrectionParameters = TmChemCorrectionParametersDisabled(
+        enabled=False
+    )
+    Tm_salt_correction_parameters: TmSaltCorrectionParameters = TmSaltCorrectionParametersDisabled(
+        enabled=False
+    )
+
+
+class TargetProbes(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    oligo_generation: TargetProbeOligoGeneration
+    property_filters: TargetProbePropertyFilter
+    specificity_filters: TargetProbeSpecificityFilter
+    probe_set_selection: TargetProbeProbeSetSelection = Field(
+        description="Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
+    )
+    global_parameters: TargetProbeGlobal
+
+
+############################################
+# Readout probes
+############################################
+
+# The codebook and readout-probe table support both source="load" and
+# source="generate", modelled as discriminated unions on `source`. Both use
+# extra="ignore" so the shipped YAML validates in either branch.
+
+
+class MerfishCodebookLoad(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["load"]
+    file: str = Field(
+        description="Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
+    )
+    hamming_weight: PositiveInt = Field(
+        description="Number of bits set to 1 in each barcode (MERFISH standard = 2). Equals readout overhangs per encoding probe (first half 5' of target, second half 3').",
+        default=2,
+    )
+
+
+class MerfishCodebookGenerate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["generate"] = "generate"
+    n_bits: PositiveInt = Field(
+        description="Number of bits in each barcode.",
+        default=16,
+    )
+    min_hamming_dist: PositiveInt = Field(
+        description="Minimum Hamming distance between any two valid barcodes (MHD4 = 4 for single-bit error correction).",
+        default=4,
+    )
+    hamming_weight: PositiveInt = Field(
+        description="Number of bits set to 1 in each barcode (MERFISH standard = 2). Equals readout overhangs per encoding probe (first half 5' of target, second half 3').",
+        default=2,
+    )
+
+
+MerfishCodebook = Annotated[MerfishCodebookLoad | MerfishCodebookGenerate, Field(discriminator="source")]
+
+
+class MerfishReadoutProbeTableLoad(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["load"]
+    file: str = Field(
+        description="Path to the bit-indexed readout probe table (csv/tsv) with columns 'channel', 'readout_probe_id', 'readout_probe_sequence'."
+    )
+
+
+class MerfishReadoutProbeOligoGeneration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe_length: PositiveInt = Field(
+        description="Length (bases) of each random readout probe.",
+        default=20,
+    )
+    base_probabilities: BaseProbabilities = Field(
+        default=BaseProbabilities(A=0.25, C=0.00, G=0.50, T=0.25),
+        description="Per-base probability used to generate random readout-probe sequences.",
+    )
+    initial_num_sequences: PositiveInt = Field(
+        description="Number of random sequences to generate before filtering.",
+        default=100000,
+    )
+
+
+class MerfishReadoutProbePropertyFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
+        default=HomopolymericRunsFilterEnabled(
+            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
+        ),
+        description="Exclude probes containing long homopolymeric runs.",
+    )
+    GC_content_filter: GCContentFilterConfig = Field(
+        default=GCContentFilterEnabled(enabled=True, GC_content_min=40, GC_content_max=50),
+        description="Enforce GC content within a specified range.",
+    )
+
+
+class MerfishReadoutProbeSpecificityFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    specificity_blastn_filter: MerfishReadoutSpecificityBlastnFilterConfig = Field(
+        description="Remove readout probes with significant hits to the reference (BLAST-based)."
+    )
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
+        default=CrossHybridizationBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=11),
+        ),
+        description="Remove readout probes that cross-hybridize to each other (BLAST-based).",
+    )
+
+
+class MerfishReadoutProbeSetSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    set_size: PositiveInt = Field(
+        default=16,
+        description="Total number of readout probes to select (must equal n_bits so each bit gets a probe).",
+    )
+    n_combinations: PositiveInt = Field(
+        default=100000,
+        description="Number of candidate sets to evaluate; higher values may find better sets but increase computation time.",
+    )
+    homogeneous_properties_weights: HomogeneousPropertiesWeightsT = {"TmNN_oligo": 1, "GC_content_oligo": 1.0}
+
+
+class MerfishReadoutProbesGlobal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    Tm_parameters: TmParameters = TmParameters(
+        nn_table="DNA_NN4",
+        tmm_table="DNA_TMM1",
+        imm_table="DNA_IMM1",
+        de_table="DNA_DE1",
+        dnac1=25,
+        dnac2=25,
+        saltcorr=5,
+        Na=300,
+        K=0,
+        Tris=0,
+        Mg=0,
+        dNTPs=0,
+    )
+    Tm_chem_correction_parameters: TmChemCorrectionParameters = TmChemCorrectionParametersDisabled(
+        enabled=False
+    )
+    Tm_salt_correction_parameters: TmSaltCorrectionParameters = TmSaltCorrectionParametersDisabled(
+        enabled=False
+    )
+
+
+class MerfishReadoutProbeTableGenerate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["generate"] = "generate"
+    channels_ids: list[str] = Field(
+        description="Fluorescence channels used for round-robin channel assignment across bits.",
+        default=["Alexa488", "Cy3b", "Alexa647"],
+    )
+    oligo_generation: MerfishReadoutProbeOligoGeneration
+    property_filters: MerfishReadoutProbePropertyFilter
+    specificity_filters: MerfishReadoutProbeSpecificityFilter
+    probe_set_selection: MerfishReadoutProbeSetSelection
+    global_parameters: MerfishReadoutProbesGlobal
+
+
+MerfishReadoutProbeTable = Annotated[
+    MerfishReadoutProbeTableLoad | MerfishReadoutProbeTableGenerate, Field(discriminator="source")
+]
+
+
+class ReadoutProbes(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    codebook: MerfishCodebook = MerfishCodebookGenerate()
+    readout_probe_table: MerfishReadoutProbeTable
+
+
+############################################
+# Primers
+############################################
+
+# The forward primer supports source="load" (provide a sequence) and
+# source="generate" (design one), modelled as a discriminated union on `source`
+# with extra="ignore". The reverse primer only supports source="load"
+# (generate_reverse_primer raises FeatureNotImplementedError).
+
+
+class MerfishForwardPrimerLoad(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["load"]
+    sequence: DRNAT = Field(
+        description="Forward primer sequence placed at the 5' end of the DNA template probe."
+    )
+
+
+class MerfishForwardPrimerOligoGeneration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe_length: PositiveInt = Field(
+        description="Length (bases) of each generated primer.",
+        default=20,
+    )
+    base_probabilities: BaseProbabilities = Field(
+        default=BaseProbabilities(A=0.25, C=0.25, G=0.25, T=0.25),
+        description="Per-base probability used to generate random primer sequences.",
+    )
+    initial_num_sequences: PositiveInt = Field(
+        description="Number of random sequences to generate before filtering.",
+        default=1000000,
+    )
+
+
+class MerfishForwardPrimerPropertyFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+    )
+    GC_content_filter: GCContentFilterConfig = Field(
+        default=GCContentFilterEnabled(enabled=True, GC_content_min=50, GC_content_max=65),
+        description="Enforce GC content within a specified range.",
+    )
+    GC_clamp_filter: GCClampFilterConfig = Field(
+        default=GCClampFilterEnabled(enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2),
+        description="Require G/C nucleotides at the 3' end of the primer for stable binding.",
+    )
+    self_complementarity_filter: SelfComplementarityFilterConfig = Field(
+        default=SelfComplementarityFilterEnabled(enabled=True, max_len_selfcomplement=6),
+        description="Limit self-complementarity to avoid hairpins.",
+    )
+    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = Field(
+        default=ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5),
+        description="Limit complementarity between the forward primer and the (known) reverse primer to prevent primer-dimer formation.",
+    )
+    Tm_filter: TmFilterConfig = TmFilterEnabled(enabled=True, Tm_min=60, Tm_max=75)
+    secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
+        enabled=True, T=76, thr_DG=0
+    )
+
+
+class MerfishForwardPrimerSpecificityFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    specificity_blastn_filter: MerfishPrimerSpecificityBlastnFilterConfig = Field(
+        description="Ensure primer specificity against a reference database (BLAST-based)."
+    )
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = Field(
+        default=HybridizationProbesBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=11),
+        ),
+        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
+    )
+
+
+class MerfishForwardPrimerGlobal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    Tm_parameters: TmParameters = TmParameters(
+        nn_table="DNA_NN4",
+        tmm_table="DNA_TMM1",
+        imm_table="DNA_IMM1",
+        de_table="DNA_DE1",
+        dnac1=250,
+        dnac2=250,
+        saltcorr=5,
+        Na=300,
+        K=0,
+        Tris=0,
+        Mg=0,
+        dNTPs=0,
+    )
+    Tm_chem_correction_parameters: TmChemCorrectionParameters = TmChemCorrectionParametersDisabled(
+        enabled=False
+    )
+    Tm_salt_correction_parameters: TmSaltCorrectionParameters = TmSaltCorrectionParametersDisabled(
+        enabled=False
+    )
+
+
+class MerfishForwardPrimerGenerate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["generate"] = "generate"
+    oligo_generation: MerfishForwardPrimerOligoGeneration = MerfishForwardPrimerOligoGeneration()
+    property_filters: MerfishForwardPrimerPropertyFilter = MerfishForwardPrimerPropertyFilter()
+    specificity_filters: MerfishForwardPrimerSpecificityFilter
+    global_parameters: MerfishForwardPrimerGlobal = MerfishForwardPrimerGlobal()
+
+
+MerfishForwardPrimer = Annotated[
+    MerfishForwardPrimerLoad | MerfishForwardPrimerGenerate, Field(discriminator="source")
+]
+
+
+class MerfishReversePrimer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["load"] = "load"
+    sequence: DRNAT = Field(
+        description="Reverse primer sequence placed at the 3' end of the DNA template probe. The default is the reverse complement of the 20 nt T7 promoter sequence.",
+        default="CCCTATAGTGAGTCGTATTA",
+    )
+
+
+class Primers(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    forward_primer: MerfishForwardPrimer
+    reverse_primer: MerfishReversePrimer = MerfishReversePrimer()
+
+
+############################################
+# Top level
+############################################
+
+
+class MerfishProbeDesignerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal[2] = 2
+    general: General = General(
+        n_jobs=4,
+        dir_output="output_Merfishplus_probe_designer",
+        write_intermediate_steps=True,
+    )
+
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -16,7 +16,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    GCContentScoreExpanded,
+    GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
     TargetedExonsScore,
@@ -187,7 +187,7 @@ class TargetProbeProbeSetSelection(BaseModel):
     uniform_distance_score: UniformDistanceScore = UniformDistanceScore(weight=1)
     isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=1)
     targeted_exons_score: TargetedExonsScore = TargetedExonsScore(weight=0, targeted_exons=[])
-    GC_content_score: GCContentScoreExpanded = GCContentScoreExpanded(
+    GC_content_score: GCContentScoreNormalized = GCContentScoreNormalized(
         weight=1, GC_content_min=45, GC_content_opt=55, GC_content_max=65
     )
     Tm_score: TmScore = TmScore(weight=1, Tm_min=50, Tm_opt=60, Tm_max=70)

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -16,7 +16,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    GCContentScore,
+    GCContentScoreExpanded,
     IndependentSetSelection,
     IsoformConsensusScore,
     TargetedExonsScore,
@@ -187,7 +187,7 @@ class TargetProbeProbeSetSelection(BaseModel):
     uniform_distance_score: UniformDistanceScore = UniformDistanceScore(weight=1)
     isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=1)
     targeted_exons_score: TargetedExonsScore = TargetedExonsScore(weight=0, targeted_exons=[])
-    GC_content_score: GCContentScore = GCContentScore(
+    GC_content_score: GCContentScoreExpanded = GCContentScoreExpanded(
         weight=1, GC_content_min=45, GC_content_opt=55, GC_content_max=65
     )
     Tm_score: TmScore = TmScore(weight=1, Tm_min=50, Tm_opt=60, Tm_max=70)

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -20,7 +20,7 @@ from oligo_designer_toolsuite.config._oligo_scoring import (
     IndependentSetSelection,
     IsoformConsensusScore,
     TargetedExonsScore,
-    TmScore,
+    TmScoreNormalized,
     UniformDistanceScore,
 )
 from oligo_designer_toolsuite.config._property_filters import (
@@ -190,7 +190,7 @@ class TargetProbeProbeSetSelection(BaseModel):
     GC_content_score: GCContentScoreExpanded = GCContentScoreExpanded(
         weight=1, GC_content_min=45, GC_content_opt=55, GC_content_max=65
     )
-    Tm_score: TmScore = TmScore(weight=1, Tm_min=50, Tm_opt=60, Tm_max=70)
+    Tm_score: TmScoreNormalized = TmScoreNormalized(weight=1, Tm_min=50, Tm_opt=60, Tm_max=70)
 
 
 class TargetProbeGlobal(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -24,7 +24,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    GCContentScore,
+    GCContentScoreExpanded,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -191,7 +191,7 @@ class TargetProbeProbeSetSelection(BaseModel):
         jaccard_step=0.1,
     )
     isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=2)
-    GC_content_score: GCContentScore = GCContentScore(
+    GC_content_score: GCContentScoreExpanded = GCContentScoreExpanded(
         weight=1, GC_content_min=40, GC_content_opt=50, GC_content_max=60
     )
     Tm_score: TmScore = TmScore(weight=1, Tm_min=65, Tm_opt=70, Tm_max=75)

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -24,7 +24,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    GCContentScoreExpanded,
+    GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -191,7 +191,7 @@ class TargetProbeProbeSetSelection(BaseModel):
         jaccard_step=0.1,
     )
     isoform_consensus_score: IsoformConsensusScore = IsoformConsensusScore(weight=2)
-    GC_content_score: GCContentScoreExpanded = GCContentScoreExpanded(
+    GC_content_score: GCContentScoreNormalized = GCContentScoreNormalized(
         weight=1, GC_content_min=40, GC_content_opt=50, GC_content_max=60
     )
     Tm_score: TmScore = TmScore(weight=1, Tm_min=65, Tm_opt=70, Tm_max=75)

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -27,7 +27,7 @@ from oligo_designer_toolsuite.config._oligo_scoring import (
     GCContentScoreExpanded,
     IndependentSetSelection,
     IsoformConsensusScore,
-    TmScore,
+    TmScoreNormalized,
 )
 from oligo_designer_toolsuite.config._property_filters import (
     GCContentFilterConfig,
@@ -194,7 +194,7 @@ class TargetProbeProbeSetSelection(BaseModel):
     GC_content_score: GCContentScoreExpanded = GCContentScoreExpanded(
         weight=1, GC_content_min=40, GC_content_opt=50, GC_content_max=60
     )
-    Tm_score: TmScore = TmScore(weight=1, Tm_min=65, Tm_opt=70, Tm_max=75)
+    Tm_score: TmScoreNormalized = TmScoreNormalized(weight=1, Tm_min=65, Tm_opt=70, Tm_max=75)
 
 
 class TargetProbeGlobal(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -246,7 +246,7 @@ class SeqfishPlusCodebookBase(BaseModel):
 
 class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
 
-    source: Literal["load"]
+    source: Literal["load"] = "load"
     file: str = Field(
         description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
     )
@@ -276,7 +276,7 @@ SeqfishPlusCodebook = Annotated[
 class SeqfishPlusReadoutProbeTableLoad(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["load"]
+    source: Literal["load"] = "load"
     file: str = Field(
         description="Only used when source = load. Path to the bit-indexed readout probe table (csv/tsv) with columns 'barcode_round', 'pseudocolor', 'channel', and 'readout_probe_sequence'."
     )
@@ -367,7 +367,7 @@ class ReadoutProbes(BaseModel):
 class SeqfishPlusForwardPrimerLoad(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: Literal["load"]
+    source: Literal["load"] = "load"
     sequence: DRNAT = Field(description="Only used when source = load.")
 
 

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -77,16 +77,22 @@ class SeqfishPlusSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled
 
 
 class SeqfishPlusTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=7,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=100,
+            strand="minus",
+            word_size=7,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description="BLAST options for the specificity search.",
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=15)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParameters(min_alignment_length=15),
+        description="Hit criteria. Hits satisfying these lead to oligo rejection.",
+    )
 
 
 SeqfishPlusTargetSpecificityBlastnFilterConfig = Annotated[
@@ -158,28 +164,42 @@ class TargetProbeOligoGeneration(BaseModel):
 class TargetProbePropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    isoform_consensus_filter: IsoformConsensusFilterConfig = IsoformConsensusFilterEnabled(
-        enabled=True, isoform_consensus=100
+    isoform_consensus_filter: IsoformConsensusFilterConfig = Field(
+        default=IsoformConsensusFilterEnabled(enabled=True, isoform_consensus=100),
+        description="Require oligos to be supported by a minimum fraction of gene transcripts.",
     )
-    hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
-    soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
-    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+    hard_masked_sequences_filter: HardMaskedFilterConfig = Field(
+        default=HardMaskedFilterConfig(enabled=True),
+        description="Exclude oligos overlapping hard-masked (e.g. N) regions in the reference.",
     )
-    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
-        enabled=True, GC_content_min=45, GC_content_max=65
+    soft_masked_sequences_filter: SoftMaskedFilterConfig = Field(
+        default=SoftMaskedFilterConfig(enabled=True),
+        description="Exclude oligos overlapping soft-masked (lowercase) regions in the reference.",
     )
-    secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
-        enabled=True, T=76, thr_DG=0
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
+        default=HomopolymericRunsFilterEnabled(
+            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+        ),
+        description="Exclude oligos containing long homopolymeric runs (e.g. AAAAA).",
+    )
+    GC_content_filter: GCContentFilterConfig = Field(
+        default=GCContentFilterEnabled(enabled=True, GC_content_min=45, GC_content_max=65),
+        description="Enforce GC content within a specified range.",
+    )
+    secondary_structure_filter: SecondaryStructureFilterConfig = Field(
+        default=SecondaryStructureFilterEnabled(enabled=True, T=76, thr_DG=0),
+        description="Reject oligos with stable secondary structure at the given temperature.",
     )
 
 
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusTargetSpecificityBlastnFilterConfig
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    specificity_blastn_filter: SeqfishPlusTargetSpecificityBlastnFilterConfig = Field(
+        description="Ensure oligo specificity against a reference database (BLAST-based)."
+    )
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
+        default=CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -190,7 +210,8 @@ class TargetProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=17),
-        )
+        ),
+        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
     )
 
 
@@ -218,7 +239,9 @@ class TargetProbes(BaseModel):
     oligo_generation: TargetProbeOligoGeneration
     property_filters: TargetProbePropertyFilter
     specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
+    probe_set_selection: TargetProbeProbeSetSelection = Field(
+        description="Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
+    )
 
 
 ############################################
@@ -303,20 +326,26 @@ class SeqfishPlusReadoutProbeOligoGeneration(BaseModel):
 class SeqfishPlusReadoutProbePropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
+        default=HomopolymericRunsFilterEnabled(
+            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
+        ),
+        description="Exclude probes containing long homopolymeric runs.",
     )
-    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
-        enabled=True, GC_content_min=40, GC_content_max=60
+    GC_content_filter: GCContentFilterConfig = Field(
+        default=GCContentFilterEnabled(enabled=True, GC_content_min=40, GC_content_max=60),
+        description="Enforce GC content within a specified range.",
     )
 
 
 class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusReadoutSpecificityBlastnFilterConfig
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    specificity_blastn_filter: SeqfishPlusReadoutSpecificityBlastnFilterConfig = Field(
+        description="Remove readout probes with significant hits to the reference (BLAST-based)."
+    )
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
+        default=CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -327,7 +356,8 @@ class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=10),
-        )
+        ),
+        description="Remove readout probes that cross-hybridize to each other (BLAST-based).",
     )
 
 
@@ -394,18 +424,21 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
         enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
     )
-    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
-        enabled=True, GC_content_min=50, GC_content_max=65
+    GC_content_filter: GCContentFilterConfig = Field(
+        default=GCContentFilterEnabled(enabled=True, GC_content_min=50, GC_content_max=65),
+        description="Enforce GC content within a specified range.",
     )
     GC_clamp_filter: GCClampFilterConfig = Field(
         default=GCClampFilterEnabled(enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2),
         description="Require G/C nucleotides at the 3' end of the primer for stable binding.",
     )
-    self_complementarity_filter: SelfComplementarityFilterConfig = SelfComplementarityFilterEnabled(
-        enabled=True, max_len_selfcomplement=6
+    self_complementarity_filter: SelfComplementarityFilterConfig = Field(
+        default=SelfComplementarityFilterEnabled(enabled=True, max_len_selfcomplement=6),
+        description="Limit self-complementarity to avoid hairpins.",
     )
-    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = (
-        ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5)
+    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = Field(
+        default=ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5),
+        description="Limit complementarity between the forward primer and the (known) reverse primer to prevent primer-dimer formation.",
     )
     Tm_filter: TmFilterConfig = TmFilterEnabled(enabled=True, Tm_min=60, Tm_max=75)
     secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
@@ -416,9 +449,11 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
 class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusPrimerSpecificityBlastnFilterConfig
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
-        HybridizationProbesBlastnFilterEnabled(
+    specificity_blastn_filter: SeqfishPlusPrimerSpecificityBlastnFilterConfig = Field(
+        description="Ensure primer specificity against a reference database (BLAST-based)."
+    )
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = Field(
+        default=HybridizationProbesBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -430,7 +465,8 @@ class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
                 max_hsps=1000,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=11),
-        )
+        ),
+        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -147,8 +147,8 @@ class TargetProbeOligoGeneration(BaseModel):
 
     file_region_ids: RegionListT
     files_fasta_probe_database: FilesFastaDatabaseT
-    probe_length_min: LengthMinT = 28
-    probe_length_max: LengthMaxT = 28
+    probe_length_min: LengthMinT = Field(default=28, json_schema_extra={"x-quick-setting": True})
+    probe_length_max: LengthMaxT = Field(default=28, json_schema_extra={"x-quick-setting": True})
 
     @model_validator(mode="after")
     def _check_min_max(self) -> Self:
@@ -234,43 +234,37 @@ class TargetProbes(BaseModel):
 # extra="ignore" so the shipped YAML validates in either branch.
 
 
-class SeqfishPlusCodebookLoad(BaseModel):
+class SeqfishPlusCodebookBase(BaseModel):
     model_config = ConfigDict(extra="ignore")
+
+    n_barcode_rounds: PositiveInt = Field(
+        description="Number of barcode rounds. Equals active bits per gene and readout overhangs per encoding probe (first half 5' of target, second half 3').",
+        default=4,
+        json_schema_extra={"x-quick-setting": True},
+    )
+    n_pseudocolors: PositiveInt = Field(
+        description="Number of pseudocolors per round.",
+        default=4,
+        json_schema_extra={"x-quick-setting": True},
+    )
+    channels_ids: list[str] = Field(
+        description="Fluorescence channels used in the experiment.",
+        default=["Alexa488", "Cy3b", "Alexa647"],
+        json_schema_extra={"x-quick-setting": True},
+    )
+
+
+class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
 
     source: Literal["load"]
     file: str = Field(
         description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
     )
-    n_barcode_rounds: PositiveInt = Field(
-        description="Number of barcode rounds. Equals active bits per gene and readout overhangs per encoding probe (first half 5' of target, second half 3').",
-        default=4,
-    )
-    n_pseudocolors: PositiveInt = Field(
-        description="Number of pseudocolors per round.",
-        default=4,
-    )
-    channels_ids: list[str] = Field(
-        description="Fluorescence channels used in the experiment.",
-        default=["Alexa488", "Cy3b", "Alexa647"],
-    )
 
 
-class SeqfishPlusCodebookGenerate(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+class SeqfishPlusCodebookGenerate(SeqfishPlusCodebookBase):
 
     source: Literal["generate"] = "generate"
-    n_barcode_rounds: PositiveInt = Field(
-        description="Number of barcode rounds. Equals active bits per gene and readout overhangs per encoding probe (first half 5' of target, second half 3').",
-        default=4,
-    )
-    n_pseudocolors: PositiveInt = Field(
-        description="Number of pseudocolors per round.",
-        default=4,
-    )
-    channels_ids: list[str] = Field(
-        description="Fluorescence channels used in the experiment.",
-        default=["Alexa488", "Cy3b", "Alexa647"],
-    )
 
 
 SeqfishPlusCodebook = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -22,7 +22,8 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    GCContentScoreBasic,
+    PROBE_SET_SELECTION_DESC,
+    GCContentScore,
     IndependentSetSelection,
     UTRScore,
 )
@@ -47,6 +48,9 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_PRIMER_DESC,
+    SPECIFICITY_READOUT_DESC,
+    SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
     HybridizationProbesBlastnFilterConfig,
@@ -77,27 +81,21 @@ class SeqfishPlusSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled
 
 
 class SeqfishPlusTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = Field(
-        default=BlastnSearchParameters(
-            perc_identity=100,
-            strand="minus",
-            word_size=7,
-            dust="no",
-            soft_masking=False,
-            max_target_seqs=10,
-            max_hsps=1000,
-        ),
-        description="BLAST options for the specificity search.",
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=100,
+        strand="minus",
+        word_size=7,
+        dust="no",
+        soft_masking=False,
+        max_target_seqs=10,
+        max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = Field(
-        default=BlastnHitParameters(min_alignment_length=15),
-        description="Hit criteria. Hits satisfying these lead to oligo rejection.",
-    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=15)
 
 
 SeqfishPlusTargetSpecificityBlastnFilterConfig = Annotated[
     SeqfishPlusTargetSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
 ]
 
 
@@ -116,7 +114,7 @@ class SeqfishPlusReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEn
 
 SeqfishPlusReadoutSpecificityBlastnFilterConfig = Annotated[
     SeqfishPlusReadoutSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(discriminator="enabled", description=SPECIFICITY_READOUT_DESC),
 ]
 
 
@@ -135,7 +133,7 @@ class SeqfishPlusPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEna
 
 SeqfishPlusPrimerSpecificityBlastnFilterConfig = Annotated[
     SeqfishPlusPrimerSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(discriminator="enabled", description=SPECIFICITY_PRIMER_DESC),
 ]
 
 
@@ -164,42 +162,28 @@ class TargetProbeOligoGeneration(BaseModel):
 class TargetProbePropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    isoform_consensus_filter: IsoformConsensusFilterConfig = Field(
-        default=IsoformConsensusFilterEnabled(enabled=True, isoform_consensus=100),
-        description="Require oligos to be supported by a minimum fraction of gene transcripts.",
+    isoform_consensus_filter: IsoformConsensusFilterConfig = IsoformConsensusFilterEnabled(
+        enabled=True, isoform_consensus=100
     )
-    hard_masked_sequences_filter: HardMaskedFilterConfig = Field(
-        default=HardMaskedFilterConfig(enabled=True),
-        description="Exclude oligos overlapping hard-masked (e.g. N) regions in the reference.",
+    hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
+    soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
     )
-    soft_masked_sequences_filter: SoftMaskedFilterConfig = Field(
-        default=SoftMaskedFilterConfig(enabled=True),
-        description="Exclude oligos overlapping soft-masked (lowercase) regions in the reference.",
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=45, GC_content_max=65
     )
-    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
-        default=HomopolymericRunsFilterEnabled(
-            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
-        ),
-        description="Exclude oligos containing long homopolymeric runs (e.g. AAAAA).",
-    )
-    GC_content_filter: GCContentFilterConfig = Field(
-        default=GCContentFilterEnabled(enabled=True, GC_content_min=45, GC_content_max=65),
-        description="Enforce GC content within a specified range.",
-    )
-    secondary_structure_filter: SecondaryStructureFilterConfig = Field(
-        default=SecondaryStructureFilterEnabled(enabled=True, T=76, thr_DG=0),
-        description="Reject oligos with stable secondary structure at the given temperature.",
+    secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
+        enabled=True, T=76, thr_DG=0
     )
 
 
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusTargetSpecificityBlastnFilterConfig = Field(
-        description="Ensure oligo specificity against a reference database (BLAST-based)."
-    )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
-        default=CrossHybridizationBlastnFilterEnabled(
+    specificity_blastn_filter: SeqfishPlusTargetSpecificityBlastnFilterConfig
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
+        CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -210,8 +194,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=17),
-        ),
-        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
+        )
     )
 
 
@@ -229,7 +212,7 @@ class TargetProbeProbeSetSelection(BaseModel):
         jaccard_opt=0.5,
         jaccard_step=0.1,
     )
-    GC_content_score: GCContentScoreBasic = GCContentScoreBasic(weight=1, GC_content_opt=55)
+    GC_content_score: GCContentScore = GCContentScore(weight=1, GC_content_opt=55)
     UTR_score: UTRScore = UTRScore(weight=10)
 
 
@@ -239,9 +222,7 @@ class TargetProbes(BaseModel):
     oligo_generation: TargetProbeOligoGeneration
     property_filters: TargetProbePropertyFilter
     specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection = Field(
-        description="Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
-    )
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
 
 
 ############################################
@@ -258,7 +239,7 @@ class SeqfishPlusCodebookLoad(BaseModel):
 
     source: Literal["load"]
     file: str = Field(
-        description="Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
+        description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
     )
     n_barcode_rounds: PositiveInt = Field(
         description="Number of barcode rounds. Equals active bits per gene and readout overhangs per encoding probe (first half 5' of target, second half 3').",
@@ -293,7 +274,10 @@ class SeqfishPlusCodebookGenerate(BaseModel):
 
 
 SeqfishPlusCodebook = Annotated[
-    SeqfishPlusCodebookLoad | SeqfishPlusCodebookGenerate, Field(discriminator="source")
+    # use this order so that react-jsonschema-forms in ODT-Cloud selects the first
+    # model as a default when no defaults are specified (as is currently the case)
+    SeqfishPlusCodebookGenerate | SeqfishPlusCodebookLoad,
+    Field(discriminator="source"),
 ]
 
 
@@ -302,7 +286,7 @@ class SeqfishPlusReadoutProbeTableLoad(BaseModel):
 
     source: Literal["load"]
     file: str = Field(
-        description="Path to the bit-indexed readout probe table (csv/tsv) with columns 'barcode_round', 'pseudocolor', 'channel', and 'readout_probe_sequence'."
+        description="Only used when source = load. Path to the bit-indexed readout probe table (csv/tsv) with columns 'barcode_round', 'pseudocolor', 'channel', and 'readout_probe_sequence'."
     )
 
 
@@ -326,26 +310,20 @@ class SeqfishPlusReadoutProbeOligoGeneration(BaseModel):
 class SeqfishPlusReadoutProbePropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = Field(
-        default=HomopolymericRunsFilterEnabled(
-            enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
-        ),
-        description="Exclude probes containing long homopolymeric runs.",
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
     )
-    GC_content_filter: GCContentFilterConfig = Field(
-        default=GCContentFilterEnabled(enabled=True, GC_content_min=40, GC_content_max=60),
-        description="Enforce GC content within a specified range.",
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=40, GC_content_max=60
     )
 
 
 class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusReadoutSpecificityBlastnFilterConfig = Field(
-        description="Remove readout probes with significant hits to the reference (BLAST-based)."
-    )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = Field(
-        default=CrossHybridizationBlastnFilterEnabled(
+    specificity_blastn_filter: SeqfishPlusReadoutSpecificityBlastnFilterConfig
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
+        CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -356,8 +334,7 @@ class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=10),
-        ),
-        description="Remove readout probes that cross-hybridize to each other (BLAST-based).",
+        )
     )
 
 
@@ -365,20 +342,23 @@ class SeqfishPlusReadoutProbeTableGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration = SeqfishPlusReadoutProbeOligoGeneration()
-    property_filters: SeqfishPlusReadoutProbePropertyFilter = SeqfishPlusReadoutProbePropertyFilter()
+    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration
+    property_filters: SeqfishPlusReadoutProbePropertyFilter
     specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter
 
 
 SeqfishPlusReadoutProbeTable = Annotated[
-    SeqfishPlusReadoutProbeTableLoad | SeqfishPlusReadoutProbeTableGenerate, Field(discriminator="source")
+    # use this order so that react-jsonschema-forms in ODT-Cloud selects the first
+    # model as a default when no defaults are specified (as is currently the case)
+    SeqfishPlusReadoutProbeTableGenerate | SeqfishPlusReadoutProbeTableLoad,
+    Field(discriminator="source"),
 ]
 
 
 class ReadoutProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    codebook: SeqfishPlusCodebook = SeqfishPlusCodebookGenerate()
+    codebook: SeqfishPlusCodebook
     readout_probe_table: SeqfishPlusReadoutProbeTable
 
 
@@ -396,9 +376,7 @@ class SeqfishPlusForwardPrimerLoad(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["load"]
-    sequence: DRNAT = Field(
-        description="Forward primer sequence placed at the 5' end of the DNA template probe."
-    )
+    sequence: DRNAT = Field(description="Only used when source = load.")
 
 
 class SeqfishPlusForwardPrimerOligoGeneration(BaseModel):
@@ -424,21 +402,17 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
         enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
     )
-    GC_content_filter: GCContentFilterConfig = Field(
-        default=GCContentFilterEnabled(enabled=True, GC_content_min=50, GC_content_max=65),
-        description="Enforce GC content within a specified range.",
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=50, GC_content_max=65
     )
-    GC_clamp_filter: GCClampFilterConfig = Field(
-        default=GCClampFilterEnabled(enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2),
-        description="Require G/C nucleotides at the 3' end of the primer for stable binding.",
+    GC_clamp_filter: GCClampFilterConfig = GCClampFilterEnabled(
+        enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2
     )
-    self_complementarity_filter: SelfComplementarityFilterConfig = Field(
-        default=SelfComplementarityFilterEnabled(enabled=True, max_len_selfcomplement=6),
-        description="Limit self-complementarity to avoid hairpins.",
+    self_complementarity_filter: SelfComplementarityFilterConfig = SelfComplementarityFilterEnabled(
+        enabled=True, max_len_selfcomplement=6
     )
-    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = Field(
-        default=ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5),
-        description="Limit complementarity between the forward primer and the (known) reverse primer to prevent primer-dimer formation.",
+    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = (
+        ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5)
     )
     Tm_filter: TmFilterConfig = TmFilterEnabled(enabled=True, Tm_min=60, Tm_max=75)
     secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
@@ -449,11 +423,9 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
 class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusPrimerSpecificityBlastnFilterConfig = Field(
-        description="Ensure primer specificity against a reference database (BLAST-based)."
-    )
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = Field(
-        default=HybridizationProbesBlastnFilterEnabled(
+    specificity_blastn_filter: SeqfishPlusPrimerSpecificityBlastnFilterConfig
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
+        HybridizationProbesBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -465,8 +437,7 @@ class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
                 max_hsps=1000,
             ),
             hit_parameters=BlastnHitParameters(min_alignment_length=11),
-        ),
-        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
+        )
     )
 
 
@@ -499,14 +470,17 @@ class SeqfishPlusForwardPrimerGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration = SeqfishPlusForwardPrimerOligoGeneration()
-    property_filters: SeqfishPlusForwardPrimerPropertyFilter = SeqfishPlusForwardPrimerPropertyFilter()
+    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration
+    property_filters: SeqfishPlusForwardPrimerPropertyFilter
     specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter
-    global_parameters: SeqfishPlusForwardPrimerGlobal = SeqfishPlusForwardPrimerGlobal()
+    global_parameters: SeqfishPlusForwardPrimerGlobal
 
 
 SeqfishPlusForwardPrimer = Annotated[
-    SeqfishPlusForwardPrimerLoad | SeqfishPlusForwardPrimerGenerate, Field(discriminator="source")
+    # use this order so that react-jsonschema-forms in ODT-Cloud selects the first
+    # model as a default when no defaults are specified (as is currently the case)
+    SeqfishPlusForwardPrimerGenerate | SeqfishPlusForwardPrimerLoad,
+    Field(discriminator="source"),
 ]
 
 
@@ -515,7 +489,7 @@ class SeqfishPlusReversePrimer(BaseModel):
 
     source: Literal["load"] = "load"
     sequence: DRNAT = Field(
-        description="Reverse primer sequence placed at the 3' end of the DNA template probe. The default is the reverse complement of the 20 nt T7 promoter sequence.",
+        description="Reverse complement of 20 nt T7 promoter sequence. Only used when source = load.",
         default="CCCTATAGTGAGTCGTATTA",
     )
 
@@ -524,7 +498,7 @@ class Primers(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     forward_primer: SeqfishPlusForwardPrimer
-    reverse_primer: SeqfishPlusReversePrimer = SeqfishPlusReversePrimer()
+    reverse_primer: SeqfishPlusReversePrimer
 
 
 ############################################

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -1,0 +1,510 @@
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveInt,
+    model_validator,
+)
+from typing_extensions import Self
+
+from oligo_designer_toolsuite.config._general_models import (
+    BaseProbabilities,
+    BlastnHitParameters,
+    BlastnSearchParameters,
+    General,
+    HomopolymericRunThreshold,
+    TmChemCorrectionParameters,
+    TmChemCorrectionParametersDisabled,
+    TmParameters,
+    TmSaltCorrectionParameters,
+    TmSaltCorrectionParametersDisabled,
+)
+from oligo_designer_toolsuite.config._oligo_scoring import (
+    GCContentScoreBasic,
+    IndependentSetSelection,
+    UTRScore,
+)
+from oligo_designer_toolsuite.config._property_filters import (
+    ComplementReversePrimerFilterConfig,
+    ComplementReversePrimerFilterEnabled,
+    GCClampFilterConfig,
+    GCClampFilterEnabled,
+    GCContentFilterConfig,
+    GCContentFilterEnabled,
+    HardMaskedFilterConfig,
+    HomopolymericRunsFilterConfig,
+    HomopolymericRunsFilterEnabled,
+    IsoformConsensusFilterConfig,
+    IsoformConsensusFilterEnabled,
+    SecondaryStructureFilterConfig,
+    SecondaryStructureFilterEnabled,
+    SelfComplementarityFilterConfig,
+    SelfComplementarityFilterEnabled,
+    SoftMaskedFilterConfig,
+    TmFilterConfig,
+    TmFilterEnabled,
+)
+from oligo_designer_toolsuite.config._specificity_filters import (
+    CrossHybridizationBlastnFilterConfig,
+    CrossHybridizationBlastnFilterEnabled,
+    HybridizationProbesBlastnFilterConfig,
+    HybridizationProbesBlastnFilterEnabled,
+    SpecificityBlastnFilterDisabled,
+    SpecificityBlastnFilterEnabled,
+)
+from oligo_designer_toolsuite.config._types import (
+    DRNAT,
+    FilesFastaDatabaseT,
+    LengthMaxT,
+    LengthMinT,
+    RegionListT,
+)
+
+############################################
+# seqFISH+-specific overrides
+############################################
+
+# The specificity BLASTN filter carries a required reference-database path
+# (files_fasta_reference_database, no default). These subclasses only set the
+# seqFISH+ default search/hit parameters; the path stays required, so the whole
+# filter must be supplied by the user.
+
+
+class SeqfishPlusSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
+    pass
+
+
+class SeqfishPlusTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=100,
+        strand="minus",
+        word_size=7,
+        dust="no",
+        soft_masking=False,
+        max_target_seqs=10,
+        max_hsps=1000,
+    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=15)
+
+
+SeqfishPlusTargetSpecificityBlastnFilterConfig = Annotated[
+    SeqfishPlusTargetSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class SeqfishPlusReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=100,
+        strand="minus",
+        word_size=7,
+        dust="no",
+        soft_masking=False,
+        max_target_seqs=10,
+        max_hsps=1000,
+    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=10)
+
+
+SeqfishPlusReadoutSpecificityBlastnFilterConfig = Annotated[
+    SeqfishPlusReadoutSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class SeqfishPlusPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
+    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
+        perc_identity=100,
+        strand="minus",
+        word_size=7,
+        dust="no",
+        soft_masking=False,
+        max_target_seqs=10,
+        max_hsps=1000,
+    )
+    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=14)
+
+
+SeqfishPlusPrimerSpecificityBlastnFilterConfig = Annotated[
+    SeqfishPlusPrimerSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+############################################
+# Target probe
+############################################
+
+
+class TargetProbeOligoGeneration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    file_region_ids: RegionListT
+    files_fasta_probe_database: FilesFastaDatabaseT
+    probe_length_min: LengthMinT = 28
+    probe_length_max: LengthMaxT = 28
+
+    @model_validator(mode="after")
+    def _check_min_max(self) -> Self:
+        if self.probe_length_min > self.probe_length_max:
+            raise ValueError(
+                f"'probe_length_min' ({self.probe_length_min}) must be <= 'probe_length_max' ({self.probe_length_max})"
+            )
+        return self
+
+
+class TargetProbePropertyFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    isoform_consensus_filter: IsoformConsensusFilterConfig = IsoformConsensusFilterEnabled(
+        enabled=True, isoform_consensus=100
+    )
+    hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
+    soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+    )
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=45, GC_content_max=65
+    )
+    secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
+        enabled=True, T=76, thr_DG=0
+    )
+
+
+class TargetProbeSpecificityFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    specificity_blastn_filter: SeqfishPlusTargetSpecificityBlastnFilterConfig
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
+        CrossHybridizationBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=80,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=17),
+        )
+    )
+
+
+class TargetProbeProbeSetSelection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    independent_set_selection: IndependentSetSelection = IndependentSetSelection(
+        n_sets=3,
+        set_size_min=24,
+        set_size_opt=24,
+        distance_between_probes=2,
+        n_attempts_graph=50,
+        n_attempts_clique_enum=50,
+        diversification_fraction=0.1,
+        jaccard_opt=0.5,
+        jaccard_step=0.1,
+    )
+    GC_content_score: GCContentScoreBasic = GCContentScoreBasic(weight=1, GC_content_opt=55)
+    UTR_score: UTRScore = UTRScore(weight=10)
+
+
+class TargetProbes(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    oligo_generation: TargetProbeOligoGeneration
+    property_filters: TargetProbePropertyFilter
+    specificity_filters: TargetProbeSpecificityFilter
+    probe_set_selection: TargetProbeProbeSetSelection
+
+
+############################################
+# Readout probes
+############################################
+
+# The codebook and readout-probe table support both source="load" and
+# source="generate", modelled as discriminated unions on `source`. Both use
+# extra="ignore" so the shipped YAML validates in either branch.
+
+
+class SeqfishPlusCodebookLoad(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["load"]
+    file: str = Field(
+        description="Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
+    )
+    n_barcode_rounds: PositiveInt = Field(
+        description="Number of barcode rounds. Equals active bits per gene and readout overhangs per encoding probe (first half 5' of target, second half 3').",
+        default=4,
+    )
+    n_pseudocolors: PositiveInt = Field(
+        description="Number of pseudocolors per round.",
+        default=4,
+    )
+    channels_ids: list[str] = Field(
+        description="Fluorescence channels used in the experiment.",
+        default=["Alexa488", "Cy3b", "Alexa647"],
+    )
+
+
+class SeqfishPlusCodebookGenerate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["generate"] = "generate"
+    n_barcode_rounds: PositiveInt = Field(
+        description="Number of barcode rounds. Equals active bits per gene and readout overhangs per encoding probe (first half 5' of target, second half 3').",
+        default=4,
+    )
+    n_pseudocolors: PositiveInt = Field(
+        description="Number of pseudocolors per round.",
+        default=4,
+    )
+    channels_ids: list[str] = Field(
+        description="Fluorescence channels used in the experiment.",
+        default=["Alexa488", "Cy3b", "Alexa647"],
+    )
+
+
+SeqfishPlusCodebook = Annotated[
+    SeqfishPlusCodebookLoad | SeqfishPlusCodebookGenerate, Field(discriminator="source")
+]
+
+
+class SeqfishPlusReadoutProbeTableLoad(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["load"]
+    file: str = Field(
+        description="Path to the bit-indexed readout probe table (csv/tsv) with columns 'barcode_round', 'pseudocolor', 'channel', and 'readout_probe_sequence'."
+    )
+
+
+class SeqfishPlusReadoutProbeOligoGeneration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe_length: PositiveInt = Field(
+        description="Length (bases) of each random readout probe.",
+        default=15,
+    )
+    base_probabilities: BaseProbabilities = Field(
+        default=BaseProbabilities(A=0.25, C=0.25, G=0.25, T=0.25),
+        description="Per-base probability used to generate random readout-probe sequences.",
+    )
+    initial_num_sequences: PositiveInt = Field(
+        description="Number of random sequences to generate before filtering.",
+        default=100000,
+    )
+
+
+class SeqfishPlusReadoutProbePropertyFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(G=3)
+    )
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=40, GC_content_max=60
+    )
+
+
+class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    specificity_blastn_filter: SeqfishPlusReadoutSpecificityBlastnFilterConfig
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
+        CrossHybridizationBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=10),
+        )
+    )
+
+
+class SeqfishPlusReadoutProbeTableGenerate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["generate"] = "generate"
+    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration = SeqfishPlusReadoutProbeOligoGeneration()
+    property_filters: SeqfishPlusReadoutProbePropertyFilter = SeqfishPlusReadoutProbePropertyFilter()
+    specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter
+
+
+SeqfishPlusReadoutProbeTable = Annotated[
+    SeqfishPlusReadoutProbeTableLoad | SeqfishPlusReadoutProbeTableGenerate, Field(discriminator="source")
+]
+
+
+class ReadoutProbes(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    codebook: SeqfishPlusCodebook = SeqfishPlusCodebookGenerate()
+    readout_probe_table: SeqfishPlusReadoutProbeTable
+
+
+############################################
+# Primers
+############################################
+
+# The forward primer supports source="load" (provide a sequence) and
+# source="generate" (design one), modelled as a discriminated union on `source`
+# with extra="ignore". The reverse primer only supports source="load"
+# (generate_reverse_primer raises FeatureNotImplementedError).
+
+
+class SeqfishPlusForwardPrimerLoad(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["load"]
+    sequence: DRNAT = Field(
+        description="Forward primer sequence placed at the 5' end of the DNA template probe."
+    )
+
+
+class SeqfishPlusForwardPrimerOligoGeneration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe_length: PositiveInt = Field(
+        description="Length (bases) of each generated primer.",
+        default=20,
+    )
+    base_probabilities: BaseProbabilities = Field(
+        default=BaseProbabilities(A=0.25, C=0.25, G=0.25, T=0.25),
+        description="Per-base probability used to generate random primer sequences.",
+    )
+    initial_num_sequences: PositiveInt = Field(
+        description="Number of random sequences to generate before filtering.",
+        default=1000000,
+    )
+
+
+class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
+        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+    )
+    GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
+        enabled=True, GC_content_min=50, GC_content_max=65
+    )
+    GC_clamp_filter: GCClampFilterConfig = Field(
+        default=GCClampFilterEnabled(enabled=True, number_GC_GCclamp=1, number_three_prime_base_GCclamp=2),
+        description="Require G/C nucleotides at the 3' end of the primer for stable binding.",
+    )
+    self_complementarity_filter: SelfComplementarityFilterConfig = SelfComplementarityFilterEnabled(
+        enabled=True, max_len_selfcomplement=6
+    )
+    complement_reverse_primer_filter: ComplementReversePrimerFilterConfig = (
+        ComplementReversePrimerFilterEnabled(enabled=True, max_len_complement=5)
+    )
+    Tm_filter: TmFilterConfig = TmFilterEnabled(enabled=True, Tm_min=60, Tm_max=75)
+    secondary_structure_filter: SecondaryStructureFilterConfig = SecondaryStructureFilterEnabled(
+        enabled=True, T=76, thr_DG=0
+    )
+
+
+class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    specificity_blastn_filter: SeqfishPlusPrimerSpecificityBlastnFilterConfig
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
+        HybridizationProbesBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=11),
+        )
+    )
+
+
+class SeqfishPlusForwardPrimerGlobal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    Tm_parameters: TmParameters = TmParameters(
+        nn_table="DNA_NN4",
+        tmm_table="DNA_TMM1",
+        imm_table="DNA_IMM1",
+        de_table="DNA_DE1",
+        dnac1=250,
+        dnac2=250,
+        saltcorr=5,
+        Na=300,
+        K=0,
+        Tris=0,
+        Mg=0,
+        dNTPs=0,
+    )
+    Tm_chem_correction_parameters: TmChemCorrectionParameters = TmChemCorrectionParametersDisabled(
+        enabled=False
+    )
+    Tm_salt_correction_parameters: TmSaltCorrectionParameters = TmSaltCorrectionParametersDisabled(
+        enabled=False
+    )
+
+
+class SeqfishPlusForwardPrimerGenerate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    source: Literal["generate"] = "generate"
+    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration = SeqfishPlusForwardPrimerOligoGeneration()
+    property_filters: SeqfishPlusForwardPrimerPropertyFilter = SeqfishPlusForwardPrimerPropertyFilter()
+    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter
+    global_parameters: SeqfishPlusForwardPrimerGlobal = SeqfishPlusForwardPrimerGlobal()
+
+
+SeqfishPlusForwardPrimer = Annotated[
+    SeqfishPlusForwardPrimerLoad | SeqfishPlusForwardPrimerGenerate, Field(discriminator="source")
+]
+
+
+class SeqfishPlusReversePrimer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["load"] = "load"
+    sequence: DRNAT = Field(
+        description="Reverse primer sequence placed at the 3' end of the DNA template probe. The default is the reverse complement of the 20 nt T7 promoter sequence.",
+        default="CCCTATAGTGAGTCGTATTA",
+    )
+
+
+class Primers(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    forward_primer: SeqfishPlusForwardPrimer
+    reverse_primer: SeqfishPlusReversePrimer = SeqfishPlusReversePrimer()
+
+
+############################################
+# Top level
+############################################
+
+
+class SeqfishPlusProbeDesignerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schema_version: Literal[2] = 2
+    general: General = General(
+        n_jobs=4,
+        dir_output="output_SeqfishPlusplus_probe_designer",
+        write_intermediate_steps=True,
+    )
+
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -242,6 +242,16 @@ class SeqfishPlusCodebookBase(BaseModel):
         default=4,
         json_schema_extra={"x-quick-setting": True},
     )
+    n_pseudocolors: PositiveInt = Field(
+        description="Number of pseudocolors per round.",
+        default=4,
+        json_schema_extra={"x-quick-setting": True},
+    )
+    channels_ids: list[str] = Field(
+        description="Fluorescence channels used in the experiment.",
+        default=["Alexa488", "Cy3b", "Alexa647"],
+        json_schema_extra={"x-quick-setting": True},
+    )
 
 
 class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
@@ -255,14 +265,6 @@ class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
 class SeqfishPlusCodebookGenerate(SeqfishPlusCodebookBase):
 
     source: Literal["generate"] = "generate"
-    n_pseudocolors: PositiveInt = Field(
-        description="Number of pseudocolors per round.",
-        default=4,
-    )
-    channels_ids: list[str] = Field(
-        description="Fluorescence channels used in the experiment.",
-        default=["Alexa488", "Cy3b", "Alexa647"],
-    )
 
 
 SeqfishPlusCodebook = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -242,16 +242,6 @@ class SeqfishPlusCodebookBase(BaseModel):
         default=4,
         json_schema_extra={"x-quick-setting": True},
     )
-    n_pseudocolors: PositiveInt = Field(
-        description="Number of pseudocolors per round.",
-        default=4,
-        json_schema_extra={"x-quick-setting": True},
-    )
-    channels_ids: list[str] = Field(
-        description="Fluorescence channels used in the experiment.",
-        default=["Alexa488", "Cy3b", "Alexa647"],
-        json_schema_extra={"x-quick-setting": True},
-    )
 
 
 class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
@@ -265,6 +255,14 @@ class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
 class SeqfishPlusCodebookGenerate(SeqfishPlusCodebookBase):
 
     source: Literal["generate"] = "generate"
+    n_pseudocolors: PositiveInt = Field(
+        description="Number of pseudocolors per round.",
+        default=4,
+    )
+    channels_ids: list[str] = Field(
+        description="Fluorescence channels used in the experiment.",
+        default=["Alexa488", "Cy3b", "Alexa647"],
+    )
 
 
 SeqfishPlusCodebook = Annotated[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,9 @@ from oligo_designer_toolsuite.config.pipelines.cycle_hcr_probe_designer import C
 from oligo_designer_toolsuite.config.pipelines.hcr_probe_designer import HcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.scrinshot_probe_designer import ScrinshotProbeDesignerConfig
+from oligo_designer_toolsuite.config.pipelines.seqfish_plus_probe_designer import (
+    SeqfishPlusProbeDesignerConfig,
+)
 
 _CONFIGS = Path("data/configs")
 
@@ -172,3 +175,65 @@ class TestCycleHcrYaml(unittest.TestCase):
         assert schema["title"] == "CycleHcrProbeDesignerConfig"
         assert "target_probes" in schema["properties"]
         assert "readout_probes" in schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# SeqfishPlusProbeDesignerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSeqfishYaml(unittest.TestCase):
+    def test_parses(self) -> None:
+        raw = _load("seqfish_plus_probe_designer.yaml")
+        cfg = SeqfishPlusProbeDesignerConfig.model_validate(raw)
+        assert cfg.schema_version == 2
+        assert cfg.general.write_intermediate_steps is True
+
+    def test_round_trip(self) -> None:
+        raw = _load("seqfish_plus_probe_designer.yaml")
+        cfg = SeqfishPlusProbeDesignerConfig.model_validate(raw)
+        cfg2 = SeqfishPlusProbeDesignerConfig.model_validate(cfg.model_dump())
+        assert cfg == cfg2
+
+    def test_unknown_top_level_field_forbidden(self) -> None:
+        # seqFISH+ has no initiator_probes section; extra="forbid" must reject it
+        raw = _load("seqfish_plus_probe_designer.yaml")
+        raw["initiator_probes"] = {"linker_sequence": "AA"}
+        with self.assertRaises(ValidationError):
+            SeqfishPlusProbeDesignerConfig.model_validate(raw)
+
+    def test_codebook_load_experiment_params_survive_dump(self) -> None:
+        # A loaded codebook still needs n_barcode_rounds / n_pseudocolors / channels_ids
+        # downstream, so they must survive model_dump() even under extra="ignore".
+        raw = _load("seqfish_plus_probe_designer.yaml")
+        raw["readout_probes"]["codebook"] = {"source": "load", "file": "codebook.tsv"}
+        dumped = SeqfishPlusProbeDesignerConfig.model_validate(raw).model_dump()
+        codebook = dumped["readout_probes"]["codebook"]
+        assert codebook["n_barcode_rounds"] == 4
+        assert codebook["n_pseudocolors"] == 4
+        assert codebook["channels_ids"] == ["Alexa488", "Cy3b", "Alexa647"]
+
+    def test_reverse_primer_generate_rejected(self) -> None:
+        # Reverse primer generation is not implemented; only "load" is allowed
+        raw = _load("seqfish_plus_probe_designer.yaml")
+        raw["primers"]["reverse_primer"]["source"] = "generate"
+        with self.assertRaises(ValidationError):
+            SeqfishPlusProbeDesignerConfig.model_validate(raw)
+
+    def test_base_probabilities_must_sum_to_one(self) -> None:
+        raw = _load("seqfish_plus_probe_designer.yaml")
+        raw["readout_probes"]["readout_probe_table"]["oligo_generation"]["base_probabilities"] = {
+            "A": 0.5,
+            "C": 0.5,
+            "G": 0.5,
+            "T": 0.5,
+        }
+        with self.assertRaises(ValidationError):
+            SeqfishPlusProbeDesignerConfig.model_validate(raw)
+
+    def test_json_schema(self) -> None:
+        schema = SeqfishPlusProbeDesignerConfig.model_json_schema()
+        assert schema["title"] == "SeqfishPlusProbeDesignerConfig"
+        assert "target_probes" in schema["properties"]
+        assert "readout_probes" in schema["properties"]
+        assert "primers" in schema["properties"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from oligo_designer_toolsuite.config.pipelines.cycle_hcr_probe_designer import CycleHcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.hcr_probe_designer import HcrProbeDesignerConfig
+from oligo_designer_toolsuite.config.pipelines.merfish_probe_designer import MerfishProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.scrinshot_probe_designer import ScrinshotProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.seqfish_plus_probe_designer import (
@@ -234,6 +235,58 @@ class TestSeqfishYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = SeqfishPlusProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "SeqfishPlusProbeDesignerConfig"
+        assert "target_probes" in schema["properties"]
+        assert "readout_probes" in schema["properties"]
+        assert "primers" in schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# MerfishProbeDesignerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMerfishYaml(unittest.TestCase):
+    def test_parses(self) -> None:
+        raw = _load("merfish_probe_designer.yaml")
+        cfg = MerfishProbeDesignerConfig.model_validate(raw)
+        assert cfg.schema_version == 2
+        assert cfg.general.write_intermediate_steps is True
+
+    def test_round_trip(self) -> None:
+        raw = _load("merfish_probe_designer.yaml")
+        cfg = MerfishProbeDesignerConfig.model_validate(raw)
+        cfg2 = MerfishProbeDesignerConfig.model_validate(cfg.model_dump())
+        assert cfg == cfg2
+
+    def test_unknown_top_level_field_forbidden(self) -> None:
+        # MERFISH has no initiator_probes section; extra="forbid" must reject it
+        raw = _load("merfish_probe_designer.yaml")
+        raw["initiator_probes"] = {"linker_sequence": "AA"}
+        with self.assertRaises(ValidationError):
+            MerfishProbeDesignerConfig.model_validate(raw)
+
+    def test_codebook_load_hamming_weight_survives_dump(self) -> None:
+        # A loaded codebook needs hamming_weight downstream and n_bits
+        # if the readoutprobe table is generated, so they must
+        # survive model_dump().
+        raw = _load("merfish_probe_designer.yaml")
+        raw["readout_probes"]["codebook"] = {"source": "load", "file": "codebook.tsv"}
+        dumped = MerfishProbeDesignerConfig.model_validate(raw).model_dump()
+        codebook = dumped["readout_probes"]["codebook"]
+        assert codebook["source"] == "load"
+        assert codebook["hamming_weight"] == 2
+        assert codebook["n_bits"] == 16
+
+    def test_reverse_primer_generate_rejected(self) -> None:
+        # Reverse primer generation is not implemented; only "load" is allowed
+        raw = _load("merfish_probe_designer.yaml")
+        raw["primers"]["reverse_primer"]["source"] = "generate"
+        with self.assertRaises(ValidationError):
+            MerfishProbeDesignerConfig.model_validate(raw)
+
+    def test_json_schema(self) -> None:
+        schema = MerfishProbeDesignerConfig.model_json_schema()
+        assert schema["title"] == "MerfishProbeDesignerConfig"
         assert "target_probes" in schema["properties"]
         assert "readout_probes" in schema["properties"]
         assert "primers" in schema["properties"]


### PR DESCRIPTION
add a pydantic model for the merfish pipeline

What is not done yet in this PR:

- more involved input validation (codebooks etc.)
- unified models for codebooks/readout probe tables across pipelines
- quick setting schema markers for paramters that depend on `source` == "load"/"generate" if they are needed -> we need to figure out best way here first
