### PR TITLE
Feature: strict config validation

### DIFF
--- a/data/configs/cycle_hcr_probe_designer.yaml
+++ b/data/configs/cycle_hcr_probe_designer.yaml
@@ -104,6 +104,11 @@ target_probes:
       Tris: 0 #[mM] default
       Mg: 0 #[mM] default
       dNTPs: 0 #[mM] default
+      check: true # Checks if the sequence is valid for the given method.
+      strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+      c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+      shift: 0 # Shift of the probe sequence on the template sequence.
+      selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
     Tm_chem_correction_parameters:
       enabled: false
     Tm_salt_correction_parameters:

--- a/data/configs/hcr_probe_designer.yaml
+++ b/data/configs/hcr_probe_designer.yaml
@@ -101,6 +101,11 @@ target_probes:
       Tris: 0 #[mM] default
       Mg: 0 #[mM] default
       dNTPs: 0 #[mM] default
+      check: true # Checks if the sequence is valid for the given method.
+      strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+      c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+      shift: 0 # Shift of the probe sequence on the template sequence.
+      selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
     Tm_chem_correction_parameters:
       enabled: false
     Tm_salt_correction_parameters:

--- a/data/configs/merfish_probe_designer.yaml
+++ b/data/configs/merfish_probe_designer.yaml
@@ -106,6 +106,11 @@ target_probes:
       Tris: 0 #[mM] default
       Mg: 0 #[mM] default
       dNTPs: 0 #[mM] default
+      check: true # Checks if the sequence is valid for the given method.
+      strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+      c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+      shift: 0 # Shift of the probe sequence on the template sequence.
+      selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
     Tm_chem_correction_parameters:
       enabled: false
     Tm_salt_correction_parameters:
@@ -132,7 +137,7 @@ readout_probes:
     property_filters:
       homopolymeric_runs_filter: # Exclude probes containing long homopolymeric runs.
         enabled: true # Turn this filter on or off.
-        homopolymeric_base_n: {"G": 3} # Minimum run length per base to count as homopolymeric (any base not listed is unrestricted).
+        homopolymeric_base_n: {"A": null, "T": null, "C": null, "G": 3} # Minimum run length per base to count as homopolymeric, null means unrestricted.
 
       GC_content_filter: # Enforce GC content within a specified range.
         enabled: true # Turn this filter on or off.
@@ -173,6 +178,11 @@ readout_probes:
         Tris: 0 #[mM] default
         Mg: 0 #[mM] default
         dNTPs: 0 #[mM] default
+        check: true # Checks if the sequence is valid for the given method.
+        strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+        c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+        shift: 0 # Shift of the probe sequence on the template sequence.
+        selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
       Tm_chem_correction_parameters:
         enabled: false
       Tm_salt_correction_parameters:
@@ -250,6 +260,11 @@ primers:
         Tris: 0 #[mM] default
         Mg: 0 #[mM] default
         dNTPs: 0 #[mM] default
+        check: true # Checks if the sequence is valid for the given method.
+        strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+        c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+        shift: 0 # Shift of the probe sequence on the template sequence.
+        selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
       Tm_chem_correction_parameters:
         enabled: false
       Tm_salt_correction_parameters:

--- a/data/configs/oligo_seq_probe_designer.yaml
+++ b/data/configs/oligo_seq_probe_designer.yaml
@@ -140,6 +140,11 @@ target_probes:
       Tris: 0 #[mM]
       Mg: 0 #[mM]
       dNTPs: 0 #[mM]
+      check: true # Checks if the sequence is valid for the given method.
+      strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+      c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+      shift: 0 # Shift of the probe sequence on the template sequence.
+      selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
     Tm_chem_correction_parameters:
       enabled: true
       parameters:

--- a/data/configs/scrinshot_probe_designer.yaml
+++ b/data/configs/scrinshot_probe_designer.yaml
@@ -112,6 +112,11 @@ target_probes:
       Tris: 20 #[mM]
       Mg: 10 #[mM]
       dNTPs: 0 #[mM] default
+      check: true # Checks if the sequence is valid for the given method.
+      strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+      c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+      shift: 0 # Shift of the probe sequence on the template sequence.
+      selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
     Tm_chem_correction_parameters:
       enabled: true
       parameters:
@@ -146,6 +151,11 @@ detection_oligo:
       Tris: 0 #[mM] default
       Mg: 0 #[mM] default
       dNTPs: 0 #[mM] default
+      check: true # Checks if the sequence is valid for the given method.
+      strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+      c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+      shift: 0 # Shift of the probe sequence on the template sequence.
+      selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
     Tm_chem_correction_parameters:
       enabled: true
       parameters:

--- a/data/configs/seqfish_plus_probe_designer.yaml
+++ b/data/configs/seqfish_plus_probe_designer.yaml
@@ -106,7 +106,7 @@ readout_probes:
     property_filters:
       homopolymeric_runs_filter: # Exclude probes containing long homopolymeric runs.
         enabled: true # Turn this filter on or off.
-        homopolymeric_base_n: {"G": 3} # Minimum run length per base to count as homopolymeric (any base not listed is unrestricted).
+        homopolymeric_base_n: {"A": null, "T": null, "C": null, "G": 3} # Minimum run length per base to count as homopolymeric, null means unrestricted.
 
       GC_content_filter: # Enforce GC content within a specified range.
         enabled: true # Turn this filter on or off.
@@ -200,6 +200,11 @@ primers:
         Tris: 0
         Mg: 0
         dNTPs: 0
+        check: true # Checks if the sequence is valid for the given method.
+        strict: true # Do not allow ambiguous base characters or neighbor duplex keys.
+        c_seq: null # Complementary sequence, needed for mismatch and dangling-end correction.
+        shift: 0 # Shift of the probe sequence on the template sequence.
+        selfcomp: false # Is the sequence self-complementary? If true dnac2 is not considered.
       Tm_chem_correction_parameters:
         enabled: false
       Tm_salt_correction_parameters:

