### PR TITLE
correct BLASTN hit criteria and simplify pipeline configs for the front end

### DIFF
--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -20,6 +20,27 @@ from oligo_designer_toolsuite.config._types import (
 )
 
 
+# High-level descriptions of the config sections, shown as the section's help text in the form.
+REQUIRED_PARAMETERS_DESC = (
+    "Parameters required for target probe generation. The reference genome is reused for all "
+    "specificity filters for all probes."
+)
+OLIGO_GENERATION_DESC = "Parameters that determine length and spacing of the probes."
+PROPERTY_FILTERS_DESC = (
+    "Parameters for filters that depend on properties of the filters (e.g., melting temperature)."
+)
+SPECIFICITY_FILTERS_DESC = "Parameters for filters that test the specificity of the probes."
+GLOBAL_PARAMETERS_DESC = (
+    "Parameters for melting temperature computation that are reused for different filtering and "
+    "scoring methods."
+)
+CODEBOOK_DESC = "Parameters that determine the codebook generation or loading."
+READOUT_PROBE_TABLE_DESC = "Parameters that determine the readout probe table generation or loading."
+INITIATOR_TABLE_DESC = "Parameters that determine the initiator table generation or loading."
+FORWARD_PRIMER_DESC = "Parameters that determine the forward primer generation or loading."
+REVERSE_PRIMER_DESC = "Parameters that determine the reverse primer generation or loading."
+
+
 class General(BaseModel):
     model_config = ConfigDict(extra="forbid")
     n_jobs: PositiveInt = Field(

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -30,6 +30,9 @@ PROPERTY_FILTERS_DESC = (
     "Parameters for filters that depend on properties of the filters (e.g., melting temperature)."
 )
 SPECIFICITY_FILTERS_DESC = "Parameters for filters that test the specificity of the probes."
+PROBE_SET_SELECTION_DESC = (
+    "Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
+)
 GLOBAL_PARAMETERS_DESC = (
     "Parameters for melting temperature computation that are reused for different filtering and "
     "scoring methods."

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -10,10 +10,6 @@ from oligo_designer_toolsuite.config._types import (
     TmOptT,
 )
 
-PROBE_SET_SELECTION_DESC = (
-    "Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
-)
-
 
 class IndependentSetSelection(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -2,12 +2,19 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt
 
-from oligo_designer_toolsuite.config._general_models import BlastnHitParameters, BlastnSearchParameters
+from oligo_designer_toolsuite.config._general_models import (
+    BlastnHitParameters,
+    BlastnHitParametersCoverage,
+    BlastnHitParametersMinAlignmentLength,
+    BlastnSearchParameters,
+)
 from oligo_designer_toolsuite.config._types import VCFReferenceDatabaseT
 
 SPECIFICITY_TARGET_DESC = "Ensure oligo specificity against a reference database (BLAST-based)."
 SPECIFICITY_READOUT_DESC = "Remove readout probes with significant hits to the reference (BLAST-based)."
 SPECIFICITY_PRIMER_DESC = "Ensure primer specificity against a reference database (BLAST-based)."
+CROSS_HYBRIDIZATION_DESC = "Remove oligos that may cross-hybridize to other probes (BLAST-based)."
+HYBRIDIZATION_PROBES_DESC = "Remove primers that match the assembled hybridization probes (BLAST-based)."
 
 
 class FilterBaseConfigEnabled(BaseModel):
@@ -60,7 +67,7 @@ CrossHybridizationBlastnFilterConfig = Annotated[
     CrossHybridizationBlastnFilterEnabled | CrossHybridizationBlastnFilterDisabled,
     Field(
         discriminator="enabled",
-        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
+        description=CROSS_HYBRIDIZATION_DESC,
     ),
 ]
 
@@ -114,7 +121,7 @@ HybridizationProbesBlastnFilterConfig = Annotated[
     HybridizationProbesBlastnFilterEnabled | HybridizationProbesBlastnFilterDisabled,
     Field(
         discriminator="enabled",
-        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
+        description=HYBRIDIZATION_PROBES_DESC,
     ),
 ]
 
@@ -132,3 +139,80 @@ class VariantFilterEnabled(FilterBaseConfigEnabled):
 
 
 VariantFilterConfig = Annotated[VariantFilterEnabled | VariantFilterDisabled, Field(discriminator="enabled")]
+
+
+# Variants that set the hit criterion on `hit_parameters` itself, not on an enclosing config.
+#
+# A JSON Schema consumer picks the branch from a default on the field; one further out is not
+# read, so it falls back to the first branch while the outer value still merges in. That made
+# `value=15` meant as 15 bases arrive as 15 % coverage -- silently, both being plain numbers.
+# Coverage variants are needed for the same reason: otherwise a pipeline is correct only while
+# coverage stays declared first.
+#
+# Values are placeholders, overridden per call site. `description` is restated because
+# redeclaring a field replaces its whole FieldInfo.
+
+
+class SpecificityBlastnFilterMinAlignmentEnabled(SpecificityBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersMinAlignmentLength(value=15),
+        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+SpecificityBlastnFilterMinAlignmentConfig = Annotated[
+    SpecificityBlastnFilterMinAlignmentEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class SpecificityBlastnFilterCoverageEnabled(SpecificityBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=50),
+        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+SpecificityBlastnFilterCoverageConfig = Annotated[
+    SpecificityBlastnFilterCoverageEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class CrossHybridizationBlastnFilterMinAlignmentEnabled(CrossHybridizationBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersMinAlignmentLength(value=17),
+        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+CrossHybridizationBlastnFilterMinAlignmentConfig = Annotated[
+    CrossHybridizationBlastnFilterMinAlignmentEnabled | CrossHybridizationBlastnFilterDisabled,
+    Field(discriminator="enabled", description=CROSS_HYBRIDIZATION_DESC),
+]
+
+
+class CrossHybridizationBlastnFilterCoverageEnabled(CrossHybridizationBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=50),
+        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+CrossHybridizationBlastnFilterCoverageConfig = Annotated[
+    CrossHybridizationBlastnFilterCoverageEnabled | CrossHybridizationBlastnFilterDisabled,
+    Field(discriminator="enabled", description=CROSS_HYBRIDIZATION_DESC),
+]
+
+
+class HybridizationProbesBlastnFilterMinAlignmentEnabled(HybridizationProbesBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersMinAlignmentLength(value=11),
+        description=HybridizationProbesBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+HybridizationProbesBlastnFilterMinAlignmentConfig = Annotated[
+    HybridizationProbesBlastnFilterMinAlignmentEnabled | HybridizationProbesBlastnFilterDisabled,
+    Field(discriminator="enabled", description=HYBRIDIZATION_PROBES_DESC),
+]

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -15,6 +15,20 @@ SPECIFICITY_READOUT_DESC = "Remove readout probes with significant hits to the r
 SPECIFICITY_PRIMER_DESC = "Ensure primer specificity against a reference database (BLAST-based)."
 CROSS_HYBRIDIZATION_DESC = "Remove oligos that may cross-hybridize to other probes (BLAST-based)."
 HYBRIDIZATION_PROBES_DESC = "Remove primers that match the assembled hybridization probes (BLAST-based)."
+SPECIFICITY_SEARCH_PARAMS_DESC = "BLAST options for the specificity search."
+SPECIFICITY_HIT_PARAMS_DESC = (
+    "Hit criteria (either coverage % or minimum alignment length). Hits satisfying these lead to "
+    "oligo rejection."
+)
+CROSS_HYBRIDIZATION_SEARCH_PARAMS_DESC = "BLAST options for the cross-hybridization search."
+CROSS_HYBRIDIZATION_HIT_PARAMS_DESC = "Hit criteria. Hits satisfying these lead to oligo rejection."
+HYBRIDIZATION_PROBES_SEARCH_PARAMS_DESC = (
+    "BLASTN search parameters for filtering primers that match the assembled hybridization probes."
+)
+HYBRIDIZATION_PROBES_HIT_PARAMS_DESC = (
+    "Parameters for filtering BLASTN hits against the hybridization probes. Use either coverage or "
+    "min_alignment_length."
+)
 
 
 class FilterBaseConfigEnabled(BaseModel):
@@ -53,13 +67,13 @@ class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLAST options for the cross-hybridization search.",
+            description=CROSS_HYBRIDIZATION_SEARCH_PARAMS_DESC,
             json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(description="Hit criteria. Hits satisfying these lead to oligo rejection."),
+        Field(description=CROSS_HYBRIDIZATION_HIT_PARAMS_DESC),
     ]
 
 
@@ -80,15 +94,13 @@ class SpecificityBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLAST options for the specificity search.",
+            description=SPECIFICITY_SEARCH_PARAMS_DESC,
             json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(
-            description="Hit criteria (either coverage % or mininum alignment length). Hits satisfying these lead to oligo rejection."
-        ),
+        Field(description=SPECIFICITY_HIT_PARAMS_DESC),
     ]
 
 
@@ -105,15 +117,13 @@ class HybridizationProbesBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLASTN search parameters for filtering primers that match the assembled hybridization probes.",
+            description=HYBRIDIZATION_PROBES_SEARCH_PARAMS_DESC,
             json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(
-            description="Parameters for filtering BLASTN hits against the hybridization probes. Use either coverage or min_alignment_length."
-        ),
+        Field(description=HYBRIDIZATION_PROBES_HIT_PARAMS_DESC),
     ]
 
 
@@ -141,22 +151,26 @@ class VariantFilterEnabled(FilterBaseConfigEnabled):
 VariantFilterConfig = Annotated[VariantFilterEnabled | VariantFilterDisabled, Field(discriminator="enabled")]
 
 
-# Variants that set the hit criterion on `hit_parameters` itself, not on an enclosing config.
+# Variants of the filters above that set the default hit criterion (coverage vs. minimum
+# alignment length) on the `hit_parameters` field itself, not on an enclosing config class.
 #
-# A JSON Schema consumer picks the branch from a default on the field; one further out is not
-# read, so it falls back to the first branch while the outer value still merges in. That made
-# `value=15` meant as 15 bases arrive as 15 % coverage -- silently, both being plain numbers.
-# Coverage variants are needed for the same reason: otherwise a pipeline is correct only while
-# coverage stays declared first.
+# The ODT-Cloud form (react-jsonschema-form) preselects a union branch from the default on the
+# field itself; a default declared further out is ignored for that choice, though its values
+# still merge in. A pipeline defaulting a whole filter section to min-alignment `value=15` was
+# therefore rendered as the coverage branch: "at least 15 aligned bases" became "15 % coverage",
+# with no error, both being plain numbers. These variants put the default where the form reads
+# it. Coverage variants exist too, so a coverage pipeline does not depend on coverage staying
+# the first branch of the union.
 #
-# Values are placeholders, overridden per call site. `description` is restated because
-# redeclaring a field replaces its whole FieldInfo.
+# The `value` defaults here are placeholders; each pipeline overrides them at its call site.
+# `description` is restated because redeclaring a field replaces its whole FieldInfo,
+# description included.
 
 
 class SpecificityBlastnFilterMinAlignmentEnabled(SpecificityBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersMinAlignmentLength(value=15),
-        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=SPECIFICITY_HIT_PARAMS_DESC,
     )
 
 
@@ -169,7 +183,7 @@ SpecificityBlastnFilterMinAlignmentConfig = Annotated[
 class SpecificityBlastnFilterCoverageEnabled(SpecificityBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersCoverage(value=50),
-        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=SPECIFICITY_HIT_PARAMS_DESC,
     )
 
 
@@ -182,7 +196,7 @@ SpecificityBlastnFilterCoverageConfig = Annotated[
 class CrossHybridizationBlastnFilterMinAlignmentEnabled(CrossHybridizationBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersMinAlignmentLength(value=17),
-        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=CROSS_HYBRIDIZATION_HIT_PARAMS_DESC,
     )
 
 
@@ -195,7 +209,7 @@ CrossHybridizationBlastnFilterMinAlignmentConfig = Annotated[
 class CrossHybridizationBlastnFilterCoverageEnabled(CrossHybridizationBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersCoverage(value=50),
-        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=CROSS_HYBRIDIZATION_HIT_PARAMS_DESC,
     )
 
 
@@ -208,7 +222,7 @@ CrossHybridizationBlastnFilterCoverageConfig = Annotated[
 class HybridizationProbesBlastnFilterMinAlignmentEnabled(HybridizationProbesBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersMinAlignmentLength(value=11),
-        description=HybridizationProbesBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=HYBRIDIZATION_PROBES_HIT_PARAMS_DESC,
     )
 
 

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -154,13 +154,29 @@ VariantFilterConfig = Annotated[VariantFilterEnabled | VariantFilterDisabled, Fi
 # Variants of the filters above that set the default hit criterion (coverage vs. minimum
 # alignment length) on the `hit_parameters` field itself, not on an enclosing config class.
 #
-# The ODT-Cloud form (react-jsonschema-form) preselects a union branch from the default on the
-# field itself; a default declared further out is ignored for that choice, though its values
-# still merge in. A pipeline defaulting a whole filter section to min-alignment `value=15` was
-# therefore rendered as the coverage branch: "at least 15 aligned bases" became "15 % coverage",
-# with no error, both being plain numbers. These variants put the default where the form reads
-# it. Coverage variants exist too, so a coverage pipeline does not depend on coverage staying
-# the first branch of the union.
+# `hit_parameters` is a union discriminated on `hit_criterion`, declared in `_general_models.py`
+# as `BlastnHitParametersCoverage | BlastnHitParametersMinAlignmentLength`. The ODT-Cloud form
+# (react-jsonschema-form) has to pick one of the two before the user has typed anything, and it
+# reads only the default on `hit_parameters` itself. Take `MerfishProbeDesignerConfig`, which
+# before these variants existed declared its target probe filter as:
+#
+#     specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+#         default=SpecificityBlastnFilterEnabled(
+#             ...,
+#             hit_parameters=BlastnHitParametersMinAlignmentLength(value=17),
+#         ),
+#     )
+#
+# That default sits on `specificity_blastn_filter`, one level above the field the form reads,
+# so `SpecificityBlastnFilterEnabled.hit_parameters` reached the schema with no default of its
+# own. The form fell back to the first branch of the union, `BlastnHitParametersCoverage`, and
+# filled it with the 17 from the enclosing default: "at least 17 aligned bases" was rendered as
+# "17 % coverage", with no error, both being plain numbers.
+#
+# `SpecificityBlastnFilterMinAlignmentEnabled` below redeclares `hit_parameters` with a
+# min-alignment default, which puts it where the form looks; the pipeline then defaults the
+# section to that variant instead. Coverage variants exist for the same reason, so a coverage
+# pipeline does not depend on coverage staying the first branch of the union.
 #
 # The `value` defaults here are placeholders; each pipeline overrides them at its call site.
 # `description` is restated because redeclaring a field replaces its whole FieldInfo,

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -9,6 +9,11 @@ from pydantic import (
 )
 
 from oligo_designer_toolsuite.config._general_models import (
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
@@ -22,6 +27,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -198,11 +204,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -324,4 +330,4 @@ class CycleHcrProbeDesignerConfig(CycleHcrProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -64,8 +64,6 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=13,
     )
-    # redeclared to change the defaults below; description/x-collapsed restated since
-    # redeclaring a field replaces its whole FieldInfo
     search_parameters: BlastnSearchParameters = Field(
         default=BlastnSearchParameters(
             perc_identity=100,
@@ -237,7 +235,6 @@ class CycleHcrCodebookGenerate(BaseModel):
             "n_readout_probes_LR * n_channels regions."
         ),
         default=4,
-        json_schema_extra={"x-quick-setting": True},
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -141,6 +141,7 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    specificity_blastn_filter: CycleHcrSpecificityBlastnFilterConfig
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
         CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
@@ -155,7 +156,6 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=90),
         )
     )
-    specificity_blastn_filter: CycleHcrSpecificityBlastnFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -64,14 +64,20 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=13,
     )
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=10,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    # redeclared to change the defaults below; description/x-collapsed restated since
+    # redeclaring a field replaces its whole FieldInfo
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=100,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        json_schema_extra={"x-collapsed": True},
     )
     hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
 

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -42,8 +42,8 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
@@ -93,14 +93,17 @@ class TargetProbeOligoGeneration(BaseModel):
     L_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the L arm of the probe; L + gap + R equals the total probe length.",
         default=45,
+        json_schema_extra={"x-quick-setting": True},
     )
     gap_sequence_length: NonNegativeInt = Field(
         description="Length (bases) of the spacer between the L and R arms (covers the junction site).",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
     R_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the R arm of the probe; L + gap + R equals the total probe length.",
         default=45,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -113,7 +116,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=False)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=30, GC_content_max=90
@@ -127,8 +131,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -227,6 +231,7 @@ class CycleHcrCodebookGenerate(BaseModel):
             "n_readout_probes_LR * n_channels regions."
         ),
         default=4,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -299,9 +304,17 @@ class HybridizationProbes(BaseModel):
 ############################################
 
 
-class CycleHcrProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class CycleHcrProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers
+    hybridization_probes: HybridizationProbes
+
+
+class CycleHcrProbeDesignerConfig(CycleHcrProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_cyclehcr_probe_designer",
@@ -309,7 +322,3 @@ class CycleHcrProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    readout_probes: ReadoutProbes
-    primers: Primers
-    hybridization_probes: HybridizationProbes

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -11,6 +11,7 @@ from pydantic import (
 from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -27,7 +28,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -47,6 +47,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_HIT_PARAMS_DESC,
+    SPECIFICITY_SEARCH_PARAMS_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterCoverageConfig,
     CrossHybridizationBlastnFilterCoverageEnabled,
@@ -80,10 +82,13 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
             max_target_seqs=10,
             max_hsps=1000,
         ),
-        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        description=SPECIFICITY_SEARCH_PARAMS_DESC,
         json_schema_extra={"x-collapsed": True},
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=90),
+        description=SPECIFICITY_HIT_PARAMS_DESC,
+    )
 
 
 CycleHcrSpecificityBlastnFilterConfig = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -41,8 +41,8 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
@@ -92,14 +92,17 @@ class TargetProbeOligoGeneration(BaseModel):
     L_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the L arm of the probe; L + gap + R equals the total probe length.",
         default=25,
+        json_schema_extra={"x-quick-setting": True},
     )
     gap_sequence_length: NonNegativeInt = Field(
         description="Length (bases) of the spacer between the L and R arms (covers the ligation site).",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
     R_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the R arm of the probe; L + gap + R equals the total probe length.",
         default=25,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -112,7 +115,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=False)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=40, GC_content_max=65
@@ -126,8 +130,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -264,9 +268,16 @@ class HybridizationProbes(BaseModel):
 ############################################
 
 
-class HcrProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class HcrProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    initiator_probes: InitiatorProbes
+    hybridization_probes: HybridizationProbes
+
+
+class HcrProbeDesignerConfig(HcrProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_hcr_probe_designer",
@@ -274,6 +285,3 @@ class HcrProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    initiator_probes: InitiatorProbes
-    hybridization_probes: HybridizationProbes

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -13,6 +13,7 @@ from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     INITIATOR_TABLE_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -29,7 +30,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
 )
@@ -48,6 +48,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_HIT_PARAMS_DESC,
+    SPECIFICITY_SEARCH_PARAMS_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterCoverageConfig,
     CrossHybridizationBlastnFilterCoverageEnabled,
@@ -81,10 +83,13 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
             max_target_seqs=10,
             max_hsps=1000,
         ),
-        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        description=SPECIFICITY_SEARCH_PARAMS_DESC,
         json_schema_extra={"x-collapsed": True},
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=90),
+        description=SPECIFICITY_HIT_PARAMS_DESC,
+    )
 
 
 HcrSpecificityBlastnFilterConfig = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -63,8 +63,6 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=0,
     )
