### PR TITLE
232 add top level pydantic model

### DIFF
--- a/data/configs/cycle_hcr_probe_designer.yaml
+++ b/data/configs/cycle_hcr_probe_designer.yaml
@@ -58,14 +58,18 @@ target_probes:
       enabled: true # Turn this filter on or off.
       junction_region_size: 13 # Size of the seed region around the junction site for the BLAST seed-region filter; set to 0 to skip seed-region filtering.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
-      hit_parameters: {"coverage": 90} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 90
       files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Use genomic_region_generator for custom reference sets.
         - data/genomic_regions/gene_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove L/R arms that may cross-hybridize to off-target sequences (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
-      hit_parameters: {"coverage": 90} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 90
 
   probe_set_selection: # Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification).
     independent_set_selection:

--- a/data/configs/cycle_hcr_probe_designer.yaml
+++ b/data/configs/cycle_hcr_probe_designer.yaml
@@ -13,12 +13,16 @@ general:
 ### USER PARAMETERS ###
 #######################
 
-target_probes:
-  oligo_generation:
-    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
-    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+required_parameters:
+  targets: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+  target_genome: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+  reference_genome: # FASTA file(s) used as reference for specificity.
+      - data/genomic_regions/gene_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+target_probes:
+  oligo_generation:
     L_probe_sequence_length: 45 # Length (bases) of the L arm of the probe; L + gap + R should equal the total probe length, e.g. 45 + 2 + 45 = 92.
     gap_sequence_length: 2 # Length (bases) of the spacer between the L and R arms (covers the junction site).
     R_probe_sequence_length: 45 # Length (bases) of the R arm of the probe; L + gap + R should equal the total probe length, e.g. 45 + 2 + 45 = 92.
@@ -61,8 +65,6 @@ target_probes:
       hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
         hit_criterion: "coverage"
         value: 90
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Use genomic_region_generator for custom reference sets.
-        - data/genomic_regions/gene_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove L/R arms that may cross-hybridize to off-target sequences (BLAST-based).
       enabled: true # Turn this filter on or off.

--- a/data/configs/hcr_probe_designer.yaml
+++ b/data/configs/hcr_probe_designer.yaml
@@ -13,12 +13,16 @@ general:
 ### USER PARAMETERS ###
 #######################
 
-target_probes:
-  oligo_generation:
-    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
-    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+required_parameters:
+  targets: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+  target_genome: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+  reference_genome: # FASTA file(s) used as reference for specificity.
+      - data/genomic_regions/gene_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+target_probes:
+  oligo_generation:
     L_probe_sequence_length: 25 # Length (bases) of the L arm of the probe; L + gap + R should equal the total probe length, e.g. 25 + 2 + 25 = 52.
     gap_sequence_length: 2 # Length (bases) of the spacer between the L and R arms (covers the ligation site).
     R_probe_sequence_length: 25 # Length (bases) of the R arm of the probe; L + gap + R should equal the total probe length, e.g. 25 + 2 + 25 = 52.
@@ -61,8 +65,6 @@ target_probes:
       hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
         hit_criterion: "coverage"
         value: 90
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Use genomic_region_generator for custom reference sets.
-        - data/genomic_regions/gene_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove L/R arms that may cross-hybridize to off-target sequences (BLAST-based).
       enabled: true # Turn this filter on or off.

--- a/data/configs/hcr_probe_designer.yaml
+++ b/data/configs/hcr_probe_designer.yaml
@@ -58,14 +58,18 @@ target_probes:
       enabled: true # Turn this filter on or off.
       junction_region_size: 0 # Size of the seed region around the junction site for the BLAST seed-region filter; set to 0 to skip seed-region filtering.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
-      hit_parameters: {"coverage": 90} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 90
       files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Use genomic_region_generator for custom reference sets.
         - data/genomic_regions/gene_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove L/R arms that may cross-hybridize to off-target sequences (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
-      hit_parameters: {"coverage": 90} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 90
 
   probe_set_selection: # Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification).
     independent_set_selection:

--- a/data/configs/merfish_probe_designer.yaml
+++ b/data/configs/merfish_probe_designer.yaml
@@ -56,7 +56,9 @@ target_probes:
     specificity_blastn_filter: # Ensure oligo specificity against a reference database (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
-      hit_parameters: {"min_alignment_length": 17} # Hit criteria. Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+        hit_criterion: "min_alignment_length"
+        value: 17
       files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
         - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
         - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
@@ -64,7 +66,9 @@ target_probes:
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to other probes (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
-      hit_parameters: {"min_alignment_length": 17} # Hit criteria. Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+        hit_criterion: "min_alignment_length"
+        value: 17
 
   probe_set_selection: # Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification).
     independent_set_selection:
@@ -137,7 +141,9 @@ readout_probes:
       specificity_blastn_filter: # Remove readout probes with significant hits to the reference (BLAST-based).
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
-        hit_parameters: {"min_alignment_length": 11}
+        hit_parameters:
+          hit_criterion: "min_alignment_length"
+          value: 11
         files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
           - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
           - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
@@ -145,7 +151,9 @@ readout_probes:
       cross_hybridization_blastn_filter: # Remove readout probes that cross-hybridize to each other (BLAST-based).
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10}
-        hit_parameters: {"min_alignment_length": 11}
+        hit_parameters:
+          hit_criterion: "min_alignment_length"
+          value: 11
 
     probe_set_selection: # Select a set of readout probes with homogeneous Tm / GC content (uses HomogeneousPropertyOligoSelection).
       set_size: 16 # Total number of readout probes to select (must equal n_bits so each bit gets a probe).
@@ -218,7 +226,9 @@ primers:
       specificity_blastn_filter: # Ensure primer specificity against a reference database (BLAST-based).
         enabled: true
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
-        hit_parameters: {"min_alignment_length": 14}
+        hit_parameters:
+          hit_criterion: "min_alignment_length"
+          value: 14
         files_fasta_reference_database: # FASTA file(s) used as reference for primer specificity.
           - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
           - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
@@ -226,7 +236,9 @@ primers:
       hybridization_probes_blastn_filter: # Remove primers that match the assembled hybridization probes (BLAST-based).
         enabled: true
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
-        hit_parameters: {"min_alignment_length": 11}
+        hit_parameters:
+          hit_criterion: "min_alignment_length"
+          value: 11
 
     global_parameters:
       Tm_parameters:

--- a/data/configs/merfish_probe_designer.yaml
+++ b/data/configs/merfish_probe_designer.yaml
@@ -13,12 +13,17 @@ general:
 ### USER PARAMETERS ###
 #######################
 
-target_probes:
-  oligo_generation:
-    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
-    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+required_parameters:
+  targets: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+  target_genome: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+  reference_genome: # FASTA file(s) used as reference for specificity.
+      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+target_probes:
+  oligo_generation:
     probe_length_min: 30 # Minimum allowed oligo length (bases).
     probe_length_max: 30 # Maximum allowed oligo length (bases).
 
@@ -59,9 +64,6 @@ target_probes:
       hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
         hit_criterion: "min_alignment_length"
         value: 17
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
-        - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-        - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to other probes (BLAST-based).
       enabled: true # Turn this filter on or off.
@@ -144,9 +146,6 @@ readout_probes:
         hit_parameters:
           hit_criterion: "min_alignment_length"
           value: 11
-        files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
-          - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-          - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
       cross_hybridization_blastn_filter: # Remove readout probes that cross-hybridize to each other (BLAST-based).
         enabled: true # Turn this filter on or off.
@@ -229,9 +228,6 @@ primers:
         hit_parameters:
           hit_criterion: "min_alignment_length"
           value: 14
-        files_fasta_reference_database: # FASTA file(s) used as reference for primer specificity.
-          - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-          - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
       hybridization_probes_blastn_filter: # Remove primers that match the assembled hybridization probes (BLAST-based).
         enabled: true

--- a/data/configs/oligo_seq_probe_designer.yaml
+++ b/data/configs/oligo_seq_probe_designer.yaml
@@ -13,12 +13,17 @@ general:
 ### USER PARAMETERS ###
 #######################
 
-target_probes:
-  oligo_generation:
-    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
-    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+required_parameters:
+  targets: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+  target_genome: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+  reference_genome: # FASTA file(s) used as reference for specificity.
+      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+target_probes:
+  oligo_generation:
     probe_length_min: 26 # Minimum allowed oligo length (bases).
     probe_length_max: 30 # Maximum allowed oligo length (bases).
     probe_split_region: 4 # Minimum bases spanning the exon–exon junction (upstream and downstream) so the oligo is junction-spanning.
@@ -77,9 +82,6 @@ target_probes:
       hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
         hit_criterion: "coverage"
         value: 50
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Use genomic_region_generator for custom reference sets.
-        - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-        - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to off-target sequences (BLAST-based).
       enabled: true # Turn this filter on or off.

--- a/data/configs/oligo_seq_probe_designer.yaml
+++ b/data/configs/oligo_seq_probe_designer.yaml
@@ -74,7 +74,9 @@ target_probes:
     specificity_blastn_filter: # Ensure oligo specificity against a reference database (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10} # BLAST options for the specificity search.
-      hit_parameters: {"coverage": 50} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 50
       files_fasta_reference_database: # FASTA file(s) used as reference for specificity. Use genomic_region_generator for custom reference sets.
         - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
         - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
@@ -82,7 +84,9 @@ target_probes:
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to off-target sequences (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10} # BLAST options for the cross-hybridization search.
-      hit_parameters: {"coverage": 50} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 50
 
     variant_filter: # Flag or exclude oligos overlapping variants from VCF files.
       enabled: true # Turn this filter on or off.

--- a/data/configs/scrinshot_probe_designer.yaml
+++ b/data/configs/scrinshot_probe_designer.yaml
@@ -13,12 +13,17 @@ general:
 ### USER PARAMETERS ###
 #######################
 
-target_probes:
-  oligo_generation:
-    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
-    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+required_parameters:
+  targets: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+  target_genome: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+  reference_genome: # FASTA file(s) used as reference for specificity.
+      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+target_probes:
+  oligo_generation:
     probe_length_min: 40 # Minimum allowed oligo length (bases).
     probe_length_max: 45 # Maximum allowed oligo length (bases).
 
@@ -61,9 +66,6 @@ target_probes:
       hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
         hit_criterion: "coverage"
         value: 50
-      files_fasta_reference_database: # FASTA file(s) used as reference for the specificity BLASTN search. Use genomic_region_generator for custom reference sets.
-      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize with each other (BLAST-based).
       enabled: true # Turn this filter on or off.

--- a/data/configs/scrinshot_probe_designer.yaml
+++ b/data/configs/scrinshot_probe_designer.yaml
@@ -58,7 +58,9 @@ target_probes:
       enabled: true # Turn this filter on or off.
       ligation_region_size: 5 # Size of the seed region around the ligation site for BLAST seed region filter; set to 0 to skip seed-region filtering.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
-      hit_parameters: {"coverage": 50} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 50
       files_fasta_reference_database: # FASTA file(s) used as reference for the specificity BLASTN search. Use genomic_region_generator for custom reference sets.
       - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
@@ -66,7 +68,9 @@ target_probes:
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize with each other (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 10, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
-      hit_parameters: {"coverage": 80} # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria (e.g. coverage %). Hits satisfying these lead to oligo rejection.
+        hit_criterion: "coverage"
+        value: 80
 
   probe_set_selection: # Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification).
     independent_set_selection:

--- a/data/configs/seqfish_plus_probe_designer.yaml
+++ b/data/configs/seqfish_plus_probe_designer.yaml
@@ -56,12 +56,16 @@ target_probes:
     specificity_blastn_filter: # Ensure oligo specificity against a reference database (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
-      hit_parameters: {"min_alignment_length": 15} # Hit criteria. Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+        hit_criterion: "min_alignment_length"
+        value: 15
 
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to other probes (BLAST-based).
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 80, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10} # BLAST options for the cross-hybridization search.
-      hit_parameters: {"min_alignment_length": 17} # Hit criteria. Hits satisfying these lead to oligo rejection.
+      hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+        hit_criterion: "min_alignment_length"
+        value: 17
 
   probe_set_selection: # Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification).
     independent_set_selection:
@@ -113,12 +117,16 @@ readout_probes:
       specificity_blastn_filter: # Remove readout probes with significant hits to the reference (BLAST-based).
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
-        hit_parameters: {"min_alignment_length": 10}
+        hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+          hit_criterion: "min_alignment_length"
+          value: 10
 
       cross_hybridization_blastn_filter: # Remove readout probes that cross-hybridize to each other (BLAST-based).
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10}
-        hit_parameters: {"min_alignment_length": 10}
+        hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+          hit_criterion: "min_alignment_length"
+          value: 10
 
 primers:
   forward_primer:
@@ -167,12 +175,16 @@ primers:
       specificity_blastn_filter: # Ensure primer specificity against a reference database (BLAST-based).
         enabled: true
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
-        hit_parameters: {"min_alignment_length": 14}
+        hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+          hit_criterion: "min_alignment_length"
+          value: 14
 
       hybridization_probes_blastn_filter: # Remove primers that match the assembled hybridization probes (BLAST-based).
         enabled: true
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
-        hit_parameters: {"min_alignment_length": 11}
+        hit_parameters: # Hit criteria. Hits satisfying these lead to oligo rejection.
+          hit_criterion: "min_alignment_length"
+          value: 11
 
     global_parameters:
       Tm_parameters:

--- a/data/configs/seqfish_plus_probe_designer.yaml
+++ b/data/configs/seqfish_plus_probe_designer.yaml
@@ -13,12 +13,17 @@ general:
 ### USER PARAMETERS ###
 #######################
 
-target_probes:
-  oligo_generation:
-    file_region_ids: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
-    files_fasta_probe_database: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
+required_parameters:
+  targets: data/genes/custom_3.txt # Path to file listing gene/region IDs to design probes for. Empty = use all genes from the FASTA.
+  target_genome: # FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.
       - data/genomic_regions/cds_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
       - data/genomic_regions/utr_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+  reference_genome: # FASTA file(s) used as reference for specificity.
+      - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+      - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
+
+target_probes:
+  oligo_generation:
     probe_length_min: 28 # Minimum allowed oligo length (bases).
     probe_length_max: 28 # Maximum allowed oligo length (bases).
 
@@ -52,9 +57,6 @@ target_probes:
       enabled: true # Turn this filter on or off.
       search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000} # BLAST options for the specificity search.
       hit_parameters: {"min_alignment_length": 15} # Hit criteria. Hits satisfying these lead to oligo rejection.
-      files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
-        - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-        - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
     cross_hybridization_blastn_filter: # Remove oligos that may cross-hybridize to other probes (BLAST-based).
       enabled: true # Turn this filter on or off.
@@ -112,9 +114,6 @@ readout_probes:
         enabled: true # Turn this filter on or off.
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
         hit_parameters: {"min_alignment_length": 10}
-        files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
-          - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-          - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
       cross_hybridization_blastn_filter: # Remove readout probes that cross-hybridize to each other (BLAST-based).
         enabled: true # Turn this filter on or off.
@@ -169,9 +168,6 @@ primers:
         enabled: true
         search_parameters: {"-perc_identity": 100, "-strand": "minus", "-word_size": 7, "-dust": "no", "-soft_masking": "false", "-max_target_seqs": 10, "-max_hsps": 1000}
         hit_parameters: {"min_alignment_length": 14}
-        files_fasta_reference_database: # FASTA file(s) used as reference for specificity.
-          - data/genomic_regions/exon_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
-          - data/genomic_regions/exon_exon_junction_annotation_source-NCBI_species-Homo_sapiens_annotation_release-110_genome_assemly-GRCh38.fna
 
       hybridization_probes_blastn_filter: # Remove primers that match the assembled hybridization probes (BLAST-based).
         enabled: true

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -353,33 +353,31 @@ class BlastnSearchParameters(BaseModel):
         }
 
 