--- a/docs/source/_pipelines/cyclehcr_probe_designer.rst
+++ b/docs/source/_pipelines/cyclehcr_probe_designer.rst
@@ -27,7 +27,7 @@ To create CycleHCR probes you can run the pipeline with
 
 where:
 
-``-c``: config file, which contains parameter settings, specific to CycleHCR probe design, `cyclehcr_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/cyclehcr_probe_designer.yaml>`__ contains default parameter settings
+``-c``: config file, which contains parameter settings, specific to CycleHCR probe design, `cyclehcr_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/cyclehcr_probe_designer.yaml>`__ contains a complete set of recommended parameters
 
 All steps and config parameters will be documented in a log file, that is saved in the defined output directory.
 The logging file will have the format: ``log_cyclehcr_probe_designer_{year}-{month}-{day}-{hour}-{minute}.txt``.
@@ -169,7 +169,7 @@ The output is stored in two separate files:
 - ``cyclehcr_probes_order.yml``: contains for each probe the sequences of the cyclehcr probe and the readout probes.
 - ``cyclehcr_probes.yml``: contains a detailed description for each probe, including the sequences of each part of the probe and probe specific properties.
 
-All default parameters can be found in the `cyclehcr_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/cyclehcr_probe_designer.yaml>`__ config file provided along the repository.
+A complete configuration with the recommended parameters can be found in the `cyclehcr_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/cyclehcr_probe_designer.yaml>`__ config file provided along the repository. Every parameter has to be set.
 
 
 .. [1] Mekki, I., Campi, F., Kuemmerle, L. B., ... & Barros de Andrade e Sousa, L. (2023). Oligo Designer Toolsuite. Zenodo, https://doi.org/10.5281/zenodo.7823048

--- a/docs/source/_pipelines/merfish_probe_designer.rst
+++ b/docs/source/_pipelines/merfish_probe_designer.rst
@@ -27,7 +27,7 @@ To create MERFISH probes you can run the pipeline with
 
 where:
 
-``-c``: config file, which contains parameter settings, specific to MERFISH probe design, `merfish_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/merfish_probe_designer.yaml>`__ contains default parameter settings
+``-c``: config file, which contains parameter settings, specific to MERFISH probe design, `merfish_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/merfish_probe_designer.yaml>`__ contains a complete set of recommended parameters
 
 All steps and config parameters will be documented in a log file, that is saved in the defined output directory.
 The logging file will have the format: ``log_merfish_probe_designer_{year}-{month}-{day}-{hour}-{minute}.txt``.
@@ -194,7 +194,7 @@ The output is stored in two separate files:
 - ``merfish_probes_order.yml``: contains for each probe the sequences of the merfish probe and the readout probes.
 - ``merfish_probes.yml``: contains a detailed description for each probe, including the sequences of each part of the probe and probe specific properties.
 
-All default parameters can be found in the `merfish_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/merfish_probe_designer.yaml>`__ config file provided along the repository.
+A complete configuration with the recommended parameters can be found in the `merfish_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/merfish_probe_designer.yaml>`__ config file provided along the repository. Every parameter has to be set.
 
 
 .. [1] Mekki, I., Campi, F., Kuemmerle, L. B., ... & Barros de Andrade e Sousa, L. (2023). Oligo Designer Toolsuite. Zenodo, https://doi.org/10.5281/zenodo.7823048

--- a/docs/source/_pipelines/oligoseq_probe_designer.rst
+++ b/docs/source/_pipelines/oligoseq_probe_designer.rst
@@ -17,7 +17,7 @@ To create oligo-seq probes you can run the pipeline with
 
 where:
 
-``-c``: config file, which contains parameter settings, specific to oligo-seq probe design, `oligo_seq_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/oligo_seq_probe_designer.yaml>`__ contains default parameter settings
+``-c``: config file, which contains parameter settings, specific to oligo-seq probe design, `oligo_seq_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/oligo_seq_probe_designer.yaml>`__ contains a complete set of recommended parameters
 
 All steps and config parameters will be documented in a log file, that is saved in the defined output directory.
 The logging file will have the format: ``log_oligo_seq_probe_designer_{year}-{month}-{day}-{hour}-{minute}.txt``.
@@ -134,7 +134,7 @@ The output is stored in two separate files:
 - ``oligo_seq_probes.tsv``: contains a table with all generated probes.
 - ``oligo_seq_probesets.yml``: contains a detailed description for each probe set, including the sequences of each part of the probe and probe specific properties.
 
-All default parameters can be found in the `oligo_seq_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/oligo_seq_probe_designer.yaml>`__ config file provided along the repository.
+A complete configuration with the recommended parameters can be found in the `oligo_seq_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/oligo_seq_probe_designer.yaml>`__ config file provided along the repository. Every parameter has to be set.
 
 
 .. [1] Mekki, I., Campi, F., Kuemmerle, L. B., ... & Barros de Andrade e Sousa, L. (2023). Oligo Designer Toolsuite. Zenodo, https://doi.org/10.5281/zenodo.7823048

--- a/docs/source/_pipelines/scrinshot_probe_designer.rst
+++ b/docs/source/_pipelines/scrinshot_probe_designer.rst
@@ -26,7 +26,7 @@ To create SCRINSHOT probes you can run the pipeline with
 
 where:
 
-``-c``: config file, which contains parameter settings, specific to SCRINSHOT probe design, `scrinshot_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/scrinshot_probe_designer.yaml>`__ contains default parameter settings
+``-c``: config file, which contains parameter settings, specific to SCRINSHOT probe design, `scrinshot_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/scrinshot_probe_designer.yaml>`__ contains a complete set of recommended parameters
 
 All steps and config parameters will be documented in a log file, that is saved in the defined output directory.
 The logging file will have the format: ``log_scrinshot_probe_designer_{year}-{month}-{day}-{hour}-{minute}.txt``.