-    # redeclared to change the defaults below; description/x-collapsed restated since
-    # redeclaring a field replaces its whole FieldInfo
     search_parameters: BlastnSearchParameters = Field(
         default=BlastnSearchParameters(
             perc_identity=100,

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -9,6 +9,13 @@ from pydantic import (
 )
 
 from oligo_designer_toolsuite.config._general_models import (
+    CODEBOOK_DESC,
+    GLOBAL_PARAMETERS_DESC,
+    INITIATOR_TABLE_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
@@ -22,6 +29,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
 )
@@ -196,11 +204,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -249,8 +257,8 @@ HcrInitiatorTable = Annotated[
 class InitiatorProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    codebook: HcrCodebook
-    initiator_table: HcrInitiatorTable
+    codebook: HcrCodebook = Field(description=CODEBOOK_DESC)
+    initiator_table: HcrInitiatorTable = Field(description=INITIATOR_TABLE_DESC)
 
 
 ############################################
@@ -288,4 +296,4 @@ class HcrProbeDesignerConfig(HcrProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -142,6 +142,7 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    specificity_blastn_filter: HcrSpecificityBlastnFilterConfig
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
         CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
@@ -156,7 +157,6 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=90),
         )
     )
-    specificity_blastn_filter: HcrSpecificityBlastnFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -63,14 +63,20 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=0,
     )
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=10,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    # redeclared to change the defaults below; description/x-collapsed restated since
+    # redeclaring a field replaces its whole FieldInfo
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=100,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        json_schema_extra={"x-collapsed": True},
     )
     hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
 