-class BlastnHitParameters(BaseModel):
+class BlastnHitParametersCoverage(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    coverage: float | None = Field(
-        default=None,
+    hit_criterion: Literal["coverage"] = "coverage"
+
+    value: float = Field(
         ge=0,
         le=100,
         description="Coverage in %, alternatively, min_alignment_length can be used",
     )
-    min_alignment_length: NonNegativeInt | None = Field(
-        default=None,
+
+
+class BlastnHitParametersMinAlignmentLength(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    hit_criterion: Literal["min_alignment_length"] = "min_alignment_length"
+
+    value: NonNegativeInt = Field(
         description="Number of nucleotides for alignment, alternatively, coverage can be used",
     )
 
-    @model_validator(mode="after")
-    def _check_mutually_exclusive(self) -> Self:
-        if (self.coverage is None) == (self.min_alignment_length is None):
-            raise ValueError("Exactly one of 'coverage' or 'min_alignment_length' must be set.")
-        return self
 
-    @model_serializer
-    def serialize(self) -> dict:
-        return {
-            self.__class__.model_fields[name].serialization_alias or name: value
-            for name, value in self.__dict__.items()
-            if value is not None
-        }
+BlastnHitParameters = Annotated[
+    BlastnHitParametersCoverage | BlastnHitParametersMinAlignmentLength, Field(discriminator="hit_criterion")
+]
 
 
 class TmParameters(BaseModel):

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -20,6 +20,27 @@ from oligo_designer_toolsuite.config._types import (
 )
 
 
+# High-level descriptions of the config sections, shown as the section's help text in the form.
+REQUIRED_PARAMETERS_DESC = (
+    "Parameters required for target probe generation. The reference genome is reused for all "
+    "specificity filters for all probes."
+)
+OLIGO_GENERATION_DESC = "Parameters that determine length and spacing of the probes."
+PROPERTY_FILTERS_DESC = (
+    "Parameters for filters that depend on properties of the filters (e.g., melting temperature)."
+)
+SPECIFICITY_FILTERS_DESC = "Parameters for filters that test the specificity of the probes."
+GLOBAL_PARAMETERS_DESC = (
+    "Parameters for melting temperature computation that are reused for different filtering and "
+    "scoring methods."
+)
+CODEBOOK_DESC = "Parameters that determine the codebook generation or loading."
+READOUT_PROBE_TABLE_DESC = "Parameters that determine the readout probe table generation or loading."
+INITIATOR_TABLE_DESC = "Parameters that determine the initiator table generation or loading."
+FORWARD_PRIMER_DESC = "Parameters that determine the forward primer generation or loading."
+REVERSE_PRIMER_DESC = "Parameters that determine the reverse primer generation or loading."
+
+
 class General(BaseModel):
     model_config = ConfigDict(extra="forbid")
     n_jobs: PositiveInt = Field(

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -30,6 +30,9 @@ PROPERTY_FILTERS_DESC = (
     "Parameters for filters that depend on properties of the filters (e.g., melting temperature)."
 )
 SPECIFICITY_FILTERS_DESC = "Parameters for filters that test the specificity of the probes."
+PROBE_SET_SELECTION_DESC = (
+    "Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
+)
 GLOBAL_PARAMETERS_DESC = (
     "Parameters for melting temperature computation that are reused for different filtering and "
     "scoring methods."

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -177,7 +177,7 @@ class BlastnSearchParameters(BaseModel):
         serialization_alias="-soft_masking",
         description="Apply filtering locations as soft masks (i.e., only for finding initial matches).",
     )
-    lcase_masking: Literal[""] | None = Field(
+    lcase_masking: bool | None = Field(
         default=None,
         validation_alias=AliasChoices("-lcase_masking", "lcase_masking"),
         serialization_alias="-lcase_masking",
@@ -250,7 +250,7 @@ class BlastnSearchParameters(BaseModel):
         gt=0,
         lt=0.5,
     )
-    subject_besthit: Literal[""] | None = Field(
+    subject_besthit: bool | None = Field(
         default=None,
         validation_alias=AliasChoices("-subject_besthit", "subject_besthit"),
         serialization_alias="-subject_besthit",
@@ -308,7 +308,7 @@ class BlastnSearchParameters(BaseModel):
         serialization_alias="-xdrop_gap_final",
         description="X-dropoff value (in bits) for final gapped alignment.",
     )
-    no_greedy: Literal[""] | None = Field(
+    no_greedy: bool | None = Field(
         default=None,
         validation_alias=AliasChoices("-no_greedy", "no_greedy"),
         serialization_alias="-no_greedy",
@@ -320,7 +320,7 @@ class BlastnSearchParameters(BaseModel):
         serialization_alias="-min_raw_gapped_score",
         description="Minimum raw gapped score to keep an alignment in the preliminary gapped and trace-back stages. Normally set based upon expect value.",
     )
-    ungapped: Literal[""] | None = Field(
+    ungapped: bool | None = Field(
         default=None,
         validation_alias=AliasChoices("-ungapped", "ungapped"),
         serialization_alias="-ungapped",

--- a/oligo_designer_toolsuite/config/_general_models.py
+++ b/oligo_designer_toolsuite/config/_general_models.py
@@ -13,6 +13,12 @@ from pydantic import (
 )
 from typing_extensions import Self
 
+from oligo_designer_toolsuite.config._types import (
+    FilesFastaDatabaseT,
+    FilesFastaReferenceDatabaseT,
+    RegionListT,
+)
+
 
 class General(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -23,6 +29,14 @@ class General(BaseModel):
     write_intermediate_steps: bool = Field(
         description="if true, writes the oligo sequences after each step of the pipeline into a csv file",
     )
+
+
+class RequiredParameters(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    targets: RegionListT
+    target_genome: FilesFastaDatabaseT
+    reference_genome: FilesFastaReferenceDatabaseT
 
 
 class HomopolymericRunThreshold(BaseModel):

--- a/oligo_designer_toolsuite/config/_oligo_scoring.py
+++ b/oligo_designer_toolsuite/config/_oligo_scoring.py
@@ -10,10 +10,6 @@ from oligo_designer_toolsuite.config._types import (
     TmOptT,
 )
 
-PROBE_SET_SELECTION_DESC = (
-    "Parameters for selecting multiple probe sets per gene (size, spacing, scoring, diversification)."
-)
-
 
 class IndependentSetSelection(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/oligo_designer_toolsuite/config/_property_filters.py
+++ b/oligo_designer_toolsuite/config/_property_filters.py
@@ -69,14 +69,14 @@ class HardMaskedFilterConfig(BaseModel):
     """Exclude oligos overlapping hard-masked (e.g. N) regions in the reference."""
 
     model_config = ConfigDict(extra="forbid")
-    enabled: bool
+    enabled: bool = Field(description="Turn this filter on or off.")
 
 
 class SoftMaskedFilterConfig(BaseModel):
     """Exclude oligos overlapping soft-masked (lowercase) regions in the reference."""
 
     model_config = ConfigDict(extra="forbid")
-    enabled: bool
+    enabled: bool = Field(description="Turn this filter on or off.")
 
 
 class HomopolymericRunsFilterDisabled(FilterBaseConfigDisabled):

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -2,12 +2,19 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt
 
-from oligo_designer_toolsuite.config._general_models import BlastnHitParameters, BlastnSearchParameters
+from oligo_designer_toolsuite.config._general_models import (
+    BlastnHitParameters,
+    BlastnHitParametersCoverage,
+    BlastnHitParametersMinAlignmentLength,
+    BlastnSearchParameters,
+)
 from oligo_designer_toolsuite.config._types import VCFReferenceDatabaseT
 
 SPECIFICITY_TARGET_DESC = "Ensure oligo specificity against a reference database (BLAST-based)."
 SPECIFICITY_READOUT_DESC = "Remove readout probes with significant hits to the reference (BLAST-based)."
 SPECIFICITY_PRIMER_DESC = "Ensure primer specificity against a reference database (BLAST-based)."
+CROSS_HYBRIDIZATION_DESC = "Remove oligos that may cross-hybridize to other probes (BLAST-based)."
+HYBRIDIZATION_PROBES_DESC = "Remove primers that match the assembled hybridization probes (BLAST-based)."
 
 
 class FilterBaseConfigEnabled(BaseModel):
@@ -60,7 +67,7 @@ CrossHybridizationBlastnFilterConfig = Annotated[
     CrossHybridizationBlastnFilterEnabled | CrossHybridizationBlastnFilterDisabled,
     Field(
         discriminator="enabled",
-        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
+        description=CROSS_HYBRIDIZATION_DESC,
     ),
 ]
 
@@ -114,7 +121,7 @@ HybridizationProbesBlastnFilterConfig = Annotated[
     HybridizationProbesBlastnFilterEnabled | HybridizationProbesBlastnFilterDisabled,
     Field(
         discriminator="enabled",
-        description="Remove primers that match the assembled hybridization probes (BLAST-based).",
+        description=HYBRIDIZATION_PROBES_DESC,
     ),
 ]
 
@@ -132,3 +139,80 @@ class VariantFilterEnabled(FilterBaseConfigEnabled):
 
 
 VariantFilterConfig = Annotated[VariantFilterEnabled | VariantFilterDisabled, Field(discriminator="enabled")]
+
+
+# Variants that set the hit criterion on `hit_parameters` itself, not on an enclosing config.
+#
+# A JSON Schema consumer picks the branch from a default on the field; one further out is not
+# read, so it falls back to the first branch while the outer value still merges in. That made
+# `value=15` meant as 15 bases arrive as 15 % coverage -- silently, both being plain numbers.
+# Coverage variants are needed for the same reason: otherwise a pipeline is correct only while
+# coverage stays declared first.
+#
+# Values are placeholders, overridden per call site. `description` is restated because
+# redeclaring a field replaces its whole FieldInfo.
+
+
+class SpecificityBlastnFilterMinAlignmentEnabled(SpecificityBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersMinAlignmentLength(value=15),
+        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+SpecificityBlastnFilterMinAlignmentConfig = Annotated[
+    SpecificityBlastnFilterMinAlignmentEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class SpecificityBlastnFilterCoverageEnabled(SpecificityBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=50),
+        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+SpecificityBlastnFilterCoverageConfig = Annotated[
+    SpecificityBlastnFilterCoverageEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled"),
+]
+
+
+class CrossHybridizationBlastnFilterMinAlignmentEnabled(CrossHybridizationBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersMinAlignmentLength(value=17),
+        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+CrossHybridizationBlastnFilterMinAlignmentConfig = Annotated[
+    CrossHybridizationBlastnFilterMinAlignmentEnabled | CrossHybridizationBlastnFilterDisabled,
+    Field(discriminator="enabled", description=CROSS_HYBRIDIZATION_DESC),
+]
+
+
+class CrossHybridizationBlastnFilterCoverageEnabled(CrossHybridizationBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=50),
+        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+CrossHybridizationBlastnFilterCoverageConfig = Annotated[
+    CrossHybridizationBlastnFilterCoverageEnabled | CrossHybridizationBlastnFilterDisabled,
+    Field(discriminator="enabled", description=CROSS_HYBRIDIZATION_DESC),
+]
+
+
+class HybridizationProbesBlastnFilterMinAlignmentEnabled(HybridizationProbesBlastnFilterEnabled):
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersMinAlignmentLength(value=11),
+        description=HybridizationProbesBlastnFilterEnabled.model_fields["hit_parameters"].description,
+    )
+
+
+HybridizationProbesBlastnFilterMinAlignmentConfig = Annotated[
+    HybridizationProbesBlastnFilterMinAlignmentEnabled | HybridizationProbesBlastnFilterDisabled,
+    Field(discriminator="enabled", description=HYBRIDIZATION_PROBES_DESC),
+]

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -15,6 +15,20 @@ SPECIFICITY_READOUT_DESC = "Remove readout probes with significant hits to the r
 SPECIFICITY_PRIMER_DESC = "Ensure primer specificity against a reference database (BLAST-based)."
 CROSS_HYBRIDIZATION_DESC = "Remove oligos that may cross-hybridize to other probes (BLAST-based)."
 HYBRIDIZATION_PROBES_DESC = "Remove primers that match the assembled hybridization probes (BLAST-based)."
+SPECIFICITY_SEARCH_PARAMS_DESC = "BLAST options for the specificity search."
+SPECIFICITY_HIT_PARAMS_DESC = (
+    "Hit criteria (either coverage % or minimum alignment length). Hits satisfying these lead to "
+    "oligo rejection."
+)
+CROSS_HYBRIDIZATION_SEARCH_PARAMS_DESC = "BLAST options for the cross-hybridization search."
+CROSS_HYBRIDIZATION_HIT_PARAMS_DESC = "Hit criteria. Hits satisfying these lead to oligo rejection."
+HYBRIDIZATION_PROBES_SEARCH_PARAMS_DESC = (
+    "BLASTN search parameters for filtering primers that match the assembled hybridization probes."
+)
+HYBRIDIZATION_PROBES_HIT_PARAMS_DESC = (
+    "Parameters for filtering BLASTN hits against the hybridization probes. Use either coverage or "
+    "min_alignment_length."
+)
 
 
 class FilterBaseConfigEnabled(BaseModel):
@@ -53,13 +67,13 @@ class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLAST options for the cross-hybridization search.",
+            description=CROSS_HYBRIDIZATION_SEARCH_PARAMS_DESC,
             json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(description="Hit criteria. Hits satisfying these lead to oligo rejection."),
+        Field(description=CROSS_HYBRIDIZATION_HIT_PARAMS_DESC),
     ]
 
 
@@ -80,15 +94,13 @@ class SpecificityBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLAST options for the specificity search.",
+            description=SPECIFICITY_SEARCH_PARAMS_DESC,
             json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(
-            description="Hit criteria (either coverage % or mininum alignment length). Hits satisfying these lead to oligo rejection."
-        ),
+        Field(description=SPECIFICITY_HIT_PARAMS_DESC),
     ]
 
 
@@ -105,15 +117,13 @@ class HybridizationProbesBlastnFilterEnabled(FilterBaseConfigEnabled):
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
-            description="BLASTN search parameters for filtering primers that match the assembled hybridization probes.",
+            description=HYBRIDIZATION_PROBES_SEARCH_PARAMS_DESC,
             json_schema_extra={"x-collapsed": True},
         ),
     ]
     hit_parameters: Annotated[
         BlastnHitParameters,
-        Field(
-            description="Parameters for filtering BLASTN hits against the hybridization probes. Use either coverage or min_alignment_length."
-        ),
+        Field(description=HYBRIDIZATION_PROBES_HIT_PARAMS_DESC),
     ]
 
 
@@ -141,22 +151,26 @@ class VariantFilterEnabled(FilterBaseConfigEnabled):
 VariantFilterConfig = Annotated[VariantFilterEnabled | VariantFilterDisabled, Field(discriminator="enabled")]
 
 
-# Variants that set the hit criterion on `hit_parameters` itself, not on an enclosing config.
+# Variants of the filters above that set the default hit criterion (coverage vs. minimum
+# alignment length) on the `hit_parameters` field itself, not on an enclosing config class.
 #
-# A JSON Schema consumer picks the branch from a default on the field; one further out is not
-# read, so it falls back to the first branch while the outer value still merges in. That made
-# `value=15` meant as 15 bases arrive as 15 % coverage -- silently, both being plain numbers.
-# Coverage variants are needed for the same reason: otherwise a pipeline is correct only while
-# coverage stays declared first.
+# The ODT-Cloud form (react-jsonschema-form) preselects a union branch from the default on the
+# field itself; a default declared further out is ignored for that choice, though its values
+# still merge in. A pipeline defaulting a whole filter section to min-alignment `value=15` was
+# therefore rendered as the coverage branch: "at least 15 aligned bases" became "15 % coverage",
+# with no error, both being plain numbers. These variants put the default where the form reads
+# it. Coverage variants exist too, so a coverage pipeline does not depend on coverage staying
+# the first branch of the union.
 #
-# Values are placeholders, overridden per call site. `description` is restated because
-# redeclaring a field replaces its whole FieldInfo.
+# The `value` defaults here are placeholders; each pipeline overrides them at its call site.
+# `description` is restated because redeclaring a field replaces its whole FieldInfo,
+# description included.
 
 
 class SpecificityBlastnFilterMinAlignmentEnabled(SpecificityBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersMinAlignmentLength(value=15),
-        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=SPECIFICITY_HIT_PARAMS_DESC,
     )
 
 
@@ -169,7 +183,7 @@ SpecificityBlastnFilterMinAlignmentConfig = Annotated[
 class SpecificityBlastnFilterCoverageEnabled(SpecificityBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersCoverage(value=50),
-        description=SpecificityBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=SPECIFICITY_HIT_PARAMS_DESC,
     )
 
 
@@ -182,7 +196,7 @@ SpecificityBlastnFilterCoverageConfig = Annotated[
 class CrossHybridizationBlastnFilterMinAlignmentEnabled(CrossHybridizationBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersMinAlignmentLength(value=17),
-        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=CROSS_HYBRIDIZATION_HIT_PARAMS_DESC,
     )
 
 
@@ -195,7 +209,7 @@ CrossHybridizationBlastnFilterMinAlignmentConfig = Annotated[
 class CrossHybridizationBlastnFilterCoverageEnabled(CrossHybridizationBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersCoverage(value=50),
-        description=CrossHybridizationBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=CROSS_HYBRIDIZATION_HIT_PARAMS_DESC,
     )
 
 
@@ -208,7 +222,7 @@ CrossHybridizationBlastnFilterCoverageConfig = Annotated[
 class HybridizationProbesBlastnFilterMinAlignmentEnabled(HybridizationProbesBlastnFilterEnabled):
     hit_parameters: BlastnHitParameters = Field(
         default=BlastnHitParametersMinAlignmentLength(value=11),
-        description=HybridizationProbesBlastnFilterEnabled.model_fields["hit_parameters"].description,
+        description=HYBRIDIZATION_PROBES_HIT_PARAMS_DESC,
     )
 
 

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -154,13 +154,29 @@ VariantFilterConfig = Annotated[VariantFilterEnabled | VariantFilterDisabled, Fi
 # Variants of the filters above that set the default hit criterion (coverage vs. minimum
 # alignment length) on the `hit_parameters` field itself, not on an enclosing config class.
 #
-# The ODT-Cloud form (react-jsonschema-form) preselects a union branch from the default on the
-# field itself; a default declared further out is ignored for that choice, though its values
-# still merge in. A pipeline defaulting a whole filter section to min-alignment `value=15` was
-# therefore rendered as the coverage branch: "at least 15 aligned bases" became "15 % coverage",
-# with no error, both being plain numbers. These variants put the default where the form reads
-# it. Coverage variants exist too, so a coverage pipeline does not depend on coverage staying
-# the first branch of the union.
+# `hit_parameters` is a union discriminated on `hit_criterion`, declared in `_general_models.py`
+# as `BlastnHitParametersCoverage | BlastnHitParametersMinAlignmentLength`. The ODT-Cloud form
+# (react-jsonschema-form) has to pick one of the two before the user has typed anything, and it
+# reads only the default on `hit_parameters` itself. Take `MerfishProbeDesignerConfig`, which
+# before these variants existed declared its target probe filter as:
+#
+#     specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+#         default=SpecificityBlastnFilterEnabled(
+#             ...,
+#             hit_parameters=BlastnHitParametersMinAlignmentLength(value=17),
+#         ),
+#     )
+#
+# That default sits on `specificity_blastn_filter`, one level above the field the form reads,
+# so `SpecificityBlastnFilterEnabled.hit_parameters` reached the schema with no default of its
+# own. The form fell back to the first branch of the union, `BlastnHitParametersCoverage`, and
+# filled it with the 17 from the enclosing default: "at least 17 aligned bases" was rendered as
+# "17 % coverage", with no error, both being plain numbers.
+#
+# `SpecificityBlastnFilterMinAlignmentEnabled` below redeclares `hit_parameters` with a
+# min-alignment default, which puts it where the form looks; the pipeline then defaults the
+# section to that variant instead. Coverage variants exist for the same reason, so a coverage
+# pipeline does not depend on coverage staying the first branch of the union.
 #
 # The `value` defaults here are placeholders; each pipeline overrides them at its call site.
 # `description` is restated because redeclaring a field replaces its whole FieldInfo,

--- a/oligo_designer_toolsuite/config/_specificity_filters.py
+++ b/oligo_designer_toolsuite/config/_specificity_filters.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt
 
 from oligo_designer_toolsuite.config._general_models import BlastnHitParameters, BlastnSearchParameters
-from oligo_designer_toolsuite.config._types import FilesFastaReferenceDatabaseT, VCFReferenceDatabaseT
+from oligo_designer_toolsuite.config._types import VCFReferenceDatabaseT
 
 SPECIFICITY_TARGET_DESC = "Ensure oligo specificity against a reference database (BLAST-based)."
 SPECIFICITY_READOUT_DESC = "Remove readout probes with significant hits to the reference (BLAST-based)."
@@ -43,8 +43,6 @@ class CrossHybridizationBlastnFilterDisabled(FilterBaseConfigDisabled):
 
 
 class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
-    """Remove oligos that may cross-hybridize to other probes (BLAST-based)."""
-
     search_parameters: Annotated[
         BlastnSearchParameters,
         Field(
@@ -60,7 +58,10 @@ class CrossHybridizationBlastnFilterEnabled(FilterBaseConfigEnabled):
 
 CrossHybridizationBlastnFilterConfig = Annotated[
     CrossHybridizationBlastnFilterEnabled | CrossHybridizationBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    Field(
+        discriminator="enabled",
+        description="Remove oligos that may cross-hybridize to other probes (BLAST-based).",
+    ),
 ]
 
 
@@ -82,7 +83,6 @@ class SpecificityBlastnFilterEnabled(FilterBaseConfigEnabled):
             description="Hit criteria (either coverage % or mininum alignment length). Hits satisfying these lead to oligo rejection."
         ),
     ]
-    files_fasta_reference_database: FilesFastaReferenceDatabaseT
 
 
 SpecificityBlastnFilterConfig = Annotated[

--- a/oligo_designer_toolsuite/config/_types.py
+++ b/oligo_designer_toolsuite/config/_types.py
@@ -12,13 +12,13 @@ FastaFileListT = Annotated[list[str], Field(min_length=1)]
 FilesFastaDatabaseT = Annotated[
     FastaFileListT,
     Field(
-        description="FASTA file(s) from which oligo sequences are generated. Use genomic_region_generator for custom regions.."
+        description="FASTA file(s) from which the target oligo sequences are generated. Use genomic_region_generator for custom regions."
     ),
 ]
 
 FilesFastaReferenceDatabaseT = Annotated[
     FastaFileListT,
-    Field(description="FASTA file(s) used as reference for specificity."),
+    Field(description="FASTA file(s) used as reference for all specificity filters (e.g. with BLAST)."),
 ]
 
 VCFReferenceDatabaseT = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -9,6 +9,11 @@ from pydantic import (
 )
 
 from oligo_designer_toolsuite.config._general_models import (
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
@@ -22,6 +27,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -198,11 +204,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -324,4 +330,4 @@ class CycleHcrProbeDesignerConfig(CycleHcrProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -64,8 +64,6 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=13,
     )
-    # redeclared to change the defaults below; description/x-collapsed restated since
-    # redeclaring a field replaces its whole FieldInfo
     search_parameters: BlastnSearchParameters = Field(
         default=BlastnSearchParameters(
             perc_identity=100,
@@ -237,7 +235,6 @@ class CycleHcrCodebookGenerate(BaseModel):
             "n_readout_probes_LR * n_channels regions."
         ),
         default=4,
-        json_schema_extra={"x-quick-setting": True},
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -141,6 +141,7 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    specificity_blastn_filter: CycleHcrSpecificityBlastnFilterConfig
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
         CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
@@ -155,7 +156,6 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=90),
         )
     )
-    specificity_blastn_filter: CycleHcrSpecificityBlastnFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -14,6 +14,7 @@ from oligo_designer_toolsuite.config._general_models import (
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
+    RequiredParameters,
     TmChemCorrectionParameters,
     TmChemCorrectionParametersDisabled,
     TmParameters,
@@ -40,24 +41,17 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
-from oligo_designer_toolsuite.config._types import (
-    DRNAT,
-    FilesFastaDatabaseT,
-    RegionListT,
-)
+from oligo_designer_toolsuite.config._types import DRNAT
 
 ############################################
 # CycleHCR-specific overrides
 ############################################
-
-
-class CycleHcrSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
-    pass
 
 
 class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
@@ -83,8 +77,8 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
 
 
 CycleHcrSpecificityBlastnFilterConfig = Annotated[
-    CycleHcrSpecificityBlastnFilterEnabled | CycleHcrSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    CycleHcrSpecificityBlastnFilterEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
 ]
 
 
@@ -96,8 +90,6 @@ CycleHcrSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    file_region_ids: RegionListT
-    files_fasta_probe_database: FilesFastaDatabaseT
     L_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the L arm of the probe; L + gap + R equals the total probe length.",
         default=45,
@@ -316,6 +308,7 @@ class CycleHcrProbeDesignerConfig(BaseModel):
         write_intermediate_steps=True,
     )
 
+    required_parameters: RequiredParameters
     target_probes: TargetProbes
     readout_probes: ReadoutProbes
     primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -64,14 +64,20 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=13,
     )
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=10,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    # redeclared to change the defaults below; description/x-collapsed restated since
+    # redeclaring a field replaces its whole FieldInfo
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=100,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        json_schema_extra={"x-collapsed": True},
     )
     hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
 

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -42,8 +42,8 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
@@ -93,14 +93,17 @@ class TargetProbeOligoGeneration(BaseModel):
     L_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the L arm of the probe; L + gap + R equals the total probe length.",
         default=45,
+        json_schema_extra={"x-quick-setting": True},
     )
     gap_sequence_length: NonNegativeInt = Field(
         description="Length (bases) of the spacer between the L and R arms (covers the junction site).",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
     R_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the R arm of the probe; L + gap + R equals the total probe length.",
         default=45,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -113,7 +116,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=False)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=30, GC_content_max=90
@@ -127,8 +131,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -227,6 +231,7 @@ class CycleHcrCodebookGenerate(BaseModel):
             "n_readout_probes_LR * n_channels regions."
         ),
         default=4,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -299,9 +304,17 @@ class HybridizationProbes(BaseModel):
 ############################################
 
 
-class CycleHcrProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class CycleHcrProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers
+    hybridization_probes: HybridizationProbes
+
+
+class CycleHcrProbeDesignerConfig(CycleHcrProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_cyclehcr_probe_designer",
@@ -309,7 +322,3 @@ class CycleHcrProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    readout_probes: ReadoutProbes
-    primers: Primers
-    hybridization_probes: HybridizationProbes

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -11,6 +11,7 @@ from pydantic import (
 from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -27,7 +28,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
     TmScore,
@@ -47,6 +47,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_HIT_PARAMS_DESC,
+    SPECIFICITY_SEARCH_PARAMS_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterCoverageConfig,
     CrossHybridizationBlastnFilterCoverageEnabled,
@@ -80,10 +82,13 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
             max_target_seqs=10,
             max_hsps=1000,
         ),
-        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        description=SPECIFICITY_SEARCH_PARAMS_DESC,
         json_schema_extra={"x-collapsed": True},
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=90),
+        description=SPECIFICITY_HIT_PARAMS_DESC,
+    )
 
 
 CycleHcrSpecificityBlastnFilterConfig = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/cycle_hcr_probe_designer.py
@@ -10,6 +10,7 @@ from pydantic import (
 
 from oligo_designer_toolsuite.config._general_models import (
     BlastnHitParameters,
+    BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
@@ -78,7 +79,7 @@ class CycleHcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         max_target_seqs=10,
         max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(coverage=90)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
 
 
 CycleHcrSpecificityBlastnFilterConfig = Annotated[
@@ -145,7 +146,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(coverage=90),
+            hit_parameters=BlastnHitParametersCoverage(value=90),
         )
     )
     specificity_blastn_filter: CycleHcrSpecificityBlastnFilterConfig

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -41,8 +41,8 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
@@ -92,14 +92,17 @@ class TargetProbeOligoGeneration(BaseModel):
     L_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the L arm of the probe; L + gap + R equals the total probe length.",
         default=25,
+        json_schema_extra={"x-quick-setting": True},
     )
     gap_sequence_length: NonNegativeInt = Field(
         description="Length (bases) of the spacer between the L and R arms (covers the ligation site).",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
     R_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the R arm of the probe; L + gap + R equals the total probe length.",
         default=25,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -112,7 +115,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=False)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=40, GC_content_max=65
@@ -126,8 +130,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -264,9 +268,16 @@ class HybridizationProbes(BaseModel):
 ############################################
 
 
-class HcrProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class HcrProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    initiator_probes: InitiatorProbes
+    hybridization_probes: HybridizationProbes
+
+
+class HcrProbeDesignerConfig(HcrProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_hcr_probe_designer",
@@ -274,6 +285,3 @@ class HcrProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    initiator_probes: InitiatorProbes
-    hybridization_probes: HybridizationProbes

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -13,6 +13,7 @@ from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     INITIATOR_TABLE_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -29,7 +30,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
 )
@@ -48,6 +48,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_HIT_PARAMS_DESC,
+    SPECIFICITY_SEARCH_PARAMS_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterCoverageConfig,
     CrossHybridizationBlastnFilterCoverageEnabled,
@@ -81,10 +83,13 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
             max_target_seqs=10,
             max_hsps=1000,
         ),
-        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        description=SPECIFICITY_SEARCH_PARAMS_DESC,
         json_schema_extra={"x-collapsed": True},
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=90),
+        description=SPECIFICITY_HIT_PARAMS_DESC,
+    )
 
 
 HcrSpecificityBlastnFilterConfig = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -63,8 +63,6 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=0,
     )
-    # redeclared to change the defaults below; description/x-collapsed restated since
-    # redeclaring a field replaces its whole FieldInfo
     search_parameters: BlastnSearchParameters = Field(
         default=BlastnSearchParameters(
             perc_identity=100,

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -9,6 +9,13 @@ from pydantic import (
 )
 
 from oligo_designer_toolsuite.config._general_models import (
+    CODEBOOK_DESC,
+    GLOBAL_PARAMETERS_DESC,
+    INITIATOR_TABLE_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
@@ -22,6 +29,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     IndependentSetSelection,
     IsoformConsensusScore,
 )
@@ -196,11 +204,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -249,8 +257,8 @@ HcrInitiatorTable = Annotated[
 class InitiatorProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    codebook: HcrCodebook
-    initiator_table: HcrInitiatorTable
+    codebook: HcrCodebook = Field(description=CODEBOOK_DESC)
+    initiator_table: HcrInitiatorTable = Field(description=INITIATOR_TABLE_DESC)
 
 
 ############################################
@@ -288,4 +296,4 @@ class HcrProbeDesignerConfig(HcrProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -10,6 +10,7 @@ from pydantic import (
 
 from oligo_designer_toolsuite.config._general_models import (
     BlastnHitParameters,
+    BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
@@ -77,7 +78,7 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         max_target_seqs=10,
         max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(coverage=90)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
 
 
 HcrSpecificityBlastnFilterConfig = Annotated[
@@ -144,7 +145,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(coverage=90),
+            hit_parameters=BlastnHitParametersCoverage(value=90),
         )
     )
     specificity_blastn_filter: HcrSpecificityBlastnFilterConfig

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -14,6 +14,7 @@ from oligo_designer_toolsuite.config._general_models import (
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
+    RequiredParameters,
     TmChemCorrectionParameters,
     TmChemCorrectionParametersDisabled,
     TmParameters,
@@ -39,24 +40,17 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
-from oligo_designer_toolsuite.config._types import (
-    DRNAT,
-    FilesFastaDatabaseT,
-    RegionListT,
-)
+from oligo_designer_toolsuite.config._types import DRNAT
 
 ############################################
 # HCR-specific overrides
 ############################################
-
-
-class HcrSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
-    pass
 
 
 class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
@@ -82,8 +76,8 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
 
 
 HcrSpecificityBlastnFilterConfig = Annotated[
-    HcrSpecificityBlastnFilterEnabled | HcrSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    HcrSpecificityBlastnFilterEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
 ]
 
 
@@ -95,8 +89,6 @@ HcrSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    file_region_ids: RegionListT
-    files_fasta_probe_database: FilesFastaDatabaseT
     L_probe_sequence_length: PositiveInt = Field(
         description="Length (bases) of the L arm of the probe; L + gap + R equals the total probe length.",
         default=25,
@@ -281,6 +273,7 @@ class HcrProbeDesignerConfig(BaseModel):
         write_intermediate_steps=True,
     )
 
+    required_parameters: RequiredParameters
     target_probes: TargetProbes
     initiator_probes: InitiatorProbes
     hybridization_probes: HybridizationProbes

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -142,6 +142,7 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    specificity_blastn_filter: HcrSpecificityBlastnFilterConfig
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
         CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
@@ -156,7 +157,6 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=90),
         )
     )
-    specificity_blastn_filter: HcrSpecificityBlastnFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/hcr_probe_designer.py
@@ -63,14 +63,20 @@ class HcrSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         ),
         default=0,
     )
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=10,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    # redeclared to change the defaults below; description/x-collapsed restated since
+    # redeclaring a field replaces its whole FieldInfo
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=100,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        json_schema_extra={"x-collapsed": True},
     )
     hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=90)
 
@@ -81,7 +87,7 @@ HcrSpecificityBlastnFilterConfig = Annotated[
 ]
 
 
-############################################
+############################################ add here expanding toggle
 # Target probe
 ############################################
 

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -10,6 +10,15 @@ from pydantic import (
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    CODEBOOK_DESC,
+    FORWARD_PRIMER_DESC,
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    READOUT_PROBE_TABLE_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    REVERSE_PRIMER_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BaseProbabilities,
     BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
@@ -190,11 +199,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
     probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
-    global_parameters: TargetProbeGlobal
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -369,10 +378,10 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
         json_schema_extra={"x-quick-setting": True},
     )
     oligo_generation: MerfishReadoutProbeOligoGeneration
-    property_filters: MerfishReadoutProbePropertyFilter
-    specificity_filters: MerfishReadoutProbeSpecificityFilter
-    probe_set_selection: MerfishReadoutProbeSetSelection
-    global_parameters: MerfishReadoutProbesGlobal
+    property_filters: MerfishReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: MerfishReadoutProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: MerfishReadoutProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: MerfishReadoutProbesGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 MerfishReadoutProbeTable = Annotated[
@@ -386,8 +395,8 @@ MerfishReadoutProbeTable = Annotated[
 class ReadoutProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    codebook: MerfishCodebook
-    readout_probe_table: MerfishReadoutProbeTable
+    codebook: MerfishCodebook = Field(description=CODEBOOK_DESC)
+    readout_probe_table: MerfishReadoutProbeTable = Field(description=READOUT_PROBE_TABLE_DESC)
 
 
 ############################################
@@ -515,9 +524,13 @@ class MerfishForwardPrimerGenerate(BaseModel):
 
     source: Literal["generate"] = "generate"
     oligo_generation: MerfishForwardPrimerOligoGeneration = MerfishForwardPrimerOligoGeneration()
-    property_filters: MerfishForwardPrimerPropertyFilter = MerfishForwardPrimerPropertyFilter()
-    specificity_filters: MerfishForwardPrimerSpecificityFilter
-    global_parameters: MerfishForwardPrimerGlobal = MerfishForwardPrimerGlobal()
+    property_filters: MerfishForwardPrimerPropertyFilter = Field(
+        default=MerfishForwardPrimerPropertyFilter(), description=PROPERTY_FILTERS_DESC
+    )
+    specificity_filters: MerfishForwardPrimerSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    global_parameters: MerfishForwardPrimerGlobal = Field(
+        default=MerfishForwardPrimerGlobal(), description=GLOBAL_PARAMETERS_DESC
+    )
 
 
 MerfishForwardPrimer = Annotated[
@@ -541,8 +554,8 @@ class MerfishReversePrimer(BaseModel):
 class Primers(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    forward_primer: MerfishForwardPrimer
-    reverse_primer: MerfishReversePrimer
+    forward_primer: MerfishForwardPrimer = Field(description=FORWARD_PRIMER_DESC)
+    reverse_primer: MerfishReversePrimer = Field(description=REVERSE_PRIMER_DESC)
 
 
 ############################################
@@ -566,4 +579,4 @@ class MerfishProbeDesignerConfig(MerfishProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -53,12 +53,12 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_PRIMER_DESC,
     SPECIFICITY_READOUT_DESC,
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
-    HybridizationProbesBlastnFilterConfig,
-    HybridizationProbesBlastnFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterMinAlignmentConfig,
+    CrossHybridizationBlastnFilterMinAlignmentEnabled,
+    HybridizationProbesBlastnFilterMinAlignmentConfig,
+    HybridizationProbesBlastnFilterMinAlignmentEnabled,
+    SpecificityBlastnFilterMinAlignmentConfig,
+    SpecificityBlastnFilterMinAlignmentEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
@@ -96,7 +96,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=43, GC_content_max=63
@@ -110,8 +111,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -126,8 +127,8 @@ class TargetProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_TARGET_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -232,6 +233,7 @@ class MerfishCodebookGenerate(MerfishCodebookBase):
     min_hamming_dist: PositiveInt = Field(
         description="Minimum Hamming distance between any two valid barcodes (MHD4 = 4 for single-bit error correction).",
         default=4,
+        json_schema_extra={"x-quick-setting": True},
     )
 
 
@@ -283,8 +285,8 @@ class MerfishReadoutProbePropertyFilter(BaseModel):
 class MerfishReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -299,8 +301,8 @@ class MerfishReadoutProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_READOUT_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -326,7 +328,10 @@ class MerfishReadoutProbeSetSelection(BaseModel):
         default=100000,
         description="Number of candidate sets to evaluate; higher values may find better sets but increase computation time.",
     )
-    homogeneous_properties_weights: HomogeneousPropertiesWeightsT = {"TmNN_oligo": 1, "GC_content_oligo": 1.0}
+    homogeneous_properties_weights: HomogeneousPropertiesWeightsT = {
+        "TmNN_oligo": 1,
+        "GC_content_oligo": 1.0,
+    }
 
 
 class MerfishReadoutProbesGlobal(BaseModel):
@@ -361,6 +366,7 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
     channels_ids: list[str] = Field(
         description="Fluorescence channels used for round-robin channel assignment across bits.",
         default=["Alexa488", "Cy3b", "Alexa647"],
+        json_schema_extra={"x-quick-setting": True},
     )
     oligo_generation: MerfishReadoutProbeOligoGeneration
     property_filters: MerfishReadoutProbePropertyFilter
@@ -422,7 +428,8 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=50, GC_content_max=65
@@ -445,8 +452,8 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
 class MerfishForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -461,8 +468,8 @@ class MerfishForwardPrimerSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_PRIMER_DESC,
     )
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
-        HybridizationProbesBlastnFilterEnabled(
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterMinAlignmentConfig = (
+        HybridizationProbesBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -543,9 +550,16 @@ class Primers(BaseModel):
 ############################################
 
 
-class MerfishProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class MerfishProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers
+
+
+class MerfishProbeDesignerConfig(MerfishProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_Merfishplus_probe_designer",
@@ -553,6 +567,3 @@ class MerfishProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    readout_probes: ReadoutProbes
-    primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -12,6 +12,7 @@ from typing_extensions import Self
 from oligo_designer_toolsuite.config._general_models import (
     BaseProbabilities,
     BlastnHitParameters,
+    BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
@@ -96,7 +97,7 @@ class MerfishTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled
         description="BLAST options for the specificity search.",
     )
     hit_parameters: BlastnHitParameters = Field(
-        default=BlastnHitParameters(min_alignment_length=17),
+        default=BlastnHitParametersMinAlignmentLength(value=17),
         description="Hit criteria. Hits satisfying these lead to oligo rejection.",
     )
 
@@ -117,7 +118,7 @@ class MerfishReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnable
         max_target_seqs=10,
         max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=11)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersMinAlignmentLength(value=11)
 
 
 MerfishReadoutSpecificityBlastnFilterConfig = Annotated[
@@ -136,7 +137,7 @@ class MerfishPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled
         max_target_seqs=10,
         max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=14)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersMinAlignmentLength(value=14)
 
 
 MerfishPrimerSpecificityBlastnFilterConfig = Annotated[
@@ -202,7 +203,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=17),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=17),
         )
     )
 
@@ -360,7 +361,7 @@ class MerfishReadoutProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=11),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=11),
         )
     )
 
@@ -508,7 +509,7 @@ class MerfishForwardPrimerSpecificityFilter(BaseModel):
                 max_target_seqs=10,
                 max_hsps=1000,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=11),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=11),
         )
     )
 

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -14,6 +14,7 @@ from oligo_designer_toolsuite.config._general_models import (
     FORWARD_PRIMER_DESC,
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     READOUT_PROBE_TABLE_DESC,
     REQUIRED_PARAMETERS_DESC,
@@ -32,7 +33,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScore,
     IndependentSetSelection,
     IsoformConsensusScore,

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -377,11 +377,23 @@ class MerfishReadoutProbeTableGenerate(BaseModel):
         default=["Alexa488", "Cy3b", "Alexa647"],
         json_schema_extra={"x-quick-setting": True},
     )