@@ -163,7 +163,7 @@ The output is stored in two separate files:
 - ``padlock_probes_order.yml``: contains for each probe the sequences of the padlock probe and the detection oligo.
 - ``padlock_probes.yml``: contains a detailed description for each probe, including the sequences of each part of the probe and probe specific properties.
 
-All default parameters can be found in the `scrinshot_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/scrinshot_probe_designer.yaml>`__ config file provided along the repository.
+A complete configuration with the recommended parameters can be found in the `scrinshot_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/scrinshot_probe_designer.yaml>`__ config file provided along the repository. Every parameter has to be set.
 
 
 .. [1] Mekki, I., Campi, F., Kuemmerle, L. B., ... & Barros de Andrade e Sousa, L. (2023). Oligo Designer Toolsuite. Zenodo, https://doi.org/10.5281/zenodo.7823048

--- a/docs/source/_pipelines/seqfishplus_probe_designer.rst
+++ b/docs/source/_pipelines/seqfishplus_probe_designer.rst
@@ -26,7 +26,7 @@ To create SeqFISH+ probes you can run the pipeline with
 
 where:
 
-``-c``: config file, which contains parameter settings, specific to SeqFISH+ probe design, `seqfish_plus_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/seqfish_plus_probe_designer.yaml>`__ contains default parameter settings
+``-c``: config file, which contains parameter settings, specific to SeqFISH+ probe design, `seqfish_plus_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/seqfish_plus_probe_designer.yaml>`__ contains a complete set of recommended parameters
 
 All steps and config parameters will be documented in a log file, that is saved in the defined output directory.
 The logging file will have the format: ``log_seqfish_plus_probe_designer_{year}-{month}-{day}-{hour}-{minute}.txt``.
@@ -186,7 +186,7 @@ The output is stored in two separate files:
 - ``seqfish_plus_probes_order.yml``: contains for each probe the sequences of the seqfish+ probe and the readout probes
 - ``seqfish_plus_probes.yml``: contains a detailed description for each probe, including the sequences of each part of the probe and probe specific properties.
 
-All default parameters can be found in the `seqfish_plus_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/seqfish_plus_probe_designer.yaml>`__ config file provided along the repository.
+A complete configuration with the recommended parameters can be found in the `seqfish_plus_probe_designer.yaml <https://github.com/HelmholtzAI-Consultants-Munich/oligo-designer-toolsuite/blob/main/data/configs/seqfish_plus_probe_designer.yaml>`__ config file provided along the repository. Every parameter has to be set.
 
 .. [1] Mekki, I., Campi, F., Kuemmerle, L. B., ... & Barros de Andrade e Sousa, L. (2023). Oligo Designer Toolsuite. Zenodo, https://doi.org/10.5281/zenodo.7823048
 .. [2] Kuemmerle, L. B., Luecken, M. D., Firsova, A. B., Barros de Andrade e Sousa, L., Straßer, L., Mekki, I. I., ... & Theis, F. J. (2024). Probe set selection for targeted spatial transcriptomics. Nature methods, 1-11. https://doi.org/10.1038/s41592-024-02496-z

--- a/oligo_designer_toolsuite/config/__init__.py
+++ b/oligo_designer_toolsuite/config/__init__.py
@@ -1,3 +1,9 @@
+from oligo_designer_toolsuite.config._completeness import (
+    MissingConfigKey,
+    check_config_complete,
+    find_missing_config_keys,
+    format_missing_config_keys,
+)
 from oligo_designer_toolsuite.config.pipelines.cycle_hcr_probe_designer import CycleHcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.hcr_probe_designer import HcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.merfish_probe_designer import MerfishProbeDesignerConfig