@@ -81,7 +87,7 @@ HcrSpecificityBlastnFilterConfig = Annotated[
 ]
 
 
-############################################
+############################################ add here expanding toggle
 # Target probe
 ############################################
 

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -10,6 +10,15 @@ from pydantic import (
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    CODEBOOK_DESC,
+    FORWARD_PRIMER_DESC,
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    READOUT_PROBE_TABLE_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    REVERSE_PRIMER_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BaseProbabilities,
     BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
@@ -190,11 +199,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
     probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
-    global_parameters: TargetProbeGlobal
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -369,10 +378,10 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
         json_schema_extra={"x-quick-setting": True},
     )
     oligo_generation: MerfishReadoutProbeOligoGeneration
-    property_filters: MerfishReadoutProbePropertyFilter
-    specificity_filters: MerfishReadoutProbeSpecificityFilter
-    probe_set_selection: MerfishReadoutProbeSetSelection
-    global_parameters: MerfishReadoutProbesGlobal
+    property_filters: MerfishReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: MerfishReadoutProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: MerfishReadoutProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: MerfishReadoutProbesGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 MerfishReadoutProbeTable = Annotated[
@@ -386,8 +395,8 @@ MerfishReadoutProbeTable = Annotated[
 class ReadoutProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    codebook: MerfishCodebook
-    readout_probe_table: MerfishReadoutProbeTable
+    codebook: MerfishCodebook = Field(description=CODEBOOK_DESC)
+    readout_probe_table: MerfishReadoutProbeTable = Field(description=READOUT_PROBE_TABLE_DESC)
 
 
 ############################################
@@ -515,9 +524,13 @@ class MerfishForwardPrimerGenerate(BaseModel):
 
     source: Literal["generate"] = "generate"
     oligo_generation: MerfishForwardPrimerOligoGeneration = MerfishForwardPrimerOligoGeneration()
-    property_filters: MerfishForwardPrimerPropertyFilter = MerfishForwardPrimerPropertyFilter()
-    specificity_filters: MerfishForwardPrimerSpecificityFilter
-    global_parameters: MerfishForwardPrimerGlobal = MerfishForwardPrimerGlobal()
+    property_filters: MerfishForwardPrimerPropertyFilter = Field(
+        default=MerfishForwardPrimerPropertyFilter(), description=PROPERTY_FILTERS_DESC
+    )
+    specificity_filters: MerfishForwardPrimerSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    global_parameters: MerfishForwardPrimerGlobal = Field(
+        default=MerfishForwardPrimerGlobal(), description=GLOBAL_PARAMETERS_DESC
+    )
 
 
 MerfishForwardPrimer = Annotated[
@@ -541,8 +554,8 @@ class MerfishReversePrimer(BaseModel):
 class Primers(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    forward_primer: MerfishForwardPrimer
-    reverse_primer: MerfishReversePrimer
+    forward_primer: MerfishForwardPrimer = Field(description=FORWARD_PRIMER_DESC)
+    reverse_primer: MerfishReversePrimer = Field(description=REVERSE_PRIMER_DESC)
 
 
 ############################################
@@ -566,4 +579,4 @@ class MerfishProbeDesignerConfig(MerfishProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -53,12 +53,12 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_PRIMER_DESC,
     SPECIFICITY_READOUT_DESC,
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
-    HybridizationProbesBlastnFilterConfig,
-    HybridizationProbesBlastnFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterMinAlignmentConfig,
+    CrossHybridizationBlastnFilterMinAlignmentEnabled,
+    HybridizationProbesBlastnFilterMinAlignmentConfig,
+    HybridizationProbesBlastnFilterMinAlignmentEnabled,
+    SpecificityBlastnFilterMinAlignmentConfig,
+    SpecificityBlastnFilterMinAlignmentEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
@@ -96,7 +96,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=43, GC_content_max=63
@@ -110,8 +111,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -126,8 +127,8 @@ class TargetProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_TARGET_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -232,6 +233,7 @@ class MerfishCodebookGenerate(MerfishCodebookBase):
     min_hamming_dist: PositiveInt = Field(
         description="Minimum Hamming distance between any two valid barcodes (MHD4 = 4 for single-bit error correction).",
         default=4,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -283,8 +285,8 @@ class MerfishReadoutProbePropertyFilter(BaseModel):
 class MerfishReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -299,8 +301,8 @@ class MerfishReadoutProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_READOUT_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -326,7 +328,10 @@ class MerfishReadoutProbeSetSelection(BaseModel):
         default=100000,
         description="Number of candidate sets to evaluate; higher values may find better sets but increase computation time.",
     )
-    homogeneous_properties_weights: HomogeneousPropertiesWeightsT = {"TmNN_oligo": 1, "GC_content_oligo": 1.0}
+    homogeneous_properties_weights: HomogeneousPropertiesWeightsT = {
+        "TmNN_oligo": 1,
+        "GC_content_oligo": 1.0,
+    }
 
 
 class MerfishReadoutProbesGlobal(BaseModel):
@@ -361,6 +366,7 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
     channels_ids: list[str] = Field(
         description="Fluorescence channels used for round-robin channel assignment across bits.",
         default=["Alexa488", "Cy3b", "Alexa647"],
+        json_schema_extra={"x-quick-setting": True},
     )
     oligo_generation: MerfishReadoutProbeOligoGeneration
     property_filters: MerfishReadoutProbePropertyFilter
@@ -422,7 +428,8 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=50, GC_content_max=65
@@ -445,8 +452,8 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
 class MerfishForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -461,8 +468,8 @@ class MerfishForwardPrimerSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_PRIMER_DESC,
     )
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
-        HybridizationProbesBlastnFilterEnabled(
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterMinAlignmentConfig = (
+        HybridizationProbesBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -543,9 +550,16 @@ class Primers(BaseModel):
 ############################################
 
 
-class MerfishProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class MerfishProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers
+
+
+class MerfishProbeDesignerConfig(MerfishProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_Merfishplus_probe_designer",
@@ -553,6 +567,3 @@ class MerfishProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    readout_probes: ReadoutProbes
-    primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -14,6 +14,7 @@ from oligo_designer_toolsuite.config._general_models import (
     FORWARD_PRIMER_DESC,
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     READOUT_PROBE_TABLE_DESC,
     REQUIRED_PARAMETERS_DESC,
@@ -32,7 +33,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScore,
     IndependentSetSelection,
     IsoformConsensusScore,

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -377,11 +377,23 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
         default=["Alexa488", "Cy3b", "Alexa647"],
         json_schema_extra={"x-quick-setting": True},
     )
-    oligo_generation: MerfishReadoutProbeOligoGeneration
-    property_filters: MerfishReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
-    specificity_filters: MerfishReadoutProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
-    probe_set_selection: MerfishReadoutProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
-    global_parameters: MerfishReadoutProbesGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
+    oligo_generation: MerfishReadoutProbeOligoGeneration = Field(json_schema_extra={"x-collapsed": True})
+    property_filters: MerfishReadoutProbePropertyFilter = Field(
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    specificity_filters: MerfishReadoutProbeSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    probe_set_selection: MerfishReadoutProbeSetSelection = Field(
+        description=PROBE_SET_SELECTION_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    global_parameters: MerfishReadoutProbesGlobal = Field(
+        description=GLOBAL_PARAMETERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
 
 
 MerfishReadoutProbeTable = Annotated[
@@ -523,13 +535,23 @@ class MerfishForwardPrimerGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: MerfishForwardPrimerOligoGeneration = MerfishForwardPrimerOligoGeneration()
-    property_filters: MerfishForwardPrimerPropertyFilter = Field(
-        default=MerfishForwardPrimerPropertyFilter(), description=PROPERTY_FILTERS_DESC
+    oligo_generation: MerfishForwardPrimerOligoGeneration = Field(
+        default=MerfishForwardPrimerOligoGeneration(),
+        json_schema_extra={"x-collapsed": True},
     )
-    specificity_filters: MerfishForwardPrimerSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    property_filters: MerfishForwardPrimerPropertyFilter = Field(
+        default=MerfishForwardPrimerPropertyFilter(),
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    specificity_filters: MerfishForwardPrimerSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
     global_parameters: MerfishForwardPrimerGlobal = Field(
-        default=MerfishForwardPrimerGlobal(), description=GLOBAL_PARAMETERS_DESC
+        default=MerfishForwardPrimerGlobal(),
+        description=GLOBAL_PARAMETERS_DESC,
+        json_schema_extra={"x-collapsed": True},
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -22,7 +23,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -149,13 +149,6 @@ class TargetProbeSpecificityFilterBase(BaseModel):
     read_length_bias_filter: ReadLengthBiasFilterConfig = ReadLengthBiasFilterEnabled(
         enabled=True, read_length_bias=20
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
-        CrossHybridizationBlastnFilterCoverageEnabled(
-            enabled=True,
-            search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
-            hit_parameters=BlastnHitParametersCoverage(value=50),
-        )
-    )
     specificity_blastn_filter: SpecificityBlastnFilterCoverageConfig = Field(
         default=SpecificityBlastnFilterCoverageEnabled(
             enabled=True,
@@ -163,6 +156,13 @@ class TargetProbeSpecificityFilterBase(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=50),
         ),
         description=SPECIFICITY_TARGET_DESC,
+    )
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
+            hit_parameters=BlastnHitParametersCoverage(value=50),
+        )
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -46,12 +46,12 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     ReadLengthBiasFilterConfig,
     ReadLengthBiasFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
+    SpecificityBlastnFilterCoverageConfig,
+    SpecificityBlastnFilterCoverageEnabled,
     VariantFilterDisabled,
     VariantFilterEnabled,
 )
@@ -77,7 +77,8 @@ class OligoSeqVariantFilterEnabled(VariantFilterEnabled):
 
 
 OligoSeqVariantFilterConfig = Annotated[
-    OligoSeqVariantFilterEnabled | OligoSeqVariantFilterDisabled, Field(discriminator="enabled")
+    OligoSeqVariantFilterEnabled | OligoSeqVariantFilterDisabled,
+    Field(discriminator="enabled"),
 ]
 
 
@@ -89,8 +90,8 @@ OligoSeqVariantFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    probe_length_min: LengthMinT = 26
-    probe_length_max: LengthMaxT = 30
+    probe_length_min: LengthMinT = Field(default=26, json_schema_extra={"x-quick-setting": True})
+    probe_length_max: LengthMaxT = Field(default=30, json_schema_extra={"x-quick-setting": True})
     probe_split_region: PositiveInt = Field(
         description="Minimum number of bases covering the exon junction, i.e. the oligo should contain at least x bases upstream/downstream of the junction.",
         default=4,
@@ -115,7 +116,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=45, GC_content_max=65
@@ -141,15 +143,15 @@ class TargetProbeSpecificityFilterBase(BaseModel):
     read_length_bias_filter: ReadLengthBiasFilterConfig = ReadLengthBiasFilterEnabled(
         enabled=True, read_length_bias=20
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
             hit_parameters=BlastnHitParametersCoverage(value=50),
         )
     )
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterCoverageConfig = Field(
+        default=SpecificityBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
             hit_parameters=BlastnHitParametersCoverage(value=50),
@@ -227,7 +229,7 @@ class TargetProbes(BaseModel):
 ############################################
 
 
-# can be used to be adjusted in the frontend
+# The front end builds its form from this, so `general` stays out of it.
 class OligoSeqProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -4,6 +4,11 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
@@ -17,6 +22,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
@@ -217,11 +223,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -243,4 +249,4 @@ class OligoSeqProbeDesignerConfig(OligoSeqProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -168,6 +168,7 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    specificity_blastn_filter: ScrinshotSpecificityBlastnFilterConfig
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
         CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
@@ -182,7 +183,6 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=80),
         )
     )
-    specificity_blastn_filter: ScrinshotSpecificityBlastnFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -31,7 +32,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
@@ -50,6 +50,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_HIT_PARAMS_DESC,
+    SPECIFICITY_SEARCH_PARAMS_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterCoverageConfig,
     CrossHybridizationBlastnFilterCoverageEnabled,
@@ -83,10 +85,13 @@ class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
             max_target_seqs=10,
             max_hsps=1000,
         ),
-        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        description=SPECIFICITY_SEARCH_PARAMS_DESC,
         json_schema_extra={"x-collapsed": True},
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=50),
+        description=SPECIFICITY_HIT_PARAMS_DESC,
+    )
     ligation_region_size: NonNegativeInt = Field(
         description=(
             "Size of the seed region around the ligation site for BLASTN seed-region filtering. "

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -12,6 +12,11 @@ from pydantic import (
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
@@ -26,6 +31,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
@@ -57,6 +63,9 @@ from oligo_designer_toolsuite.config._types import (
     TmMinT,
     TmOptT,
 )
+
+PADLOCK_ARMS_PROPERTIES_DESC = "Parameters that determine properties of the padlock arms."
+DETECTION_OLIGO_GENERATION_DESC = "Parameters that determine length and melting temperature of the probes."
 
 ############################################
 # SCRINSHOT-specific overrides
@@ -228,12 +237,12 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    padlock_arms_properties: PadlockArmsProperties
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    padlock_arms_properties: PadlockArmsProperties = Field(description=PADLOCK_ARMS_PROPERTIES_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -298,8 +307,8 @@ class DetectionOligoGlobal(BaseModel):
 class DetectionOligo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: DetectionOligoOligoGeneration
-    global_parameters: DetectionOligoGlobal
+    oligo_generation: DetectionOligoOligoGeneration = Field(description=DETECTION_OLIGO_GENERATION_DESC)
+    global_parameters: DetectionOligoGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -322,4 +331,4 @@ class ScrinshotProbeDesignerConfig(ScrinshotProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -64,14 +64,18 @@ from oligo_designer_toolsuite.config._types import (
 
 
 class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=80,
-        strand="minus",
-        word_size=10,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=80,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        json_schema_extra={"x-collapsed": True},
     )
     hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
     ligation_region_size: NonNegativeInt = Field(

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -45,8 +45,8 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
@@ -99,8 +99,8 @@ ScrinshotSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    probe_length_min: LengthMinT = 40
-    probe_length_max: LengthMaxT = 45
+    probe_length_min: LengthMinT = Field(default=40, json_schema_extra={"x-quick-setting": True})
+    probe_length_max: LengthMaxT = Field(default=45, json_schema_extra={"x-quick-setting": True})
 
     @model_validator(mode="after")
     def _check_min_max(self) -> Self:
@@ -143,7 +143,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=40, GC_content_max=60
@@ -154,8 +155,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -242,12 +243,14 @@ class DetectionOligoOligoGeneration(BaseModel):
     min_thymines: PositiveInt = Field(
         description="Minimal number of thymines (T) in the detection oligo (required for UNG cleavage after U-substitution).",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
-    oligo_length_min: LengthMinT = 15
-    oligo_length_max: LengthMaxT = 40
+    oligo_length_min: LengthMinT = Field(default=15, json_schema_extra={"x-quick-setting": True})
+    oligo_length_max: LengthMaxT = Field(default=40, json_schema_extra={"x-quick-setting": True})
     U_distance: PositiveInt = Field(
         description="Preferred minimum distance (bases) between consecutive uracils.",
         default=5,
+        json_schema_extra={"x-quick-setting": True},
     )
     Tm_opt: TmOptT = 56
 
@@ -300,9 +303,15 @@ class DetectionOligo(BaseModel):
 ############################################
 
 
-class ScrinshotProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class ScrinshotProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    detection_oligo: DetectionOligo
+
+
+class ScrinshotProbeDesignerConfig(ScrinshotProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_scrinshot_probe_designer",
@@ -310,5 +319,3 @@ class ScrinshotProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    detection_oligo: DetectionOligo

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -52,12 +52,12 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_PRIMER_DESC,
     SPECIFICITY_READOUT_DESC,
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
-    HybridizationProbesBlastnFilterConfig,
-    HybridizationProbesBlastnFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterMinAlignmentConfig,
+    CrossHybridizationBlastnFilterMinAlignmentEnabled,
+    HybridizationProbesBlastnFilterMinAlignmentConfig,
+    HybridizationProbesBlastnFilterMinAlignmentEnabled,
+    SpecificityBlastnFilterMinAlignmentConfig,
+    SpecificityBlastnFilterMinAlignmentEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
@@ -94,7 +94,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=45, GC_content_max=65
@@ -107,8 +108,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -123,8 +124,8 @@ class TargetProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_TARGET_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -196,7 +197,6 @@ class SeqfishPlusCodebookBase(BaseModel):
 
 
 class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
-
     source: Literal["load"] = "load"
     file: str = Field(
         description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
@@ -204,7 +204,6 @@ class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
 
 
 class SeqfishPlusCodebookGenerate(SeqfishPlusCodebookBase):
-
     source: Literal["generate"] = "generate"
 
 
@@ -256,8 +255,8 @@ class SeqfishPlusReadoutProbePropertyFilter(BaseModel):
 class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -272,8 +271,8 @@ class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_READOUT_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -350,7 +349,8 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=50, GC_content_max=65
@@ -373,8 +373,8 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
 class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -389,8 +389,8 @@ class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_PRIMER_DESC,
     )
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
-        HybridizationProbesBlastnFilterEnabled(
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterMinAlignmentConfig = (
+        HybridizationProbesBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -471,15 +471,20 @@ class Primers(BaseModel):
 ############################################
 
 
-class SeqfishPlusProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class SeqfishPlusProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers
+
+
+class SeqfishPlusProbeDesignerConfig(SeqfishPlusProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_SeqfishPlusplus_probe_designer",
         write_intermediate_steps=True,
     )
+
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    readout_probes: ReadoutProbes
-    primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -298,10 +298,14 @@ class SeqfishPlusReadoutProbeTableGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration
-    property_filters: SeqfishPlusReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration = Field(json_schema_extra={"x-collapsed": True})
+    property_filters: SeqfishPlusReadoutProbePropertyFilter = Field(
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
     specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter = Field(
-        description=SPECIFICITY_FILTERS_DESC
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
     )
 
 
@@ -444,12 +448,19 @@ class SeqfishPlusForwardPrimerGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration
-    property_filters: SeqfishPlusForwardPrimerPropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
-    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter = Field(
-        description=SPECIFICITY_FILTERS_DESC
+    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration = Field(json_schema_extra={"x-collapsed": True})
+    property_filters: SeqfishPlusForwardPrimerPropertyFilter = Field(
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
     )
-    global_parameters: SeqfishPlusForwardPrimerGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
+    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    global_parameters: SeqfishPlusForwardPrimerGlobal = Field(
+        description=GLOBAL_PARAMETERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
 
 
 SeqfishPlusForwardPrimer = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -10,6 +10,13 @@ from pydantic import (
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    FORWARD_PRIMER_DESC,
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    REVERSE_PRIMER_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BaseProbabilities,
     BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
@@ -161,9 +168,9 @@ class TargetProbeProbeSetSelection(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
     probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
 
 
@@ -292,8 +299,10 @@ class SeqfishPlusReadoutProbeTableGenerate(BaseModel):
 
     source: Literal["generate"] = "generate"
     oligo_generation: SeqfishPlusReadoutProbeOligoGeneration
-    property_filters: SeqfishPlusReadoutProbePropertyFilter
-    specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter
+    property_filters: SeqfishPlusReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC
+    )
 
 
 SeqfishPlusReadoutProbeTable = Annotated[
@@ -436,9 +445,11 @@ class SeqfishPlusForwardPrimerGenerate(BaseModel):
 
     source: Literal["generate"] = "generate"
     oligo_generation: SeqfishPlusForwardPrimerOligoGeneration
-    property_filters: SeqfishPlusForwardPrimerPropertyFilter
-    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter
-    global_parameters: SeqfishPlusForwardPrimerGlobal
+    property_filters: SeqfishPlusForwardPrimerPropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC
+    )
+    global_parameters: SeqfishPlusForwardPrimerGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 SeqfishPlusForwardPrimer = Annotated[
@@ -462,8 +473,8 @@ class SeqfishPlusReversePrimer(BaseModel):
 class Primers(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    forward_primer: SeqfishPlusForwardPrimer
-    reverse_primer: SeqfishPlusReversePrimer
+    forward_primer: SeqfishPlusForwardPrimer = Field(description=FORWARD_PRIMER_DESC)
+    reverse_primer: SeqfishPlusReversePrimer = Field(description=REVERSE_PRIMER_DESC)
 
 
 ############################################
@@ -487,4 +498,4 @@ class SeqfishPlusProbeDesignerConfig(SeqfishPlusProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -13,6 +13,7 @@ from oligo_designer_toolsuite.config._general_models import (
     FORWARD_PRIMER_DESC,
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     REVERSE_PRIMER_DESC,
@@ -30,7 +31,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScore,
     IndependentSetSelection,
     UTRScore,


### PR DESCRIPTION
## Changes

- **Fixed BLASTN hit criteria being read as the wrong unit.** The criterion used to be set by a
  default on the filter config above `hit_parameters`. Form builders only look at a default on the
  field itself when picking a union branch, so they picked the first one, `coverage`, but the outer
  `value` still came through. In merfish and seqfish that turned `15` (nucleotides) into 15 %
  coverage.
- **Added coverage and min-alignment versions of the BLASTN filters** in `_specificity_filters.py`,
  so the default sits on `hit_parameters` where it gets read. Each pipeline now picks the one it
  wants. The coverage versions are there too, otherwise the rest only work while `coverage` happens
  to be first in the union.
- **Split a `...ProbeDesignerConfigBase` out of all six pipeline configs**, holding everything
  except `general` and `required_parameters`. The front end builds its form from the base.
  `general` is set by the server anyway and was being stripped later on. `...ProbeDesignerConfig`
  still validates the same configs as before.
- **Marked 17 more fields as `x-quick-setting`**: probe length limits in every pipeline, plus
  scrinshot's `min_thymines`, `U_distance` and oligo length, and the same fields in hcr and
  cyclehcr. ODT-Cloud used to keep this list by hand and it had to be updated whenever a field moved.