-    oligo_generation: MerfishReadoutProbeOligoGeneration
-    property_filters: MerfishReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
-    specificity_filters: MerfishReadoutProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
-    probe_set_selection: MerfishReadoutProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
-    global_parameters: MerfishReadoutProbesGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
+    oligo_generation: MerfishReadoutProbeOligoGeneration = Field(json_schema_extra={"x-collapsed": True})
+    property_filters: MerfishReadoutProbePropertyFilter = Field(
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    specificity_filters: MerfishReadoutProbeSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    probe_set_selection: MerfishReadoutProbeSetSelection = Field(
+        description=PROBE_SET_SELECTION_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    global_parameters: MerfishReadoutProbesGlobal = Field(
+        description=GLOBAL_PARAMETERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
 
 
 MerfishReadoutProbeTable = Annotated[
@@ -523,13 +535,23 @@ class MerfishForwardPrimerGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: MerfishForwardPrimerOligoGeneration = MerfishForwardPrimerOligoGeneration()
-    property_filters: MerfishForwardPrimerPropertyFilter = Field(
-        default=MerfishForwardPrimerPropertyFilter(), description=PROPERTY_FILTERS_DESC
+    oligo_generation: MerfishForwardPrimerOligoGeneration = Field(
+        default=MerfishForwardPrimerOligoGeneration(),
+        json_schema_extra={"x-collapsed": True},
     )
-    specificity_filters: MerfishForwardPrimerSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    property_filters: MerfishForwardPrimerPropertyFilter = Field(
+        default=MerfishForwardPrimerPropertyFilter(),
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    specificity_filters: MerfishForwardPrimerSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
     global_parameters: MerfishForwardPrimerGlobal = Field(
-        default=MerfishForwardPrimerGlobal(), description=GLOBAL_PARAMETERS_DESC
+        default=MerfishForwardPrimerGlobal(),
+        description=GLOBAL_PARAMETERS_DESC,
+        json_schema_extra={"x-collapsed": True},
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/merfish_probe_designer.py
@@ -11,11 +11,11 @@ from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
     BaseProbabilities,
-    BlastnHitParameters,
     BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
+    RequiredParameters,
     TmChemCorrectionParameters,
     TmChemCorrectionParametersDisabled,
     TmParameters,
@@ -57,94 +57,15 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     CrossHybridizationBlastnFilterEnabled,
     HybridizationProbesBlastnFilterConfig,
     HybridizationProbesBlastnFilterEnabled,
-    SpecificityBlastnFilterDisabled,
+    SpecificityBlastnFilterConfig,
     SpecificityBlastnFilterEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
-    FilesFastaDatabaseT,
     HomogeneousPropertiesWeightsT,
     LengthMaxT,
     LengthMinT,
-    RegionListT,
 )
-
-############################################
-# MERFISH-specific overrides
-############################################
-
-# The specificity BLASTN filter carries a required reference-database path
-# (files_fasta_reference_database, no default). These subclasses only set the
-# MERFISH default search/hit parameters; the path stays required, so the whole
-# filter must be supplied by the user.
-
-
-class MerfishSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
-    pass
-
-
-class MerfishTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = Field(
-        default=BlastnSearchParameters(
-            perc_identity=80,
-            strand="minus",
-            word_size=10,
-            dust="no",
-            soft_masking=False,
-            max_target_seqs=10,
-            max_hsps=1000,
-        ),
-        description="BLAST options for the specificity search.",
-    )
-    hit_parameters: BlastnHitParameters = Field(
-        default=BlastnHitParametersMinAlignmentLength(value=17),
-        description="Hit criteria. Hits satisfying these lead to oligo rejection.",
-    )
-
-
-MerfishTargetSpecificityBlastnFilterConfig = Annotated[
-    MerfishTargetSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
-]
-
-
-class MerfishReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=7,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
-    )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersMinAlignmentLength(value=11)
-
-
-MerfishReadoutSpecificityBlastnFilterConfig = Annotated[
-    MerfishReadoutSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled", description=SPECIFICITY_READOUT_DESC),
-]
-
-
-class MerfishPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=7,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
-    )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersMinAlignmentLength(value=14)
-
-
-MerfishPrimerSpecificityBlastnFilterConfig = Annotated[
-    MerfishPrimerSpecificityBlastnFilterEnabled | MerfishSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled", description=SPECIFICITY_PRIMER_DESC),
-]
-
 
 ############################################
 # Target probe
@@ -154,8 +75,6 @@ MerfishPrimerSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    file_region_ids: RegionListT
-    files_fasta_probe_database: FilesFastaDatabaseT
     probe_length_min: LengthMinT = Field(default=30, json_schema_extra={"x-quick-setting": True})
     probe_length_max: LengthMaxT = Field(default=30, json_schema_extra={"x-quick-setting": True})
 
@@ -191,7 +110,22 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: MerfishTargetSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=80,
+                strand="minus",
+                word_size=10,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=17),
+        ),
+        description=SPECIFICITY_TARGET_DESC,
+    )
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
         CrossHybridizationBlastnFilterEnabled(
             enabled=True,
@@ -349,7 +283,22 @@ class MerfishReadoutProbePropertyFilter(BaseModel):
 class MerfishReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: MerfishReadoutSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=11),
+        ),
+        description=SPECIFICITY_READOUT_DESC,
+    )
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
         CrossHybridizationBlastnFilterEnabled(
             enabled=True,
@@ -496,7 +445,22 @@ class MerfishForwardPrimerPropertyFilter(BaseModel):
 class MerfishForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: MerfishPrimerSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=14),