@@ -8,6 +14,10 @@ from oligo_designer_toolsuite.config.pipelines.seqfish_plus_probe_designer impor
 )
 
 __all__ = [
+    "MissingConfigKey",
+    "check_config_complete",
+    "find_missing_config_keys",
+    "format_missing_config_keys",
     "CycleHcrProbeDesignerConfig",
     "HcrProbeDesignerConfig",
     "MerfishProbeDesignerConfig",

--- a/oligo_designer_toolsuite/config/_completeness.py
+++ b/oligo_designer_toolsuite/config/_completeness.py
@@ -27,7 +27,7 @@ from oligo_designer_toolsuite._exceptions import ConfigurationError
 # Completeness check
 ############################################
 
-SPARSE_MARKER = "x-config-sparse"
+ALLOW_INCOMPLETE_MARKER = "x-allow-incomplete"
 
 
 class MissingConfigKey(NamedTuple):
@@ -70,7 +70,7 @@ def _accepted_keys(name: str, field: FieldInfo) -> list[str]:
     if field.alias is not None:
         keys.append(field.alias)
     keys.append(name)
-    return keys
+    return list(dict.fromkeys(keys))
 
 
 def _preferred_key(name: str, field: FieldInfo) -> str:
@@ -89,11 +89,11 @@ def _preferred_key(name: str, field: FieldInfo) -> str:
     return _accepted_keys(name, field)[0]
 
 
-def _is_sparse(model: type[BaseModel]) -> bool:
+def _allows_incomplete(model: type[BaseModel]) -> bool:
     """
-    Report whether a model may be filled in partially.
+    Report whether a model is allowed to leave parameters unset.
 
-    A sparse model passes its fields on to an external tool and drops the unset ones when it is
+    Such a model passes its fields on to an external tool and drops the unset ones when it is
     serialized, so an omitted key means "do not pass this option" rather than "use a default".
 
     :param model: Model to check.
@@ -102,7 +102,7 @@ def _is_sparse(model: type[BaseModel]) -> bool:
     :rtype: bool
     """
     json_schema_extra = model.model_config.get("json_schema_extra")
-    return isinstance(json_schema_extra, dict) and bool(json_schema_extra.get(SPARSE_MARKER))
+    return isinstance(json_schema_extra, dict) and bool(json_schema_extra.get(ALLOW_INCOMPLETE_MARKER))
 
 
 def find_missing_config_keys(
@@ -132,7 +132,7 @@ def find_missing_config_keys(
     """
     missing = [] if missing is None else missing
     model = type(config)
-    if _is_sparse(model) or not isinstance(config_raw, Mapping):
+    if _allows_incomplete(model) or not isinstance(config_raw, Mapping):
         return missing
 
     for name, field in model.model_fields.items():

--- a/oligo_designer_toolsuite/config/_completeness.py
+++ b/oligo_designer_toolsuite/config/_completeness.py
@@ -1,0 +1,200 @@
+"""
+Completeness check for pipeline configuration files.
+
+A parameter that is left out of a configuration file does not have one obvious value: which
+default applies depends on how much of the surrounding section was left out with it. The command
+line pipelines therefore require every parameter to be written out.
+
+Only the command line entry points call this, so validating a configuration elsewhere, as
+ODT-Cloud does, behaves as it did before.
+"""
+
+############################################
+# imports
+############################################
+
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple
+
+import yaml
+from pydantic import BaseModel
+from pydantic.aliases import AliasChoices
+from pydantic.fields import FieldInfo
+
+from oligo_designer_toolsuite._exceptions import ConfigurationError
+
+############################################
+# Completeness check
+############################################
+
+SPARSE_MARKER = "x-config-sparse"
+
+
+class MissingConfigKey(NamedTuple):
+    """
+    A parameter that the configuration file does not set.
+
+    :param path: Dotted path of the parameter, e.g. ``target_probes.global_parameters``.
+    :type path: str
+    :param key: Key to write in the configuration file, which is the alias where a field has one.
+    :type key: str
+    :param value: Value the model fell back to.
+    :type value: Any
+    """
+
+    path: str
+    key: str
+    value: Any
+
+
+def _accepted_keys(name: str, field: FieldInfo) -> list[str]:
+    """
+    Collect every key that validation accepts for one field.
+
+    Kept for models whose fields carry aliases. The only one today, ``BlastnSearchParameters``, is
+    exempt from the check, so this currently resolves to the field name for every parameter walked.
+
+    :param name: Name the field is declared under.
+    :type name: str
+    :param field: Field to collect the keys of.
+    :type field: FieldInfo
+    :return: The accepted keys, most specific first.
+    :rtype: list[str]
+    """
+    keys: list[str] = []
+    validation_alias = field.validation_alias
+    if isinstance(validation_alias, AliasChoices):
+        keys.extend(choice for choice in validation_alias.choices if isinstance(choice, str))
+    elif isinstance(validation_alias, str):
+        keys.append(validation_alias)
+    if field.alias is not None:
+        keys.append(field.alias)
+    keys.append(name)
+    return keys
+
+
+def _preferred_key(name: str, field: FieldInfo) -> str:
+    """
+    Return the key to suggest when a field has to be added to a configuration file.
+
+    :param name: Name the field is declared under.
+    :type name: str
+    :param field: Field to suggest a key for.
+    :type field: FieldInfo
+    :return: The key, which is the serialization alias where a field has one.
+    :rtype: str
+    """
+    if isinstance(field.serialization_alias, str):
+        return field.serialization_alias
+    return _accepted_keys(name, field)[0]
+
+
+def _is_sparse(model: type[BaseModel]) -> bool:
+    """
+    Report whether a model may be filled in partially.
+
+    A sparse model passes its fields on to an external tool and drops the unset ones when it is
+    serialized, so an omitted key means "do not pass this option" rather than "use a default".
+
+    :param model: Model to check.
+    :type model: type[BaseModel]
+    :return: True if the model is exempt from the completeness check.
+    :rtype: bool
+    """
+    json_schema_extra = model.model_config.get("json_schema_extra")
+    return isinstance(json_schema_extra, dict) and bool(json_schema_extra.get(SPARSE_MARKER))
+
+
+def find_missing_config_keys(
+    config: BaseModel,
+    config_raw: Mapping[str, Any],
+    path: str = "",
+    missing: list[MissingConfigKey] | None = None,
+) -> list[MissingConfigKey]:
+    """
+    Collect the parameters that a configuration file does not set.
+
+    The validated configuration is walked in parallel with the mapping it was built from, which
+    means the branch of a union does not have to be worked out from the annotations: it is the type
+    of the attribute that validation produced. A key that is absent is reported and not descended
+    into, so a missing section is one entry rather than one entry per parameter below it.
+
+    :param config: Validated configuration, or one of the models nested in it.
+    :type config: BaseModel
+    :param config_raw: Mapping that ``config`` was validated from.
+    :type config_raw: Mapping[str, Any]
+    :param path: Dotted path of ``config`` within the whole configuration.
+    :type path: str
+    :param missing: Parameters found so far, used by the recursion.
+    :type missing: list[MissingConfigKey] | None
+    :return: The missing parameters, in the order the models declare them.
+    :rtype: list[MissingConfigKey]
+    """
+    missing = [] if missing is None else missing
+    model = type(config)
+    if _is_sparse(model) or not isinstance(config_raw, Mapping):
+        return missing
+
+    for name, field in model.model_fields.items():
+        field_path = f"{path}.{name}" if path else name
+        key = next((key for key in _accepted_keys(name, field) if key in config_raw), None)
+        if key is None:
+            missing.append(MissingConfigKey(field_path, _preferred_key(name, field), getattr(config, name)))
+            continue
+
+        value = getattr(config, name)
+        value_raw = config_raw[key]
+        if isinstance(value, BaseModel):
+            find_missing_config_keys(value, value_raw, field_path, missing)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            if isinstance(value_raw, Sequence) and not isinstance(value_raw, (str, bytes)):
+                for index, (item, item_raw) in enumerate(zip(value, value_raw)):
+                    if isinstance(item, BaseModel):
+                        find_missing_config_keys(item, item_raw, f"{field_path}[{index}]", missing)
+
+    return missing
+
+
+def format_missing_config_keys(missing: list[MissingConfigKey], source: str | None = None) -> str:
+    """
+    List the missing parameters and the value each of them fell back to.
+
+    :param missing: Parameters as returned by :func:`find_missing_config_keys`.
+    :type missing: list[MissingConfigKey]
+    :param source: Path of the configuration file, named in the message.
+    :type source: str | None
+    :return: The message.
+    :rtype: str
+    """
+    lines = [
+        f"All parameters have to be set in {source or 'the configuration file'},"
+        f" {len(missing)} are missing.",
+        "",
+        "The value each of them fell back to:",
+        "",
+    ]
+    for entry in missing:
+        value = entry.value.model_dump(mode="json") if isinstance(entry.value, BaseModel) else entry.value
+        # only the first line: dumping a scalar on its own also emits YAML's "..." end marker
+        rendered = yaml.safe_dump(value, default_flow_style=True).splitlines()[0]
+        lines.append(f"  {entry.path}: {rendered}")
+    return "\n".join(lines)
+
+
+def check_config_complete(
+    config: BaseModel, config_raw: Mapping[str, Any], source: str | None = None
+) -> None:
+    """
+    Raise if a configuration file leaves any parameter unset.
+
+    :param config: Configuration validated from ``config_raw``.
+    :type config: BaseModel
+    :param config_raw: Mapping loaded from the configuration file.
+    :type config_raw: Mapping[str, Any]
+    :param source: Path of the configuration file, named in the error message.
+    :type source: str | None
+    :raises ConfigurationError: If at least one parameter is not set.
+    """
+    missing = find_missing_config_keys(config, config_raw)
+    if missing:
+        raise ConfigurationError(format_missing_config_keys(missing, source))

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -76,7 +76,16 @@ class BaseProbabilities(BaseModel):
 
 
 class BlastnSearchParameters(BaseModel):
-    model_config = ConfigDict(extra="forbid", validate_by_name=True, validate_by_alias=True)
+    # `x-config-sparse` exempts this model from the completeness check (see `_completeness.py`):
+    # these are BLAST flags, so an option left out is not passed rather than defaulted, and the
+    # serializer below drops every None, so a complete file could not be written anyway. A block
+    # that is written is taken as written, no enclosing default merges into it.
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_by_name=True,
+        validate_by_alias=True,
+        json_schema_extra={"x-config-sparse": True},
+    )
 
     # don't allow
     # -h

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -76,7 +76,7 @@ class BaseProbabilities(BaseModel):
 
 
 class BlastnSearchParameters(BaseModel):
-    # `x-config-sparse` exempts this model from the completeness check (see `_completeness.py`):
+    # `x-allow-incomplete` exempts this model from the completeness check (see `_completeness.py`):
     # these are BLAST flags, so an option left out is not passed rather than defaulted, and the
     # serializer below drops every None, so a complete file could not be written anyway. A block
     # that is written is taken as written, no enclosing default merges into it.
@@ -84,7 +84,7 @@ class BlastnSearchParameters(BaseModel):
         extra="forbid",
         validate_by_name=True,
         validate_by_alias=True,
-        json_schema_extra={"x-config-sparse": True},
+        json_schema_extra={"x-allow-incomplete": True},
     )
 
     # don't allow

--- a/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
@@ -22,9 +22,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import yaml
 from Bio.SeqUtils import Seq
-from pydantic import ValidationError
 
 from oligo_designer_toolsuite._exceptions import (
     ConfigurationError,
@@ -75,6 +73,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
     base_parser,
     check_content_oligo_database,
     format_sequence,
+    load_config,
     pipeline_step_basic,
     preprocess_tm_parameters,
     validate_bit_mapping_table,
@@ -2062,14 +2061,7 @@ def main() -> None:
         description=__doc__,
     )
 
-    with open(args["config"], "r") as handle:
-        config_raw = yaml.safe_load(handle)
-
-    try:
-        config_validated = CycleHcrProbeDesignerConfig.model_validate(config_raw)
-    except ValidationError as e:
-        print(f"Invalid configuration file:\n{e}")
-        raise
+    config_validated = load_config(args["config"], CycleHcrProbeDesignerConfig)
 
     configure_root_logger(
         dir_output=config_validated.general.dir_output,

--- a/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
@@ -20,8 +20,6 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-import yaml
-from pydantic import ValidationError
 
 from oligo_designer_toolsuite._exceptions import (
     FeatureNotImplementedError,
@@ -70,6 +68,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
     base_parser,
     check_content_oligo_database,
     format_sequence,
+    load_config,
     pipeline_step_basic,
     preprocess_tm_parameters,
     validate_bit_mapping_table,
@@ -1546,14 +1545,7 @@ def main() -> None:
         description=__doc__,
     )
 
-    with open(args["config"], "r") as handle:
-        config_raw = yaml.safe_load(handle)
-
-    try:
-        config_validated = HcrProbeDesignerConfig.model_validate(config_raw)
-    except ValidationError as e:
-        print(f"Invalid configuration file:\n{e}")
-        raise
+    config_validated = load_config(args["config"], HcrProbeDesignerConfig)
 
     # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -22,9 +22,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import yaml
 from Bio.SeqUtils import Seq
-from pydantic import ValidationError
 from scipy.spatial.distance import hamming
 
 from oligo_designer_toolsuite._exceptions import (
@@ -82,6 +80,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
     base_parser,
     check_content_oligo_database,
     format_sequence,
+    load_config,
     pipeline_step_basic,
     preprocess_tm_parameters,
     validate_bit_mapping_table,
@@ -2716,13 +2715,7 @@ def main() -> None:
         description=__doc__,
     )
 
-    with open(args["config"], "r") as handle:
-        config_raw = yaml.safe_load(handle)
-    try:
-        config_validated = MerfishProbeDesignerConfig.model_validate(config_raw)
-    except ValidationError as e:
-        print(f"Invalid configuration file:\n{e}")
-        raise
+    config_validated = load_config(args["config"], MerfishProbeDesignerConfig)
 
     # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -18,9 +18,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-import yaml
-from pydantic import ValidationError
-
 from oligo_designer_toolsuite.config.pipelines.oligo_seq_probe_designer import OligoSeqProbeDesignerConfig
 from oligo_designer_toolsuite.database import OligoDatabase, ReferenceDatabase
 from oligo_designer_toolsuite.oligo_efficiency_filter import (
@@ -72,6 +69,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
     base_parser,
     check_content_oligo_database,
     get_highly_abundant_kmer_sequences,
+    load_config,
     pipeline_step_basic,
     preprocess_tm_parameters,
 )
@@ -1133,6 +1131,7 @@ def main() -> None:
     :rtype: None
     :raises pydantic.ValidationError: If the configuration file fails schema
         validation.
+    :raises ConfigurationError: If the configuration file leaves parameters unset.
     """
     print("--------------START PIPELINE--------------")
 
@@ -1142,14 +1141,7 @@ def main() -> None:
         description=__doc__,
     )
 
-    with open(args["config"], "r") as handle:
-        config_raw = yaml.safe_load(handle)
-
-    try:
-        config_validated = OligoSeqProbeDesignerConfig.model_validate(config_raw)
-    except ValidationError as e:
-        print("Invalid configuration file:\n%s", e)
-        raise
+    config_validated = load_config(args["config"], OligoSeqProbeDesignerConfig)
 
     # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -21,10 +21,8 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-import yaml
 from joblib import Parallel, delayed
 from joblib_progress import joblib_progress
-from pydantic import ValidationError
 
 from oligo_designer_toolsuite.config.pipelines.scrinshot_probe_designer import ScrinshotProbeDesignerConfig
 from oligo_designer_toolsuite.database import OligoDatabase, ReferenceDatabase
@@ -75,6 +73,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
+    load_config,
     pipeline_step_basic,
     preprocess_tm_parameters,
 )
@@ -1769,14 +1768,7 @@ def main() -> None:
         description=__doc__,
     )
 
-    with open(args["config"], "r") as handle:
-        config_raw = yaml.safe_load(handle)
-
-    try:
-        config_validated = ScrinshotProbeDesignerConfig.model_validate(config_raw)
-    except ValidationError as e:
-        print(f"Invalid configuration file:\n{e}")
-        raise
+    config_validated = load_config(args["config"], ScrinshotProbeDesignerConfig)
 
     # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -23,9 +23,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import yaml
 from Bio.SeqUtils import Seq
-from pydantic import ValidationError
 
 from oligo_designer_toolsuite._exceptions import (
     ConfigurationError,
@@ -75,6 +73,7 @@ from oligo_designer_toolsuite.pipelines._utils import (
     base_parser,
     check_content_oligo_database,
     format_sequence,
+    load_config,
     pipeline_step_basic,
     preprocess_tm_parameters,
     validate_bit_mapping_table,
@@ -2529,14 +2528,7 @@ def main() -> None:
         description=__doc__,
     )
 
-    with open(args["config"], "r") as handle:
-        config_raw = yaml.safe_load(handle)
-
-    try:
-        config_validated = SeqfishPlusProbeDesignerConfig.model_validate(config_raw)
-    except ValidationError as e:
-        print(f"Invalid configuration file:\n{e}")
-        raise
+    config_validated = load_config(args["config"], SeqfishPlusProbeDesignerConfig)
 
     # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(

--- a/oligo_designer_toolsuite/pipelines/_utils.py
+++ b/oligo_designer_toolsuite/pipelines/_utils.py
@@ -15,13 +15,17 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from typing import Any, Callable, TypeVar, cast
 
 import pandas as pd
+import yaml
 from Bio.SeqUtils import MeltingTemp as mt
+from pydantic import BaseModel, ValidationError
 
-from oligo_designer_toolsuite._exceptions import FileFormatError
+from oligo_designer_toolsuite._exceptions import ConfigurationError, FileFormatError
+from oligo_designer_toolsuite.config._completeness import check_config_complete
 from oligo_designer_toolsuite.database import OligoDatabase
 from oligo_designer_toolsuite.utils import check_if_dna_sequence, count_kmer_abundance, logger
 
 F = TypeVar("F", bound=Callable[..., Any])
+ConfigT = TypeVar("ConfigT", bound=BaseModel)
 
 ############################################
 # Utils functions
@@ -62,6 +66,40 @@ def base_parser(*, prog: str, usage: str, description: str | None = None) -> dic
     )
     args = parser.parse_args()
     return vars(args)