+        ),
+        description=SPECIFICITY_PRIMER_DESC,
+    )
     hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
         HybridizationProbesBlastnFilterEnabled(
             enabled=True,
@@ -588,6 +552,7 @@ class MerfishProbeDesignerConfig(BaseModel):
         write_intermediate_steps=True,
     )
 
+    required_parameters: RequiredParameters
     target_probes: TargetProbes
     readout_probes: ReadoutProbes
     primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -6,6 +6,7 @@ from typing_extensions import Self
 from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -22,7 +23,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -134,7 +134,8 @@ class TargetProbePropertyFilter(BaseModel):
     )
 
 
-class TargetProbeSpecificityFilter(BaseModel):
+# can be used to be adapted in the frontend
+class TargetProbeSpecificityFilterBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     read_length_bias_filter: ReadLengthBiasFilterConfig = ReadLengthBiasFilterEnabled(
@@ -155,6 +156,9 @@ class TargetProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_TARGET_DESC,
     )
+
+
+class TargetProbeSpecificityFilter(TargetProbeSpecificityFilterBase):
     variant_filter: OligoSeqVariantFilterConfig
 
 
@@ -223,9 +227,14 @@ class TargetProbes(BaseModel):
 ############################################
 
 
-class OligoSeqProbeDesignerConfig(BaseModel):
+# can be used to be adjusted in the frontend
+class OligoSeqProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+
+
+class OligoSeqProbeDesignerConfig(OligoSeqProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_oligo_seq_probe_designer",
@@ -233,4 +242,3 @@ class OligoSeqProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -149,13 +149,6 @@ class TargetProbeSpecificityFilterBase(BaseModel):
     read_length_bias_filter: ReadLengthBiasFilterConfig = ReadLengthBiasFilterEnabled(
         enabled=True, read_length_bias=20
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
-        CrossHybridizationBlastnFilterCoverageEnabled(
-            enabled=True,
-            search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
-            hit_parameters=BlastnHitParametersCoverage(value=50),
-        )
-    )
     specificity_blastn_filter: SpecificityBlastnFilterCoverageConfig = Field(
         default=SpecificityBlastnFilterCoverageEnabled(
             enabled=True,
@@ -163,6 +156,13 @@ class TargetProbeSpecificityFilterBase(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=50),
         ),
         description=SPECIFICITY_TARGET_DESC,
+    )
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
+            hit_parameters=BlastnHitParametersCoverage(value=50),
+        )
     )
 
 

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -5,6 +5,7 @@ from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
     BlastnHitParameters,
+    BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
@@ -73,7 +74,7 @@ class OligoSeqSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
     search_parameters: BlastnSearchParameters = BlastnSearchParameters(
         perc_identity=80, strand="minus", word_size=10
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(coverage=50)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
 
 
 OligoSeqSpecificityBlastnFilterConfig = Annotated[
@@ -163,7 +164,7 @@ class TargetProbeSpecificityFilter(BaseModel):
         CrossHybridizationBlastnFilterEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
-            hit_parameters=BlastnHitParameters(coverage=50),
+            hit_parameters=BlastnHitParametersCoverage(value=50),
         )
     )
     specificity_blastn_filter: OligoSeqSpecificityBlastnFilterConfig

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -4,11 +4,11 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
-    BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
+    RequiredParameters,
     TmChemCorrectionParameters,
     TmChemCorrectionParametersDetails,
     TmChemCorrectionParametersEnabled,