+
+
+def load_config(file_config: str, model: type[ConfigT]) -> ConfigT:
+    """
+    Read a configuration file and check it against the configuration model of a pipeline.
+
+    The file has to set every parameter of the model. A parameter that is left out resolves to a
+    different value depending on how much of its section is left out with it, so the parameters
+    that are missing are reported together with the value that was used so far.
+
+    :param file_config: Path to the config file in yaml format.
+    :type file_config: str
+    :param model: Configuration model of the pipeline.
+    :type model: type[ConfigT]
+    :return: The validated configuration.
+    :rtype: ConfigT
+    :raises SystemExit: If the file does not match the model or leaves parameters unset.
+    """
+    with open(file_config, "r") as handle:
+        config_raw = yaml.safe_load(handle)
+
+    # Reported and exited rather than raised: both messages are written for the person running the
+    # command, and a traceback would print the whole report a second time.
+    try:
+        config_validated = model.model_validate(config_raw)
+    except ValidationError as error:
+        sys.exit(f"Invalid configuration file:\n{error}")
+
+    try:
+        check_config_complete(config_validated, config_raw, source=file_config)
+    except ConfigurationError as error:
+        sys.exit(f"Incomplete configuration file:\n{error}")
+
+    return config_validated
 
 
 def base_log_parameters(parameters: dict[str, Any]) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -371,7 +371,7 @@ class TestConfigCompleteness(unittest.TestCase):
 
         assert [entry for entry in self._merfish(raw) if "Tm_filter" in entry.path] == []
 