@@ -45,42 +45,24 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
     ReadLengthBiasFilterConfig,
     ReadLengthBiasFilterEnabled,
-    SpecificityBlastnFilterDisabled,
+    SpecificityBlastnFilterConfig,
     SpecificityBlastnFilterEnabled,
     VariantFilterDisabled,
     VariantFilterEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
-    FilesFastaDatabaseT,
     LengthMaxT,
     LengthMinT,
-    RegionListT,
 )
 
 ############################################
 # Oligoseq-specific overrides
 ############################################
-
-
-class OligoSeqSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
-    pass
-
-
-class OligoSeqSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=80, strand="minus", word_size=10
-    )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
-
-
-OligoSeqSpecificityBlastnFilterConfig = Annotated[
-    OligoSeqSpecificityBlastnFilterEnabled | OligoSeqSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
-]
 
 
 class OligoSeqVariantFilterDisabled(VariantFilterDisabled):
@@ -107,8 +89,6 @@ OligoSeqVariantFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    file_region_ids: RegionListT
-    files_fasta_probe_database: FilesFastaDatabaseT
     probe_length_min: LengthMinT = 26
     probe_length_max: LengthMaxT = 30
     probe_split_region: PositiveInt = Field(
@@ -167,7 +147,14 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=50),
         )
     )
-    specificity_blastn_filter: OligoSeqSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
+            hit_parameters=BlastnHitParametersCoverage(value=50),
+        ),
+        description=SPECIFICITY_TARGET_DESC,
+    )
     variant_filter: OligoSeqVariantFilterConfig
 
 
@@ -245,4 +232,5 @@ class OligoSeqProbeDesignerConfig(BaseModel):
         write_intermediate_steps=True,
     )
 
+    required_parameters: RequiredParameters
     target_probes: TargetProbes

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -46,12 +46,12 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     ReadLengthBiasFilterConfig,
     ReadLengthBiasFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
+    SpecificityBlastnFilterCoverageConfig,
+    SpecificityBlastnFilterCoverageEnabled,
     VariantFilterDisabled,
     VariantFilterEnabled,
 )
@@ -77,7 +77,8 @@ class OligoSeqVariantFilterEnabled(VariantFilterEnabled):
 
 
 OligoSeqVariantFilterConfig = Annotated[
-    OligoSeqVariantFilterEnabled | OligoSeqVariantFilterDisabled, Field(discriminator="enabled")
+    OligoSeqVariantFilterEnabled | OligoSeqVariantFilterDisabled,
+    Field(discriminator="enabled"),
 ]
 
 
@@ -89,8 +90,8 @@ OligoSeqVariantFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    probe_length_min: LengthMinT = 26
-    probe_length_max: LengthMaxT = 30
+    probe_length_min: LengthMinT = Field(default=26, json_schema_extra={"x-quick-setting": True})
+    probe_length_max: LengthMaxT = Field(default=30, json_schema_extra={"x-quick-setting": True})
     probe_split_region: PositiveInt = Field(
         description="Minimum number of bases covering the exon junction, i.e. the oligo should contain at least x bases upstream/downstream of the junction.",
         default=4,
@@ -115,7 +116,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=6, T=6, C=6, G=6),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=45, GC_content_max=65
@@ -141,15 +143,15 @@ class TargetProbeSpecificityFilterBase(BaseModel):
     read_length_bias_filter: ReadLengthBiasFilterConfig = ReadLengthBiasFilterEnabled(
         enabled=True, read_length_bias=20
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
             hit_parameters=BlastnHitParametersCoverage(value=50),
         )
     )
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterCoverageConfig = Field(
+        default=SpecificityBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(perc_identity=80, strand="minus", word_size=10),
             hit_parameters=BlastnHitParametersCoverage(value=50),
@@ -227,7 +229,7 @@ class TargetProbes(BaseModel):
 ############################################
 
 
-# can be used to be adjusted in the frontend
+# The front end builds its form from this, so `general` stays out of it.
 class OligoSeqProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2

--- a/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/oligo_seq_probe_designer.py
@@ -4,6 +4,11 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
@@ -17,6 +22,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
@@ -217,11 +223,11 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -243,4 +249,4 @@ class OligoSeqProbeDesignerConfig(OligoSeqProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -168,6 +168,7 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    specificity_blastn_filter: ScrinshotSpecificityBlastnFilterConfig
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
         CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
@@ -182,7 +183,6 @@ class TargetProbeSpecificityFilter(BaseModel):
             hit_parameters=BlastnHitParametersCoverage(value=80),
         )
     )
-    specificity_blastn_filter: ScrinshotSpecificityBlastnFilterConfig
 
 
 class TargetProbeProbeSetSelection(BaseModel):

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -17,6 +17,7 @@ from oligo_designer_toolsuite.config._general_models import (
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
+    RequiredParameters,
     TmChemCorrectionParameters,
     TmChemCorrectionParametersDetails,
     TmChemCorrectionParametersEnabled,
@@ -43,16 +44,15 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterConfig,
     CrossHybridizationBlastnFilterEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
-    FilesFastaDatabaseT,
     LengthMaxT,
     LengthMinT,
-    RegionListT,
     TmMaxT,
     TmMinT,
     TmOptT,
@@ -61,10 +61,6 @@ from oligo_designer_toolsuite.config._types import (
 ############################################
 # SCRINSHOT-specific overrides
 ############################################
-
-
-class ScrinshotSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
-    pass
 
 
 class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
@@ -90,8 +86,8 @@ class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
 
 
 ScrinshotSpecificityBlastnFilterConfig = Annotated[
-    ScrinshotSpecificityBlastnFilterEnabled | ScrinshotSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled"),
+    ScrinshotSpecificityBlastnFilterEnabled | SpecificityBlastnFilterDisabled,
+    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
 ]
 
 
@@ -103,8 +99,6 @@ ScrinshotSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    file_region_ids: RegionListT
-    files_fasta_probe_database: FilesFastaDatabaseT
     probe_length_min: LengthMinT = 40
     probe_length_max: LengthMaxT = 45
 
@@ -315,5 +309,6 @@ class ScrinshotProbeDesignerConfig(BaseModel):
         write_intermediate_steps=True,
     )
 
+    required_parameters: RequiredParameters
     target_probes: TargetProbes
     detection_oligo: DetectionOligo

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -14,6 +14,7 @@ from typing_extensions import Self
 from oligo_designer_toolsuite.config._general_models import (
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     SPECIFICITY_FILTERS_DESC,
@@ -31,7 +32,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
@@ -50,6 +50,8 @@ from oligo_designer_toolsuite.config._property_filters import (
     TmFilterEnabled,
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
+    SPECIFICITY_HIT_PARAMS_DESC,
+    SPECIFICITY_SEARCH_PARAMS_DESC,
     SPECIFICITY_TARGET_DESC,
     CrossHybridizationBlastnFilterCoverageConfig,
     CrossHybridizationBlastnFilterCoverageEnabled,
@@ -83,10 +85,13 @@ class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
             max_target_seqs=10,
             max_hsps=1000,
         ),
-        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        description=SPECIFICITY_SEARCH_PARAMS_DESC,
         json_schema_extra={"x-collapsed": True},
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
+    hit_parameters: BlastnHitParameters = Field(
+        default=BlastnHitParametersCoverage(value=50),
+        description=SPECIFICITY_HIT_PARAMS_DESC,
+    )
     ligation_region_size: NonNegativeInt = Field(
         description=(
             "Size of the seed region around the ligation site for BLASTN seed-region filtering. "

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
     BlastnHitParameters,
+    BlastnHitParametersCoverage,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
@@ -76,7 +77,7 @@ class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
         max_target_seqs=10,
         max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(coverage=50)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
     ligation_region_size: NonNegativeInt = Field(
         description=(
             "Size of the seed region around the ligation site for BLASTN seed-region filtering. "
@@ -170,7 +171,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(coverage=80),
+            hit_parameters=BlastnHitParametersCoverage(value=80),
         )
     )
     specificity_blastn_filter: ScrinshotSpecificityBlastnFilterConfig

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -12,6 +12,11 @@ from pydantic import (
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BlastnHitParameters,
     BlastnHitParametersCoverage,
     BlastnSearchParameters,
@@ -26,6 +31,7 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
+    PROBE_SET_SELECTION_DESC,
     GCContentScoreNormalized,
     IndependentSetSelection,
     IsoformConsensusScore,
@@ -57,6 +63,9 @@ from oligo_designer_toolsuite.config._types import (
     TmMinT,
     TmOptT,
 )
+
+PADLOCK_ARMS_PROPERTIES_DESC = "Parameters that determine properties of the padlock arms."
+DETECTION_OLIGO_GENERATION_DESC = "Parameters that determine length and melting temperature of the probes."
 
 ############################################
 # SCRINSHOT-specific overrides
@@ -228,12 +237,12 @@ class TargetProbeGlobal(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    padlock_arms_properties: PadlockArmsProperties
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
-    probe_set_selection: TargetProbeProbeSetSelection
-    global_parameters: TargetProbeGlobal
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    padlock_arms_properties: PadlockArmsProperties = Field(description=PADLOCK_ARMS_PROPERTIES_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
+    probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
+    global_parameters: TargetProbeGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -298,8 +307,8 @@ class DetectionOligoGlobal(BaseModel):
 class DetectionOligo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: DetectionOligoOligoGeneration
-    global_parameters: DetectionOligoGlobal
+    oligo_generation: DetectionOligoOligoGeneration = Field(description=DETECTION_OLIGO_GENERATION_DESC)
+    global_parameters: DetectionOligoGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 ############################################
@@ -322,4 +331,4 @@ class ScrinshotProbeDesignerConfig(ScrinshotProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -64,14 +64,18 @@ from oligo_designer_toolsuite.config._types import (
 
 
 class ScrinshotSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=80,
-        strand="minus",
-        word_size=10,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
+    search_parameters: BlastnSearchParameters = Field(
+        default=BlastnSearchParameters(
+            perc_identity=80,
+            strand="minus",
+            word_size=10,
+            dust="no",
+            soft_masking=False,
+            max_target_seqs=10,
+            max_hsps=1000,
+        ),
+        description=SpecificityBlastnFilterEnabled.model_fields["search_parameters"].description,
+        json_schema_extra={"x-collapsed": True},
     )
     hit_parameters: BlastnHitParameters = BlastnHitParametersCoverage(value=50)
     ligation_region_size: NonNegativeInt = Field(

--- a/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/scrinshot_probe_designer.py
@@ -45,8 +45,8 @@ from oligo_designer_toolsuite.config._property_filters import (
 )
 from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterCoverageConfig,
+    CrossHybridizationBlastnFilterCoverageEnabled,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
@@ -99,8 +99,8 @@ ScrinshotSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    probe_length_min: LengthMinT = 40
-    probe_length_max: LengthMaxT = 45
+    probe_length_min: LengthMinT = Field(default=40, json_schema_extra={"x-quick-setting": True})
+    probe_length_max: LengthMaxT = Field(default=45, json_schema_extra={"x-quick-setting": True})
 
     @model_validator(mode="after")
     def _check_min_max(self) -> Self:
@@ -143,7 +143,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=40, GC_content_max=60
@@ -154,8 +155,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterCoverageConfig = (
+        CrossHybridizationBlastnFilterCoverageEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -242,12 +243,14 @@ class DetectionOligoOligoGeneration(BaseModel):
     min_thymines: PositiveInt = Field(
         description="Minimal number of thymines (T) in the detection oligo (required for UNG cleavage after U-substitution).",
         default=2,
+        json_schema_extra={"x-quick-setting": True},
     )
-    oligo_length_min: LengthMinT = 15
-    oligo_length_max: LengthMaxT = 40
+    oligo_length_min: LengthMinT = Field(default=15, json_schema_extra={"x-quick-setting": True})
+    oligo_length_max: LengthMaxT = Field(default=40, json_schema_extra={"x-quick-setting": True})
     U_distance: PositiveInt = Field(
         description="Preferred minimum distance (bases) between consecutive uracils.",
         default=5,
+        json_schema_extra={"x-quick-setting": True},
     )
     Tm_opt: TmOptT = 56
 
@@ -300,9 +303,15 @@ class DetectionOligo(BaseModel):
 ############################################
 
 
-class ScrinshotProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class ScrinshotProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    detection_oligo: DetectionOligo
+
+
+class ScrinshotProbeDesignerConfig(ScrinshotProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_scrinshot_probe_designer",
@@ -310,5 +319,3 @@ class ScrinshotProbeDesignerConfig(BaseModel):
     )
 
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    detection_oligo: DetectionOligo

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -52,12 +52,12 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     SPECIFICITY_PRIMER_DESC,
     SPECIFICITY_READOUT_DESC,
     SPECIFICITY_TARGET_DESC,
-    CrossHybridizationBlastnFilterConfig,
-    CrossHybridizationBlastnFilterEnabled,
-    HybridizationProbesBlastnFilterConfig,
-    HybridizationProbesBlastnFilterEnabled,
-    SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterEnabled,
+    CrossHybridizationBlastnFilterMinAlignmentConfig,
+    CrossHybridizationBlastnFilterMinAlignmentEnabled,
+    HybridizationProbesBlastnFilterMinAlignmentConfig,
+    HybridizationProbesBlastnFilterMinAlignmentEnabled,
+    SpecificityBlastnFilterMinAlignmentConfig,
+    SpecificityBlastnFilterMinAlignmentEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
@@ -94,7 +94,8 @@ class TargetProbePropertyFilter(BaseModel):
     hard_masked_sequences_filter: HardMaskedFilterConfig = HardMaskedFilterConfig(enabled=True)
     soft_masked_sequences_filter: SoftMaskedFilterConfig = SoftMaskedFilterConfig(enabled=True)
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=5, T=5, C=5, G=5),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=45, GC_content_max=65
@@ -107,8 +108,8 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -123,8 +124,8 @@ class TargetProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_TARGET_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=80,
@@ -196,7 +197,6 @@ class SeqfishPlusCodebookBase(BaseModel):
 
 
 class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
-
     source: Literal["load"] = "load"
     file: str = Field(
         description="Only used when source = load. Path to the codebook file (csv/tsv): columns = 'bits', rows = 'gene_name'; entries are 0/1 bit-encodings for each gene."
@@ -204,7 +204,6 @@ class SeqfishPlusCodebookLoad(SeqfishPlusCodebookBase):
 
 
 class SeqfishPlusCodebookGenerate(SeqfishPlusCodebookBase):
-
     source: Literal["generate"] = "generate"
 
 
@@ -256,8 +255,8 @@ class SeqfishPlusReadoutProbePropertyFilter(BaseModel):
 class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -272,8 +271,8 @@ class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_READOUT_DESC,
     )
-    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
-        CrossHybridizationBlastnFilterEnabled(
+    cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterMinAlignmentConfig = (
+        CrossHybridizationBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -350,7 +349,8 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     homopolymeric_runs_filter: HomopolymericRunsFilterConfig = HomopolymericRunsFilterEnabled(
-        enabled=True, homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4)
+        enabled=True,
+        homopolymeric_base_n=HomopolymericRunThreshold(A=4, T=4, C=4, G=4),
     )
     GC_content_filter: GCContentFilterConfig = GCContentFilterEnabled(
         enabled=True, GC_content_min=50, GC_content_max=65
@@ -373,8 +373,8 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
 class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
-        default=SpecificityBlastnFilterEnabled(
+    specificity_blastn_filter: SpecificityBlastnFilterMinAlignmentConfig = Field(
+        default=SpecificityBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -389,8 +389,8 @@ class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
         ),
         description=SPECIFICITY_PRIMER_DESC,
     )
-    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
-        HybridizationProbesBlastnFilterEnabled(
+    hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterMinAlignmentConfig = (
+        HybridizationProbesBlastnFilterMinAlignmentEnabled(
             enabled=True,
             search_parameters=BlastnSearchParameters(
                 perc_identity=100,
@@ -471,15 +471,20 @@ class Primers(BaseModel):
 ############################################
 
 
-class SeqfishPlusProbeDesignerConfig(BaseModel):
+# The front end builds its form from this, so `general` stays out of it.
+class SeqfishPlusProbeDesignerConfigBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
     schema_version: Literal[2] = 2
+    target_probes: TargetProbes
+    readout_probes: ReadoutProbes
+    primers: Primers
+
+
+class SeqfishPlusProbeDesignerConfig(SeqfishPlusProbeDesignerConfigBase):
     general: General = General(
         n_jobs=4,
         dir_output="output_SeqfishPlusplus_probe_designer",
         write_intermediate_steps=True,
     )
+
     required_parameters: RequiredParameters
-    target_probes: TargetProbes
-    readout_probes: ReadoutProbes
-    primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -11,11 +11,11 @@ from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
     BaseProbabilities,
-    BlastnHitParameters,
     BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
+    RequiredParameters,
     TmChemCorrectionParameters,
     TmChemCorrectionParametersDisabled,
     TmParameters,
@@ -57,63 +57,13 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     HybridizationProbesBlastnFilterConfig,
     HybridizationProbesBlastnFilterEnabled,
     SpecificityBlastnFilterConfig,
-    SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
-    FilesFastaDatabaseT,
-    FilesFastaReferenceDatabaseT,
     LengthMaxT,
     LengthMinT,
-    RegionListT,
 )
-
-############################################
-# seqFISH+-specific overrides
-############################################
-
-# The specificity BLASTN filter carries a required reference-database path
-# (files_fasta_reference_database, no default). These subclasses only set the
-# seqFISH+ default search/hit parameters; the path stays required, so the whole
-# filter must be supplied by the user.
-
-
-class SeqfishPlusSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
-    pass
-
-
-class SeqfishPlusPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=7,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
-    )
-    hit_parameters: BlastnHitParameters = BlastnHitParametersMinAlignmentLength(value=14)
-
-
-SeqfishPlusPrimerSpecificityBlastnFilterConfig = Annotated[
-    SeqfishPlusPrimerSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled", description=SPECIFICITY_PRIMER_DESC),
-]
-
-
-############################################
-# Required parameters
-############################################
-
-
-class RequiredParameters(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    targets: RegionListT
-    target_genome: FilesFastaDatabaseT
-    reference_genome: FilesFastaReferenceDatabaseT
-
 
 ############################################
 # Target probe

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -12,6 +12,7 @@ from typing_extensions import Self
 from oligo_designer_toolsuite.config._general_models import (
     BaseProbabilities,
     BlastnHitParameters,
+    BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
     General,
     HomopolymericRunThreshold,
@@ -92,7 +93,7 @@ class SeqfishPlusPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEna
         max_target_seqs=10,
         max_hsps=1000,
     )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=14)
+    hit_parameters: BlastnHitParameters = BlastnHitParametersMinAlignmentLength(value=14)
 
 
 SeqfishPlusPrimerSpecificityBlastnFilterConfig = Annotated[
@@ -168,7 +169,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
                 max_hsps=1000,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=15),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=15),
         ),
         description=SPECIFICITY_TARGET_DESC,
     )
@@ -183,7 +184,7 @@ class TargetProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=17),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=17),
         )
     )
 
@@ -317,7 +318,7 @@ class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
                 max_target_seqs=10,
                 max_hsps=1000,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=10),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=10),
         ),
         description=SPECIFICITY_READOUT_DESC,
     )
@@ -332,7 +333,7 @@ class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
                 soft_masking=False,
                 max_target_seqs=10,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=10),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=10),
         )
     )
 
@@ -434,7 +435,7 @@ class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
                 max_target_seqs=10,
                 max_hsps=1000,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=14),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=14),
         ),
         description=SPECIFICITY_PRIMER_DESC,
     )
@@ -450,7 +451,7 @@ class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
                 max_target_seqs=10,
                 max_hsps=1000,
             ),
-            hit_parameters=BlastnHitParameters(min_alignment_length=11),
+            hit_parameters=BlastnHitParametersMinAlignmentLength(value=11),
         )
     )
 

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -298,10 +298,14 @@ class SeqfishPlusReadoutProbeTableGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration
-    property_filters: SeqfishPlusReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    oligo_generation: SeqfishPlusReadoutProbeOligoGeneration = Field(json_schema_extra={"x-collapsed": True})
+    property_filters: SeqfishPlusReadoutProbePropertyFilter = Field(
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
     specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter = Field(
-        description=SPECIFICITY_FILTERS_DESC
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
     )
 
 
@@ -444,12 +448,19 @@ class SeqfishPlusForwardPrimerGenerate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     source: Literal["generate"] = "generate"
-    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration
-    property_filters: SeqfishPlusForwardPrimerPropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
-    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter = Field(
-        description=SPECIFICITY_FILTERS_DESC
+    oligo_generation: SeqfishPlusForwardPrimerOligoGeneration = Field(json_schema_extra={"x-collapsed": True})
+    property_filters: SeqfishPlusForwardPrimerPropertyFilter = Field(
+        description=PROPERTY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
     )
-    global_parameters: SeqfishPlusForwardPrimerGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
+    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
+    global_parameters: SeqfishPlusForwardPrimerGlobal = Field(
+        description=GLOBAL_PARAMETERS_DESC,
+        json_schema_extra={"x-collapsed": True},
+    )
 
 
 SeqfishPlusForwardPrimer = Annotated[

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -55,12 +55,14 @@ from oligo_designer_toolsuite.config._specificity_filters import (
     CrossHybridizationBlastnFilterEnabled,
     HybridizationProbesBlastnFilterConfig,
     HybridizationProbesBlastnFilterEnabled,
+    SpecificityBlastnFilterConfig,
     SpecificityBlastnFilterDisabled,
     SpecificityBlastnFilterEnabled,
 )
 from oligo_designer_toolsuite.config._types import (
     DRNAT,
     FilesFastaDatabaseT,
+    FilesFastaReferenceDatabaseT,
     LengthMaxT,
     LengthMinT,
     RegionListT,
@@ -78,44 +80,6 @@ from oligo_designer_toolsuite.config._types import (
 
 class SeqfishPlusSpecificityBlastnFilterDisabled(SpecificityBlastnFilterDisabled):
     pass
-
-
-class SeqfishPlusTargetSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=7,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
-    )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=15)
-
-
-SeqfishPlusTargetSpecificityBlastnFilterConfig = Annotated[
-    SeqfishPlusTargetSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled", description=SPECIFICITY_TARGET_DESC),
-]
-
-
-class SeqfishPlusReadoutSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
-    search_parameters: BlastnSearchParameters = BlastnSearchParameters(
-        perc_identity=100,
-        strand="minus",
-        word_size=7,
-        dust="no",
-        soft_masking=False,
-        max_target_seqs=10,
-        max_hsps=1000,
-    )
-    hit_parameters: BlastnHitParameters = BlastnHitParameters(min_alignment_length=10)
-
-
-SeqfishPlusReadoutSpecificityBlastnFilterConfig = Annotated[
-    SeqfishPlusReadoutSpecificityBlastnFilterEnabled | SeqfishPlusSpecificityBlastnFilterDisabled,
-    Field(discriminator="enabled", description=SPECIFICITY_READOUT_DESC),
-]
 
 
 class SeqfishPlusPrimerSpecificityBlastnFilterEnabled(SpecificityBlastnFilterEnabled):
@@ -138,6 +102,19 @@ SeqfishPlusPrimerSpecificityBlastnFilterConfig = Annotated[
 
 
 ############################################
+# Required parameters
+############################################
+
+
+class RequiredParameters(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    targets: RegionListT
+    target_genome: FilesFastaDatabaseT
+    reference_genome: FilesFastaReferenceDatabaseT
+
+
+############################################
 # Target probe
 ############################################
 
@@ -145,8 +122,6 @@ SeqfishPlusPrimerSpecificityBlastnFilterConfig = Annotated[
 class TargetProbeOligoGeneration(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    file_region_ids: RegionListT
-    files_fasta_probe_database: FilesFastaDatabaseT
     probe_length_min: LengthMinT = Field(default=28, json_schema_extra={"x-quick-setting": True})
     probe_length_max: LengthMaxT = Field(default=28, json_schema_extra={"x-quick-setting": True})
 
@@ -181,7 +156,22 @@ class TargetProbePropertyFilter(BaseModel):
 class TargetProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusTargetSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=15),
+        ),
+        description=SPECIFICITY_TARGET_DESC,
+    )
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
         CrossHybridizationBlastnFilterEnabled(
             enabled=True,
@@ -315,7 +305,22 @@ class SeqfishPlusReadoutProbePropertyFilter(BaseModel):
 class SeqfishPlusReadoutProbeSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusReadoutSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=10),
+        ),
+        description=SPECIFICITY_READOUT_DESC,
+    )
     cross_hybridization_blastn_filter: CrossHybridizationBlastnFilterConfig = (
         CrossHybridizationBlastnFilterEnabled(
             enabled=True,
@@ -417,7 +422,22 @@ class SeqfishPlusForwardPrimerPropertyFilter(BaseModel):
 class SeqfishPlusForwardPrimerSpecificityFilter(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    specificity_blastn_filter: SeqfishPlusPrimerSpecificityBlastnFilterConfig
+    specificity_blastn_filter: SpecificityBlastnFilterConfig = Field(
+        default=SpecificityBlastnFilterEnabled(
+            enabled=True,
+            search_parameters=BlastnSearchParameters(
+                perc_identity=100,
+                strand="minus",
+                word_size=7,
+                dust="no",
+                soft_masking=False,
+                max_target_seqs=10,
+                max_hsps=1000,
+            ),
+            hit_parameters=BlastnHitParameters(min_alignment_length=14),
+        ),
+        description=SPECIFICITY_PRIMER_DESC,
+    )
     hybridization_probes_blastn_filter: HybridizationProbesBlastnFilterConfig = (
         HybridizationProbesBlastnFilterEnabled(
             enabled=True,
@@ -508,7 +528,7 @@ class SeqfishPlusProbeDesignerConfig(BaseModel):
         dir_output="output_SeqfishPlusplus_probe_designer",
         write_intermediate_steps=True,
     )
-
+    required_parameters: RequiredParameters
     target_probes: TargetProbes
     readout_probes: ReadoutProbes
     primers: Primers

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -10,6 +10,13 @@ from pydantic import (
 from typing_extensions import Self
 
 from oligo_designer_toolsuite.config._general_models import (
+    FORWARD_PRIMER_DESC,
+    GLOBAL_PARAMETERS_DESC,
+    OLIGO_GENERATION_DESC,
+    PROPERTY_FILTERS_DESC,
+    REQUIRED_PARAMETERS_DESC,
+    REVERSE_PRIMER_DESC,
+    SPECIFICITY_FILTERS_DESC,
     BaseProbabilities,
     BlastnHitParametersMinAlignmentLength,
     BlastnSearchParameters,
@@ -161,9 +168,9 @@ class TargetProbeProbeSetSelection(BaseModel):
 class TargetProbes(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    oligo_generation: TargetProbeOligoGeneration
-    property_filters: TargetProbePropertyFilter
-    specificity_filters: TargetProbeSpecificityFilter
+    oligo_generation: TargetProbeOligoGeneration = Field(description=OLIGO_GENERATION_DESC)
+    property_filters: TargetProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: TargetProbeSpecificityFilter = Field(description=SPECIFICITY_FILTERS_DESC)
     probe_set_selection: TargetProbeProbeSetSelection = Field(description=PROBE_SET_SELECTION_DESC)
 
 
@@ -292,8 +299,10 @@ class SeqfishPlusReadoutProbeTableGenerate(BaseModel):
 
     source: Literal["generate"] = "generate"
     oligo_generation: SeqfishPlusReadoutProbeOligoGeneration
-    property_filters: SeqfishPlusReadoutProbePropertyFilter
-    specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter
+    property_filters: SeqfishPlusReadoutProbePropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: SeqfishPlusReadoutProbeSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC
+    )
 
 
 SeqfishPlusReadoutProbeTable = Annotated[
@@ -436,9 +445,11 @@ class SeqfishPlusForwardPrimerGenerate(BaseModel):
 
     source: Literal["generate"] = "generate"
     oligo_generation: SeqfishPlusForwardPrimerOligoGeneration
-    property_filters: SeqfishPlusForwardPrimerPropertyFilter
-    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter
-    global_parameters: SeqfishPlusForwardPrimerGlobal
+    property_filters: SeqfishPlusForwardPrimerPropertyFilter = Field(description=PROPERTY_FILTERS_DESC)
+    specificity_filters: SeqfishPlusForwardPrimerSpecificityFilter = Field(
+        description=SPECIFICITY_FILTERS_DESC
+    )
+    global_parameters: SeqfishPlusForwardPrimerGlobal = Field(description=GLOBAL_PARAMETERS_DESC)
 
 
 SeqfishPlusForwardPrimer = Annotated[
@@ -462,8 +473,8 @@ class SeqfishPlusReversePrimer(BaseModel):
 class Primers(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    forward_primer: SeqfishPlusForwardPrimer
-    reverse_primer: SeqfishPlusReversePrimer
+    forward_primer: SeqfishPlusForwardPrimer = Field(description=FORWARD_PRIMER_DESC)
+    reverse_primer: SeqfishPlusReversePrimer = Field(description=REVERSE_PRIMER_DESC)
 
 
 ############################################
@@ -487,4 +498,4 @@ class SeqfishPlusProbeDesignerConfig(SeqfishPlusProbeDesignerConfigBase):
         write_intermediate_steps=True,
     )
 
-    required_parameters: RequiredParameters
+    required_parameters: RequiredParameters = Field(description=REQUIRED_PARAMETERS_DESC)

--- a/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/config/pipelines/seqfish_plus_probe_designer.py
@@ -13,6 +13,7 @@ from oligo_designer_toolsuite.config._general_models import (
     FORWARD_PRIMER_DESC,
     GLOBAL_PARAMETERS_DESC,
     OLIGO_GENERATION_DESC,
+    PROBE_SET_SELECTION_DESC,
     PROPERTY_FILTERS_DESC,
     REQUIRED_PARAMETERS_DESC,
     REVERSE_PRIMER_DESC,
@@ -30,7 +31,6 @@ from oligo_designer_toolsuite.config._general_models import (
     TmSaltCorrectionParametersDisabled,
 )
 from oligo_designer_toolsuite.config._oligo_scoring import (
-    PROBE_SET_SELECTION_DESC,
     GCContentScore,
     IndependentSetSelection,
     UTRScore,

--- a/oligo_designer_toolsuite/oligo_property_filter/_filter_experiment_unspecific.py
+++ b/oligo_designer_toolsuite/oligo_property_filter/_filter_experiment_unspecific.py
@@ -146,7 +146,7 @@ class HomopolymericRunsFilter(BasePropertyFilter):
                     f"DNA sequences must contain only A, C, T, G (and optionally U) characters."
                 )
         # create all homopolymeric runs
-        self.homopolymeric_runs = [base.upper() * n for base, n in base_n.items()]
+        self.homopolymeric_runs = [base.upper() * n for base, n in base_n.items() if n is not None]
 
     def apply(self, sequence: str) -> bool:
         """

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -171,8 +171,19 @@ class BlastNFilter(AlignmentSpecificityFilter):
         ]
 
         for parameter, value in self.search_parameters.items():
-            args.append(parameter)
-            if str(value) != "":
+            # - search_parameters only contains parameters that are not None
+            # - parameters that have a string/numeric value are always included
+            # - flags can be enabled with True but are still contained when set
+            # to False, so we need to check for that
+            # - soft_masking is a parameter that expects True/False, so we need to keep that
+            if parameter == "-soft_masking":
+                args.append(parameter)
+                args.append(str(value).lower())  # BLAST uses lower case boolean
+            elif isinstance(value, bool):
+                if value:
+                    args.append(parameter)
+            else:
+                args.append(parameter)
                 args.append(str(value))
 
         subprocess.run(args, cwd=self.dir_output, check=True, stdout=subprocess.DEVNULL)

--- a/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
+++ b/oligo_designer_toolsuite/oligo_specificity_filter/_filter_blastn.py
@@ -19,7 +19,6 @@ from oligo_designer_toolsuite.oligo_property_calculator import (
     SeedregionSiteProperty,
 )
 from oligo_designer_toolsuite.oligo_specificity_filter import AlignmentSpecificityFilter
-from oligo_designer_toolsuite.utils import logger
 from oligo_designer_toolsuite.utils._checkers_and_helpers import safe_append_filename
 
 from ..utils._sequence_processor import get_sequence_from_annotation
@@ -69,25 +68,30 @@ class BlastNFilter(AlignmentSpecificityFilter):
 
     def __init__(
         self,
+        *,
         remove_hits: bool = True,
-        search_parameters: dict = {},
-        hit_parameters: dict = {},
-        names_search_output: list = [
-            "query",
-            "reference",
-            "alignment_length",
-            "query_start",
-            "query_end",
-            "query_length",
-        ],
+        search_parameters: dict | None = None,
+        hit_parameters: dict,
+        names_search_output: list | None = None,
         filter_name: str = "blast_filter",
         dir_output: str = "output",
     ) -> None:
         """Constructor for the BlastNFilter class."""
         super().__init__(remove_hits, filter_name, dir_output)
 
+        if not search_parameters:
+            search_parameters = {}
         self.search_parameters = search_parameters
         self.hit_parameters = hit_parameters
+        if not names_search_output:
+            names_search_output = [
+                "query",
+                "reference",
+                "alignment_length",
+                "query_start",
+                "query_end",
+                "query_length",
+            ]
         self.names_search_output = names_search_output
 
         # Define default output format for blast search filter. The fields are:
@@ -226,17 +230,16 @@ class BlastNFilter(AlignmentSpecificityFilter):
         :return: A DataFrame containing the filtered BLAST search hits.
         :rtype: pd.DataFrame
         """
-        if "min_alignment_length" in self.hit_parameters.keys():
-            if "coverage" in self.hit_parameters.keys():
-                logger.warning(
-                    "Both, 'min_alignment_length' and 'coverage' parameters were provided. Using 'min_alignment_length' parameter."
-                )
-            min_alignment_length = self.hit_parameters["min_alignment_length"]
-        elif "coverage" in self.hit_parameters.keys():
-            min_alignment_length = search_results["query_length"] * self.hit_parameters["coverage"] / 100
+        if "hit_criterion" not in self.hit_parameters.keys() or "value" not in self.hit_parameters.keys():
+            raise ConfigurationError(f"You need to provide 'hit_criterion' and 'value'.")
+        hit_criterion = self.hit_parameters["hit_criterion"]
+        if hit_criterion == "coverage":
+            min_alignment_length = search_results["query_length"] * self.hit_parameters["value"] / 100
+        elif hit_criterion == "min_alignment_length":
+            min_alignment_length = self.hit_parameters["value"]
         else:
             raise ConfigurationError(
-                "Please provide either 'coverage' or a 'min_alignment_length' in hit_parameters!"
+                f"Unknown hit_criterion '{hit_criterion}', expected 'coverage' or 'min_alignment_length'."
             )
 
         search_results["min_alignment_length"] = min_alignment_length
@@ -525,9 +528,10 @@ class BlastNSeedregionFilterBase(BlastNFilter):
 
     def __init__(
         self,
+        *,
         remove_hits: bool = True,
         search_parameters: dict | None = None,
-        hit_parameters: dict | None = None,
+        hit_parameters: dict,
         names_search_output: list | None = None,
         filter_name: str = "blast_filter",
         dir_output: str = "output",
@@ -535,8 +539,6 @@ class BlastNSeedregionFilterBase(BlastNFilter):
         """Constructor for the BlastNSeedregionFilterBase class."""
         if not search_parameters:
             search_parameters = {}
-        if not hit_parameters:
-            hit_parameters = {}
         if not names_search_output:
             names_search_output = [
                 "query",
@@ -547,12 +549,12 @@ class BlastNSeedregionFilterBase(BlastNFilter):
                 "query_length",
             ]
         super().__init__(
-            remove_hits,
-            search_parameters,
-            hit_parameters,
-            names_search_output,
-            filter_name,
-            dir_output,
+            remove_hits=remove_hits,
+            search_parameters=search_parameters,
+            hit_parameters=hit_parameters,
+            names_search_output=names_search_output,
+            filter_name=filter_name,
+            dir_output=dir_output,
         )
 
     @abstractmethod
@@ -599,17 +601,16 @@ class BlastNSeedregionFilterBase(BlastNFilter):
         :return: Filtered BLAST search results containing significant hits.
         :rtype: pd.DataFrame
         """
-        if "min_alignment_length" in self.hit_parameters.keys():
-            if "coverage" in self.hit_parameters.keys():
-                logger.warning(
-                    "Both, 'min_alignment_length' and 'coverage' parameters were provided. Using 'min_alignment_length' parameter."
-                )
-            min_alignment_length = self.hit_parameters["min_alignment_length"]
-        elif "coverage" in self.hit_parameters.keys():
-            min_alignment_length = search_results["query_length"] * self.hit_parameters["coverage"] / 100
+        if "hit_criterion" not in self.hit_parameters.keys() or "value" not in self.hit_parameters.keys():
+            raise ConfigurationError(f"You need to provide 'hit_criterion' and 'value'.")
+        hit_criterion = self.hit_parameters["hit_criterion"]
+        if hit_criterion == "coverage":
+            min_alignment_length = search_results["query_length"] * self.hit_parameters["value"] / 100
+        elif hit_criterion == "min_alignment_length":
+            min_alignment_length = self.hit_parameters["value"]
         else:
             raise ConfigurationError(
-                "Please provide either 'coverage' or a 'min_alignment_length' in hit_parameters!"
+                f"Unknown hit_criterion '{hit_criterion}', expected 'coverage' or 'min_alignment_length'."
             )
 
         search_results["min_alignment_length"] = min_alignment_length
@@ -682,11 +683,12 @@ class BlastNSeedregionFilter(BlastNSeedregionFilterBase):
 
     def __init__(
         self,
+        *,
         seedregion_start: int | float,
         seedregion_end: int | float,
         remove_hits: bool = True,
         search_parameters: dict | None = None,
-        hit_parameters: dict | None = None,
+        hit_parameters: dict,
         names_search_output: list | None = None,
         filter_name: str = "blast_filter",
         dir_output: str = "output",
@@ -694,8 +696,6 @@ class BlastNSeedregionFilter(BlastNSeedregionFilterBase):
         """Constructor for the BlastNSeedregionFilter class."""
         if not search_parameters:
             search_parameters = {}
-        if not hit_parameters:
-            hit_parameters = {}
         if not names_search_output:
             names_search_output = [
                 "query",
@@ -706,12 +706,12 @@ class BlastNSeedregionFilter(BlastNSeedregionFilterBase):
                 "query_length",
             ]
         super().__init__(
-            remove_hits,
-            search_parameters,
-            hit_parameters,
-            names_search_output,
-            filter_name,
-            dir_output,
+            remove_hits=remove_hits,
+            search_parameters=search_parameters,
+            hit_parameters=hit_parameters,
+            names_search_output=names_search_output,
+            filter_name=filter_name,
+            dir_output=dir_output,
         )
 
         self.seedregion_start = seedregion_start
@@ -802,30 +802,35 @@ class BlastNSeedregionSiteFilter(BlastNSeedregionFilterBase):
 
     def __init__(
         self,
+        *,
         seedregion_size: int,
         seedregion_site_name: str,
         remove_hits: bool = True,
-        search_parameters: dict = {},
-        hit_parameters: dict = {},
-        names_search_output: list = [
-            "query",
-            "reference",
-            "alignment_length",
-            "query_start",
-            "query_end",
-            "query_length",
-        ],
+        search_parameters: dict | None = None,
+        hit_parameters: dict,
+        names_search_output: list | None = None,
         filter_name: str = "blast_filter",
         dir_output: str = "output",
     ) -> None:
         """Constructor for the BlastNSeedregionSiteFilter class."""
+        if not search_parameters:
+            search_parameters = {}
+        if not names_search_output:
+            names_search_output = [
+                "query",
+                "reference",
+                "alignment_length",
+                "query_start",
+                "query_end",
+                "query_length",
+            ]
         super().__init__(
-            remove_hits,
-            search_parameters,
-            hit_parameters,
-            names_search_output,
-            filter_name,
-            dir_output,
+            remove_hits=remove_hits,
+            search_parameters=search_parameters,
+            hit_parameters=hit_parameters,
+            names_search_output=names_search_output,
+            filter_name=filter_name,
+            dir_output=dir_output,
         )
         self.seedregion_size = seedregion_size
         self.seedregion_site_name = seedregion_site_name

--- a/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_cycle_hcr_probe_designer.py
@@ -70,6 +70,7 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     SpecificityFilter,
 )
 from oligo_designer_toolsuite.pipelines._utils import (
+    apply_required_parameters,
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
@@ -1883,6 +1884,8 @@ def _preprocess_config(config_validated: CycleHcrProbeDesignerConfig) -> dict[st
     list of target regions. If no gene list is provided, all regions in the input
     FASTA files are used.
 
+    Lastly, it inserts the parameters from required_parameters into the correct sections.
+
     :param config_validated: Validated pipeline configuration (pydantic model).
     :type config_validated: CycleHcrProbeDesignerConfig
     :return: The configuration converted to a dict, updated with the prepared settings.
@@ -1890,6 +1893,8 @@ def _preprocess_config(config_validated: CycleHcrProbeDesignerConfig) -> dict[st
     """
 
     config = config_validated.model_dump()
+
+    apply_required_parameters(config)
 
     # Resolve Tm table names and blank disabled chem/salt corrections to None so
     # downstream filters treat None as "no correction" without checking the flag.

--- a/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_hcr_probe_designer.py
@@ -65,6 +65,7 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     SpecificityFilter,
 )
 from oligo_designer_toolsuite.pipelines._utils import (
+    apply_required_parameters,
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
@@ -1388,6 +1389,8 @@ def _preprocess_config(config_validated: HcrProbeDesignerConfig) -> dict[str, An
     list of target regions. If no gene list is provided, all regions in the input
     FASTA files are used.
 
+    Lastly, it inserts the parameters from required_parameters into the correct sections.
+
     :param config_validated: Validated pipeline configuration (pydantic model).
     :type config_validated: HcrProbeDesignerConfig
     :return: The configuration converted to a dict, updated with the prepared settings.
@@ -1395,6 +1398,8 @@ def _preprocess_config(config_validated: HcrProbeDesignerConfig) -> dict[str, An
     """
 
     config = config_validated.model_dump()
+
+    apply_required_parameters(config)
 
     # Resolve Tm table names and blank disabled chem/salt corrections to None so
     # downstream filters treat None as "no correction" without checking the flag.

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -24,6 +24,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from Bio.SeqUtils import Seq
+from pydantic import ValidationError
 from scipy.spatial.distance import hamming
 
 from oligo_designer_toolsuite._exceptions import (
@@ -31,6 +32,7 @@ from oligo_designer_toolsuite._exceptions import (
     FeatureNotImplementedError,
     FileFormatError,
 )
+from oligo_designer_toolsuite.config import MerfishProbeDesignerConfig
 from oligo_designer_toolsuite.database import OligoDatabase, ReferenceDatabase
 from oligo_designer_toolsuite.oligo_efficiency_filter import (
     IsoformConsensusScorer,
@@ -2449,12 +2451,13 @@ class PrimerDesigner:
 ############################################
 
 
-def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
+def _preprocess_config(config_validated: MerfishProbeDesignerConfig) -> dict[str, Any]:
     """
     Prepare the MERFISH config before the pipeline runs.
 
-    This step updates the config in place so later design stages can read ready-to-use
-    settings. It resolves melting-temperature tables, turns off unused temperature
+    This step converts the validated pydantic config to a plain dict and updates it
+    so later design stages can read ready-to-use settings.
+    It resolves melting-temperature tables, turns off unused temperature
     corrections, and copies the shared temperature settings into the filters and
     scoring steps that need them.
 
@@ -2467,11 +2470,13 @@ def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
     regions. If no gene list is provided, all regions in the input FASTA files are
     used.
 
-    :param config: Pipeline configuration loaded from the YAML config file.
-    :type config: dict
-    :return: The same config dict, updated with the prepared settings.
+    :param config_validated: Validated pipeline configuration (pydantic model).
+    :type config_validated: MerfishProbeDesignerConfig
+    :return: The configuration converted to a dict, updated with the prepared settings.
     :rtype: dict
     """
+
+    config = config_validated.model_dump()
 
     # Resolve Tm table names and blank disabled chem/salt corrections to None so
     # downstream filters treat None as "no correction" without checking the flag.
@@ -2593,9 +2598,9 @@ def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
-def merfish_probe_designer(config: dict[str, Any]) -> None:
+def merfish_probe_designer(config: MerfishProbeDesignerConfig) -> None:
     """
-    Run the MERFISH probe design pipeline from a config dict.
+    Run the MERFISH probe design pipeline from a validated configuration (pydantic model).
 
     This function prepares the config with :func:`_preprocess_config`, then runs
     :class:`MerfishProbeDesigner` end to end. It designs target probes, loads or
@@ -2628,9 +2633,9 @@ def merfish_probe_designer(config: dict[str, Any]) -> None:
     See :class:`MerfishProbeDesigner` for the pipeline description and probe
     structure.
 
-    :param config: Pipeline configuration loaded from the YAML config file. It is
-        updated in place by :func:`_preprocess_config` before the pipeline runs.
-    :type config: dict
+    :param config: Validated pipeline configuration. It is converted and prepared by
+        :func:`_preprocess_config` before the pipeline runs.
+    :type config: MerfishProbeDesignerConfig
     :return: None
     :rtype: None
     """
@@ -2698,15 +2703,20 @@ def main() -> None:
     )
 
     with open(args["config"], "r") as handle:
-        config = yaml.safe_load(handle)
+        config_raw = yaml.safe_load(handle)
+    try:
+        config_validated = MerfishProbeDesignerConfig.model_validate(config_raw)
+    except ValidationError as e:
+        print(f"Invalid configuration file:\n{e}")
+        raise
 
     # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(
-        dir_output=config["general"]["dir_output"],
+        dir_output=config_validated.general.dir_output,
         pipeline_name="merfish_probe_designer",
     )
 
-    merfish_probe_designer(config)
+    merfish_probe_designer(config_validated)
 
     print("--------------END PIPELINE--------------")
 

--- a/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_merfish_probe_designer.py
@@ -77,6 +77,7 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     SpecificityFilter,
 )
 from oligo_designer_toolsuite.pipelines._utils import (
+    apply_required_parameters,
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
@@ -2470,6 +2471,8 @@ def _preprocess_config(config_validated: MerfishProbeDesignerConfig) -> dict[str
     regions. If no gene list is provided, all regions in the input FASTA files are
     used.
 
+    Lastly, it inserts the parameters from required_parameters into the correct sections.
+
     :param config_validated: Validated pipeline configuration (pydantic model).
     :type config_validated: MerfishProbeDesignerConfig
     :return: The configuration converted to a dict, updated with the prepared settings.
@@ -2477,6 +2480,8 @@ def _preprocess_config(config_validated: MerfishProbeDesignerConfig) -> dict[str
     """
 
     config = config_validated.model_dump()
+
+    apply_required_parameters(config)
 
     # Resolve Tm table names and blank disabled chem/salt corrections to None so
     # downstream filters treat None as "no correction" without checking the flag.
@@ -2526,8 +2531,13 @@ def _preprocess_config(config_validated: MerfishProbeDesignerConfig) -> dict[str
         "target_probes"
     ]["property_filters"]["GC_content_filter"]["GC_content_max"]
 
-    # Same Tm prep when readout sequences are generated rather than loaded.
+    # Readout probes only carry specificity filters and Tm settings when they are
+    # generated rather than loaded.
     if config["readout_probes"]["readout_probe_table"]["source"] == "generate":
+        config["readout_probes"]["readout_probe_table"]["specificity_filters"]["specificity_blastn_filter"][
+            "files_fasta_reference_database"
+        ] = config["required_parameters"]["reference_genome"]
+
         config["readout_probes"]["readout_probe_table"]["global_parameters"]["Tm_parameters"] = (
             preprocess_tm_parameters(
                 config["readout_probes"]["readout_probe_table"]["global_parameters"]["Tm_parameters"]
@@ -2556,8 +2566,12 @@ def _preprocess_config(config_validated: MerfishProbeDesignerConfig) -> dict[str
             "parameters"
         ]
 
-    # Same Tm prep when the forward primer is generated rather than loaded.
+    # Same for the forward primer when it is generated rather than loaded.
     if config["primers"]["forward_primer"]["source"] == "generate":
+        config["primers"]["forward_primer"]["specificity_filters"]["specificity_blastn_filter"][
+            "files_fasta_reference_database"
+        ] = config["required_parameters"]["reference_genome"]
+
         config["primers"]["forward_primer"]["global_parameters"]["Tm_parameters"] = preprocess_tm_parameters(
             config["primers"]["forward_primer"]["global_parameters"]["Tm_parameters"]
         )

--- a/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_oligo_seq_probe_designer.py
@@ -67,6 +67,7 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     VariantsFilter,
 )
 from oligo_designer_toolsuite.pipelines._utils import (
+    apply_required_parameters,
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
@@ -1009,12 +1010,16 @@ def _preprocess_config(config_validated: OligoSeqProbeDesignerConfig) -> dict[st
     regions. If no gene list is provided, all regions in the input FASTA files are
     used.
 
+    Lastly, it inserts the parameters from required_parameters into the correct sections.
+
     :param config_validated: Validated pipeline configuration (pydantic model).
     :type config_validated: OligoSeqProbeDesignerConfig
     :return: The configuration converted to a dict, updated with the prepared settings.
     :rtype: dict
     """
     config = config_validated.model_dump()
+
+    apply_required_parameters(config)
 
     # Resolve Tm table names and blank disabled chem/salt corrections to None so
     # downstream filters treat None as "no correction" without checking the flag.

--- a/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_scrinshot_probe_designer.py
@@ -71,6 +71,7 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     SpecificityFilter,
 )
 from oligo_designer_toolsuite.pipelines._utils import (
+    apply_required_parameters,
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
@@ -1586,6 +1587,8 @@ def _preprocess_config(config_validated: ScrinshotProbeDesignerConfig) -> dict[s
     concrete list of target regions. If no gene list is provided, all regions in the
     input FASTA files are used.
 
+    Lastly, it inserts the parameters from required_parameters into the correct sections.
+
     :param config_validated: Validated pipeline configuration (pydantic model).
     :type config_validated: ScrinshotProbeDesignerConfig
     :return: The configuration converted to a dict, updated with the prepared settings.
@@ -1593,6 +1596,8 @@ def _preprocess_config(config_validated: ScrinshotProbeDesignerConfig) -> dict[s
     """
 
     config = config_validated.model_dump()
+
+    apply_required_parameters(config)
 
     # Resolve Tm table names and blank disabled chem/salt corrections to None so
     # downstream filters treat None as "no correction" without checking the flag.

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -25,12 +25,14 @@ import numpy as np
 import pandas as pd
 import yaml
 from Bio.SeqUtils import Seq
+from pydantic import ValidationError
 
 from oligo_designer_toolsuite._exceptions import (
     ConfigurationError,
     FeatureNotImplementedError,
     FileFormatError,
 )
+from oligo_designer_toolsuite.config import SeqfishPlusProbeDesignerConfig
 from oligo_designer_toolsuite.database import OligoDatabase, ReferenceDatabase
 from oligo_designer_toolsuite.oligo_efficiency_filter import (
     DeviationFromOptimalGCContentScorer,
@@ -2346,12 +2348,13 @@ class PrimerDesigner:
 ############################################
 
 
-def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
+def _preprocess_config(config_validated: SeqfishPlusProbeDesignerConfig) -> dict[str, Any]:
     """
     Prepare the seqFISH+ config before the pipeline runs.
 
-    This step updates the config in place so later design stages can read ready-to-use
-    settings. Target-probe design in this pipeline does not use melting-temperature
+    This step converts the validated pydantic config to a plain dict and updates it
+    so later design stages can read ready-to-use settings. Target-probe design in this
+    pipeline does not use melting-temperature
     settings. When the forward primer is generated rather than loaded, this step also
     resolves melting-temperature tables, turns off unused temperature corrections,
     and copies the shared temperature settings into the forward-primer filter that
@@ -2361,11 +2364,30 @@ def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
     regions. If no gene list is provided, all regions in the input FASTA files are
     used.
 
-    :param config: Pipeline configuration loaded from the YAML config file.
-    :type config: dict
-    :return: The same config dict, updated with the prepared settings.
+    Lastly, it inserts the parameters from required_parameters into the correct sections.
+
+    :param config_validated: Validated pipeline configuration (pydantic model).
+    :type config_validated: SeqfishPlusProbeDesignerConfig
+    :return: The configuration converted to a dict, updated with the prepared settings.
     :rtype: dict
     """
+
+    config = config_validated.model_dump()
+
+    config["target_probes"]["oligo_generation"]["file_region_ids"] = config["required_parameters"]["targets"]
+    config["target_probes"]["oligo_generation"]["files_fasta_probe_database"] = config["required_parameters"][
+        "target_genome"
+    ]
+    files_fasta_reference_database = config["required_parameters"]["reference_genome"]
+    config["target_probes"]["specificity_filters"]["specificity_blastn_filter"][
+        "files_fasta_reference_database"
+    ] = files_fasta_reference_database
+    config["readout_probes"]["readout_probe_table"]["specificity_filters"]["specificity_blastn_filter"][
+        "files_fasta_reference_database"
+    ] = files_fasta_reference_database
+    config["primers"]["forward_primer"]["specificity_filters"]["specificity_blastn_filter"][
+        "files_fasta_reference_database"
+    ] = files_fasta_reference_database
 
     file_region_ids = config["target_probes"]["oligo_generation"]["file_region_ids"]
     if file_region_ids is None:
@@ -2403,9 +2425,9 @@ def _preprocess_config(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
-def seqfish_plus_probe_designer(config: dict[str, Any]) -> None:
+def seqfish_plus_probe_designer(config: SeqfishPlusProbeDesignerConfig) -> None:
     """
-    Run the seqFISH+ probe design pipeline from a config dict.
+    Run the seqFISH+ probe design pipeline from a validated configuration (pydantic model).
 
     This function prepares the config with :func:`_preprocess_config`, then runs
     :class:`SeqFishPlusProbeDesigner` end to end. It designs target probes, loads or
@@ -2438,9 +2460,9 @@ def seqfish_plus_probe_designer(config: dict[str, Any]) -> None:
     See :class:`SeqFishPlusProbeDesigner` for the pipeline description and probe
     structure.
 
-    :param config: Pipeline configuration loaded from the YAML config file. It is
-        updated in place by :func:`_preprocess_config` before the pipeline runs.
-    :type config: dict
+    :param config: Validated pipeline configuration. It is converted and prepared by
+        :func:`_preprocess_config` before the pipeline runs.
+    :type config: SeqfishPlusProbeDesignerConfig
     :return: None
     :rtype: None
     """
@@ -2508,15 +2530,20 @@ def main() -> None:
     )
 
     with open(args["config"], "r") as handle:
-        config = yaml.safe_load(handle)
+        config_raw = yaml.safe_load(handle)
 
-    # Configure logging only after dir_output is known so the log file lands there.
+    try:
+        config_validated = SeqfishPlusProbeDesignerConfig.model_validate(config_raw)
+    except ValidationError as e:
+        print(f"Invalid configuration file:\n{e}")
+        raise
+
     configure_root_logger(
-        dir_output=config["general"]["dir_output"],
+        dir_output=config_validated.general.dir_output,
         pipeline_name="seqfishplus_probe_designer",
     )
 
-    seqfish_plus_probe_designer(config)
+    seqfish_plus_probe_designer(config_validated)
 
     print("--------------END PIPELINE--------------")
 

--- a/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
+++ b/oligo_designer_toolsuite/pipelines/_seqfish_plus_probe_designer.py
@@ -70,6 +70,7 @@ from oligo_designer_toolsuite.oligo_specificity_filter import (
     SpecificityFilter,
 )
 from oligo_designer_toolsuite.pipelines._utils import (
+    apply_required_parameters,
     base_log_parameters,
     base_parser,
     check_content_oligo_database,
@@ -2374,20 +2375,15 @@ def _preprocess_config(config_validated: SeqfishPlusProbeDesignerConfig) -> dict
 
     config = config_validated.model_dump()
 
-    config["target_probes"]["oligo_generation"]["file_region_ids"] = config["required_parameters"]["targets"]
-    config["target_probes"]["oligo_generation"]["files_fasta_probe_database"] = config["required_parameters"][
-        "target_genome"
-    ]
-    files_fasta_reference_database = config["required_parameters"]["reference_genome"]
-    config["target_probes"]["specificity_filters"]["specificity_blastn_filter"][
-        "files_fasta_reference_database"
-    ] = files_fasta_reference_database
-    config["readout_probes"]["readout_probe_table"]["specificity_filters"]["specificity_blastn_filter"][
-        "files_fasta_reference_database"
-    ] = files_fasta_reference_database
-    config["primers"]["forward_primer"]["specificity_filters"]["specificity_blastn_filter"][
-        "files_fasta_reference_database"
-    ] = files_fasta_reference_database
+    apply_required_parameters(config)
+
+    # Readout probes and the forward primer only carry specificity filters when they
+    # are generated rather than loaded.
+    readout_probe_table_cfg = config["readout_probes"]["readout_probe_table"]
+    if readout_probe_table_cfg["source"] == "generate":
+        readout_probe_table_cfg["specificity_filters"]["specificity_blastn_filter"][
+            "files_fasta_reference_database"
+        ] = config["required_parameters"]["reference_genome"]
 
     file_region_ids = config["target_probes"]["oligo_generation"]["file_region_ids"]
     if file_region_ids is None:
@@ -2402,6 +2398,10 @@ def _preprocess_config(config_validated: SeqfishPlusProbeDesignerConfig) -> dict
 
     forward_primer_cfg = config["primers"]["forward_primer"]
     if forward_primer_cfg["source"] == "generate":
+        forward_primer_cfg["specificity_filters"]["specificity_blastn_filter"][
+            "files_fasta_reference_database"
+        ] = config["required_parameters"]["reference_genome"]
+
         # Resolve Tm table names and blank disabled chem/salt corrections to None so
         # downstream filters treat None as "no correction" without checking the flag.
         global_parameters = forward_primer_cfg["global_parameters"]
@@ -2538,6 +2538,7 @@ def main() -> None:
         print(f"Invalid configuration file:\n{e}")
         raise
 
+    # Configure logging only after dir_output is known so the log file lands there.
     configure_root_logger(
         dir_output=config_validated.general.dir_output,
         pipeline_name="seqfishplus_probe_designer",

--- a/oligo_designer_toolsuite/pipelines/_utils.py
+++ b/oligo_designer_toolsuite/pipelines/_utils.py
@@ -264,6 +264,27 @@ def preprocess_tm_parameters(tm_parameters: dict[str, Any]) -> dict[str, Any]:
     return tm_parameters
 
 
+def apply_required_parameters(config: dict[str, Any]) -> None:
+    """
+    Copy the entries of ``required_parameters`` into the sections that consume them.
+
+    Config files collect the gene list and the FASTA files that every run needs in a
+    single ``required_parameters`` section for better user experience. The helper writes
+    them to the entries the pipelines expect. This only covers the cases that are the same
+    across all pipelines; some pipelines might need additional copies.
+
+    :param config: Configuration dictionary, updated in place.
+    :type config: dict[str, Any]
+    """
+    required_parameters = config["required_parameters"]
+    oligo_generation = config["target_probes"]["oligo_generation"]
+    oligo_generation["file_region_ids"] = required_parameters["targets"]
+    oligo_generation["files_fasta_probe_database"] = required_parameters["target_genome"]
+    config["target_probes"]["specificity_filters"]["specificity_blastn_filter"][
+        "files_fasta_reference_database"
+    ] = required_parameters["reference_genome"]
+
+
 def validate_codebook(
     codebook: pd.DataFrame,
     region_ids: list[str],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,7 @@ class TestOligoSeqYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = OligoSeqProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "OligoSeqProbeDesignerConfig"
+        assert "required_parameters" in schema["properties"]
         assert "target_probes" in schema["properties"]
 
 
@@ -88,6 +89,7 @@ class TestScrinshotYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = ScrinshotProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "ScrinshotProbeDesignerConfig"
+        assert "required_parameters" in schema["properties"]
         assert "target_probes" in schema["properties"]
         assert "detection_oligo" in schema["properties"]
 
@@ -120,6 +122,7 @@ class TestHcrYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = HcrProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "HcrProbeDesignerConfig"
+        assert "required_parameters" in schema["properties"]
         assert "target_probes" in schema["properties"]
         assert "initiator_probes" in schema["properties"]
 
@@ -174,6 +177,7 @@ class TestCycleHcrYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = CycleHcrProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "CycleHcrProbeDesignerConfig"
+        assert "required_parameters" in schema["properties"]
         assert "target_probes" in schema["properties"]
         assert "readout_probes" in schema["properties"]
 
@@ -235,6 +239,7 @@ class TestSeqfishYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = SeqfishPlusProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "SeqfishPlusProbeDesignerConfig"
+        assert "required_parameters" in schema["properties"]
         assert "target_probes" in schema["properties"]
         assert "readout_probes" in schema["properties"]
         assert "primers" in schema["properties"]
@@ -287,6 +292,7 @@ class TestMerfishYaml(unittest.TestCase):
     def test_json_schema(self) -> None:
         schema = MerfishProbeDesignerConfig.model_json_schema()
         assert schema["title"] == "MerfishProbeDesignerConfig"
+        assert "required_parameters" in schema["properties"]
         assert "target_probes" in schema["properties"]
         assert "readout_probes" in schema["properties"]
         assert "primers" in schema["properties"]

--- a/tests/test_oligo_specificity_filter.py
+++ b/tests/test_oligo_specificity_filter.py
@@ -212,7 +212,7 @@ class TestBlastFilter(AlignmentFilterTestBase, unittest.TestCase):
             "-strand": "plus",
             "-word_size": 10,
         }
-        hit_parameters = {"coverage": 50}
+        hit_parameters = {"hit_criterion": "coverage", "value": 50}
 
         return BlastNFilter(
             search_parameters=blastn_search_parameters,
@@ -251,7 +251,7 @@ class TestBlastNSeedregionSiteFilter(AlignmentFilterTestBase, unittest.TestCase)
             "-strand": "plus",
             "-word_size": 10,
         }
-        hit_parameters = {"coverage": 50}
+        hit_parameters = {"hit_criterion": "coverage", "value": 50}
         seedregion_size = 10
 
         return BlastNSeedregionSiteFilter(
@@ -285,7 +285,7 @@ class TestCrossHybridizationFilter(unittest.TestCase):
             "-strand": "minus",
             "-word_size": 10,
         }
-        self.hit_parameters_crosshyb = {"coverage": 50}
+        self.hit_parameters_crosshyb = {"hit_criterion": "coverage", "value": 50}
 
         # Bowtie parameters
         self.bowtie_search_parameters_crosshyb = {"-n": 3, "-l": 5, "--nofw": ""}
@@ -517,7 +517,7 @@ class DummyAPI(APIBase):
         return predictions
 
 
-class TestHybridizationProbabilityBalstn(unittest.TestCase):
+class TestHybridizationProbabilityBlastn(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp_path = os.path.join(os.getcwd(), "tmp_output_hybridization_probability_filter_blast")
 
@@ -541,7 +541,7 @@ class TestHybridizationProbabilityBalstn(unittest.TestCase):
             "-strand": "both",
             "-word_size": 10,
         }
-        hit_parameters = {"coverage": 50}
+        hit_parameters = {"hit_criterion": "coverage", "value": 50}
         self.alignment_filter = BlastNFilter(
             search_parameters=blastn_search_parameters,
             hit_parameters=hit_parameters,


### PR DESCRIPTION
This PR adds a top level pydantic model (required_parameters) and several other improvements:

- add required_parameters as a top level pydantic model and restructure the YAML accordingly and the pipeline preprocessing
- change BlastnSearchParameters flags from Literal[""] to bool -> makes it easier in the frontend to render. At the same time, the code that deals with integrating flags to deal with the new structure
- change BlastnHitParameters to discriminated union between coverage and min_alignment_length to show better in frontend. Also adjust backend code that checks if one or two of these parameters are present (now there has to be only one)
- make BlastnHitParameters required parameters in the Blastn filters and don't allow empty parameters anymore
- improve pydantic model descriptions and remove pipeline specific overrides that are not needed anymore

Additionally also contains the content from feat-integrate-all-pipelines:
- Fixed BLASTN hit criteria being read as the wrong unit.
- Added coverage and min-alignment versions of the BLASTN filters in _specificity_filters.py
- Split a ...ProbeDesignerConfigBase out of all six pipeline configs
- Marked 17 more fields as x-quick-setting

-> the changes from feat-integrate-all-pipelines are needed so that ODT-Cloud works at the moment, but this will be changed again partly when we remove the defaults from the pydantic models