-    def test_sparse_model_is_exempt(self) -> None:
+    def test_model_allowing_incomplete_is_exempt(self) -> None:
         """An unset BLAST option means the flag is not passed, so it needs no value."""
         raw = _load("merfish_probe_designer.yaml")
         filters = raw["target_probes"]["specificity_filters"]["specificity_blastn_filter"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,10 @@ import unittest
 from pathlib import Path
 
 import yaml
-from pydantic import ValidationError
+from pydantic import AliasChoices, BaseModel, Field, ValidationError
 
+from oligo_designer_toolsuite.config import find_missing_config_keys, format_missing_config_keys
+from oligo_designer_toolsuite.config._completeness import MissingConfigKey
 from oligo_designer_toolsuite.config.pipelines.cycle_hcr_probe_designer import CycleHcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.hcr_probe_designer import HcrProbeDesignerConfig
 from oligo_designer_toolsuite.config.pipelines.merfish_probe_designer import MerfishProbeDesignerConfig
@@ -24,6 +26,13 @@ def _load(filename: str) -> dict:
         return data
 
 
+def _assert_complete(filename: str, model: type[BaseModel]) -> None:
+    """Assert that a shipped config sets every parameter instead of relying on a default."""
+    raw = _load(filename)
+    missing = find_missing_config_keys(model.model_validate(raw), raw)
+    assert missing == [], format_missing_config_keys(missing, filename)
+
+
 # ---------------------------------------------------------------------------
 # OligoSeqProbeDesignerConfig
 # ---------------------------------------------------------------------------
@@ -35,6 +44,9 @@ class TestOligoSeqYaml(unittest.TestCase):
         cfg = OligoSeqProbeDesignerConfig.model_validate(raw)
         assert cfg.schema_version == 2
         assert cfg.general.write_intermediate_steps is True
+
+    def test_config_is_complete(self) -> None:
+        _assert_complete("oligo_seq_probe_designer.yaml", OligoSeqProbeDesignerConfig)
 
     def test_no_readout_probe_key(self) -> None:
         """OligoSeq has no readout_probe; the YAML must not contain it either."""
@@ -73,6 +85,9 @@ class TestScrinshotYaml(unittest.TestCase):
         assert cfg.schema_version == 2
         assert cfg.general.write_intermediate_steps is True
 
+    def test_config_is_complete(self) -> None:
+        _assert_complete("scrinshot_probe_designer.yaml", ScrinshotProbeDesignerConfig)
+
     def test_round_trip(self) -> None:
         raw = _load("scrinshot_probe_designer.yaml")
         cfg = ScrinshotProbeDesignerConfig.model_validate(raw)
@@ -106,6 +121,9 @@ class TestHcrYaml(unittest.TestCase):
         assert cfg.schema_version == 2
         assert cfg.general.write_intermediate_steps is True
 
+    def test_config_is_complete(self) -> None:
+        _assert_complete("hcr_probe_designer.yaml", HcrProbeDesignerConfig)
+
     def test_round_trip(self) -> None:
         raw = _load("hcr_probe_designer.yaml")
         cfg = HcrProbeDesignerConfig.model_validate(raw)
@@ -138,6 +156,9 @@ class TestCycleHcrYaml(unittest.TestCase):
         cfg = CycleHcrProbeDesignerConfig.model_validate(raw)
         assert cfg.schema_version == 2
         assert cfg.general.write_intermediate_steps is True
+
+    def test_config_is_complete(self) -> None:
+        _assert_complete("cycle_hcr_probe_designer.yaml", CycleHcrProbeDesignerConfig)
 
     def test_round_trip(self) -> None:
         raw = _load("cycle_hcr_probe_designer.yaml")
@@ -193,6 +214,9 @@ class TestSeqfishYaml(unittest.TestCase):
         cfg = SeqfishPlusProbeDesignerConfig.model_validate(raw)
         assert cfg.schema_version == 2
         assert cfg.general.write_intermediate_steps is True
+
+    def test_config_is_complete(self) -> None:
+        _assert_complete("seqfish_plus_probe_designer.yaml", SeqfishPlusProbeDesignerConfig)
 
     def test_round_trip(self) -> None:
         raw = _load("seqfish_plus_probe_designer.yaml")
@@ -257,6 +281,9 @@ class TestMerfishYaml(unittest.TestCase):
         assert cfg.schema_version == 2
         assert cfg.general.write_intermediate_steps is True
 
+    def test_config_is_complete(self) -> None:
+        _assert_complete("merfish_probe_designer.yaml", MerfishProbeDesignerConfig)
+
     def test_round_trip(self) -> None:
         raw = _load("merfish_probe_designer.yaml")
         cfg = MerfishProbeDesignerConfig.model_validate(raw)
@@ -296,3 +323,117 @@ class TestMerfishYaml(unittest.TestCase):
         assert "target_probes" in schema["properties"]
         assert "readout_probes" in schema["properties"]
         assert "primers" in schema["properties"]
+
+    def test_omitted_parameter_resolves_differently_than_an_omitted_section(self) -> None:
+        """The bug this check exists for: which default wins depends on how much is left out.
+
+        `nn_table` selects the nearest neighbour table every melting temperature is computed
+        from. Leaving it out of a section that is otherwise written resolves to the default on
+        the field, while leaving the whole section out resolves to the value merfish declares.
+        """
+        raw = _load("merfish_probe_designer.yaml")
+        without_section = _load("merfish_probe_designer.yaml")
+        del raw["target_probes"]["global_parameters"]["Tm_parameters"]["nn_table"]
+        del without_section["target_probes"]["global_parameters"]["Tm_parameters"]
+
+        cfg = MerfishProbeDesignerConfig.model_validate(raw)
+        cfg_without_section = MerfishProbeDesignerConfig.model_validate(without_section)
+
+        assert cfg.target_probes.global_parameters.Tm_parameters.nn_table is None
+        assert cfg_without_section.target_probes.global_parameters.Tm_parameters.nn_table == "DNA_NN4"
+        paths = [entry.path for entry in find_missing_config_keys(cfg, raw)]
+        assert "target_probes.global_parameters.Tm_parameters.nn_table" in paths
+
+
+# ---------------------------------------------------------------------------
+# find_missing_config_keys
+# ---------------------------------------------------------------------------
+
+
+class TestConfigCompleteness(unittest.TestCase):
+    def _merfish(self, raw: dict) -> list[MissingConfigKey]:
+        return find_missing_config_keys(MerfishProbeDesignerConfig.model_validate(raw), raw)
+
+    def test_missing_section_reported_once(self) -> None:
+        """A whole section is one entry, not one entry per parameter below it."""
+        raw = _load("merfish_probe_designer.yaml")
+        del raw["general"]
+        missing = self._merfish(raw)
+
+        assert [entry.path for entry in missing] == ["general"]
+        message = format_missing_config_keys(missing)
+        assert "n_jobs" in message and "dir_output" in message
+
+    def test_disabled_branch_demands_no_siblings(self) -> None:
+        """A filter that is turned off only has to say so."""
+        raw = _load("merfish_probe_designer.yaml")
+        raw["target_probes"]["property_filters"]["Tm_filter"] = {"enabled": False}
+
+        assert [entry for entry in self._merfish(raw) if "Tm_filter" in entry.path] == []
+
+    def test_sparse_model_is_exempt(self) -> None:
+        """An unset BLAST option means the flag is not passed, so it needs no value."""
+        raw = _load("merfish_probe_designer.yaml")
+        filters = raw["target_probes"]["specificity_filters"]["specificity_blastn_filter"]
+        filters["search_parameters"] = {}
+
+        assert [entry for entry in self._merfish(raw) if "search_parameters" in entry.path] == []
+
+    def test_branch_of_a_union_decides_what_is_demanded(self) -> None:
+        """`source` selects the branch, and only that branch's parameters are required."""
+        raw = _load("merfish_probe_designer.yaml")
+        raw["readout_probes"]["codebook"] = {"source": "generate"}
+        paths = [entry.path for entry in self._merfish(raw)]
+
+        assert "readout_probes.codebook.n_bits" in paths
+        assert "readout_probes.codebook.file" not in paths
+
+    def test_null_counts_as_set(self) -> None:
+        """Writing a parameter out as null is setting it; leaving it out is not."""
+        raw = _load("merfish_probe_designer.yaml")
+        assert self._merfish(raw) == []
+
+        del raw["target_probes"]["global_parameters"]["Tm_parameters"]["c_seq"]
+
+        assert "target_probes.global_parameters.Tm_parameters.c_seq" in [
+            entry.path for entry in self._merfish(raw)
+        ]
+
+    def test_alias_is_accepted_and_suggested(self) -> None:
+        """A field with an alias counts as set under either spelling, and is suggested as the alias."""
+
+        class Aliased(BaseModel):
+            evalue: int = Field(
+                default=1, validation_alias=AliasChoices("-evalue", "evalue"), serialization_alias="-evalue"
+            )
+
+        assert find_missing_config_keys(Aliased.model_validate({"-evalue": 2}), {"-evalue": 2}) == []
+        assert find_missing_config_keys(Aliased.model_validate({"evalue": 2}), {"evalue": 2}) == []
+        missing = find_missing_config_keys(Aliased.model_validate({}), {})
+        assert [(entry.path, entry.key) for entry in missing] == [("evalue", "-evalue")]
+
+    def test_list_of_models_is_indexed(self) -> None:
+        """Each element of a list is walked, and its position shows up in the path."""
+
+        class Item(BaseModel):
+            a: int = 1
+            b: int = 2
+
+        class Outer(BaseModel):
+            items: list[Item]
+
+        raw = {"items": [{"a": 1, "b": 2}, {"a": 1}]}
+
+        assert [entry.path for entry in find_missing_config_keys(Outer.model_validate(raw), raw)] == [
+            "items[1].b"
+        ]
+
+    def test_validation_alone_does_not_check(self) -> None:
+        """ODT-Cloud validates the same models and must keep accepting a partial configuration."""
+        raw = _load("merfish_probe_designer.yaml")
+        del raw["target_probes"]["global_parameters"]["Tm_parameters"]["c_seq"]
+        cfg = MerfishProbeDesignerConfig.model_validate(raw)
+
+        # validation is happy, only the completeness check is not
+        assert cfg.target_probes.global_parameters.Tm_parameters.c_seq is None
+        assert self._merfish(raw) != []


### PR DESCRIPTION
Summary 

- Config files must now set every parameter — the command line pipelines reject one that leaves anything out, and list what's missing with the value it fell back to.
- New config/_completeness.py does the check, plus a shared load_config replacing six copies of read-validate-report.
- BlastnSearchParameters is exempt: those are BLAST flags, not settings, and its serializer drops None so they can't be written out anyway.
- The six shipped configs gained the 51 parameters they were relying on defaults for. Resolved config is byte-identical, so nothing behaves differently.